### PR TITLE
Add scripts to build ToolAnalysis in ups product mode

### DIFF
--- a/FrameworkMakefileUPS.patch
+++ b/FrameworkMakefileUPS.patch
@@ -1,0 +1,16 @@
+--- Makefile	2018-01-22 22:52:49.266673013 -0600
++++ mak	2018-01-22 22:46:22.486197611 -0600
+@@ -1,9 +1,9 @@
+ 
+-ZMQLib= -L ../zeromq-4.0.7/lib -lzmq 
+-ZMQInclude= -I ../zeromq-4.0.7/include/ 
++ZMQLib= -L $(ZEROMQ_LIB) -lzmq 
++ZMQInclude= -I $(ZEROMQ_INC)
+ 
+-BoostLib= -L ../boost_1_60_0/install/lib -lboost_date_time -lboost_serialization  -lboost_iostreams
+-BoostInclude= -I ../boost_1_60_0/install/include/
++BoostLib= -L $(BOOST_LIB) -lboost_date_time -lboost_serialization -lboost_iostreams
++BoostInclude= -I $(BOOST_INC)
+ 
+ DataModelInclude =
+ DataModelLib =

--- a/GetToolDAQ.sh
+++ b/GetToolDAQ.sh
@@ -6,6 +6,7 @@
 rootflag=1
 boostflag=1
 zeromqflag=1
+upsflag=0
 b1=1
 b3=1
 b5=1
@@ -53,6 +54,7 @@ do
             boostflag=0
 	    rootflag=0
 	    zeromqflag=0
+            upsflag=1
 	    cp Makefile.UPS Makefile
 	    ;;
 
@@ -103,7 +105,7 @@ done
 if [ $b1 -eq 1 ]
 then
     
-    mkdir ToolDAQ
+    mkdir -p ToolDAQ
 fi
 
 cd ToolDAQ
@@ -150,6 +152,11 @@ if [ $b3 -eq 1 ]
 then
     
     cd ToolDAQFramework
+
+    if [ $upsflag -eq 1 ]
+    then
+        patch Makefile ../../FrameworkMakefileUPS.patch
+    fi
     
     make clean
     make

--- a/GetToolDAQ.sh
+++ b/GetToolDAQ.sh
@@ -5,6 +5,7 @@
 
 rootflag=1
 boostflag=1
+zeromqflag=1
 b1=1
 b3=1
 b5=1
@@ -32,6 +33,27 @@ do
             boostflag=0
 	    rootflag=0
 	    cp Makefile.FNAL Makefile
+	    ;;
+
+	--ups | -u)
+            echo "Installing ToolDAQ for FNAL UPS"
+            if [ -z "$BOOST_DIR" ]; then
+                echo "The boost product has not been set up."
+                exit 1
+            elif [ -z "$ROOT_DIR" ]; then
+                echo "The root product has not been set up."
+                exit 2
+            elif [ -z "$ZEROMQ_DIR" ]; then
+                echo "The zeromq product has not been set up."
+                exit 3
+            elif [ -z "$PYTHON_DIR" ]; then
+                echo "The python product has not been set up."
+                exit 4
+            fi
+            boostflag=0
+	    rootflag=0
+	    zeromqflag=0
+	    cp Makefile.UPS Makefile
 	    ;;
 
 	--b1 )
@@ -89,17 +111,21 @@ cd ToolDAQ
 if [ $b1 -eq 1 ]
 then
     git clone https://github.com/ToolDAQ/ToolDAQFramework.git
-    git clone https://github.com/ToolDAQ/zeromq-4.0.7.git
+
+    if [ $zeromqflag -eq 1 ]
+    then
+        git clone https://github.com/ToolDAQ/zeromq-4.0.7.git
     
-    cd zeromq-4.0.7
+        cd zeromq-4.0.7
+
+        ./configure --prefix=`pwd`
+        make
+        make install
     
-    ./configure --prefix=`pwd`
-    make
-    make install
+        export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
     
-    export LD_LIBRARY_PATH=`pwd`/lib:$LD_LIBRARY_PATH
-    
-    cd ../
+        cd ../
+    fi
 fi
 
 if [ $boostflag -eq 1 ]

--- a/Makefile.UPS
+++ b/Makefile.UPS
@@ -2,13 +2,13 @@ ToolDAQFrameworkPath=ToolDAQ/ToolDAQFramework
 
 CPPFLAGS= -Wno-reorder -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable
 
-PythonLib= `python-config --libs` -L $(PYTHON_LIB)/../src/Python-2.7.11
+PythonLib= `python-config --libs` -L $(PYTHON_LIB)
 PythonInclude=`python-config --cflags`
 
-ZMQLib= -L $(ZEROMQ_LIB) -lzmq 
+ZMQLib= -L $(ZEROMQ_LIB) -lzmq
 ZMQInclude= -I $(ZEROMQ_INC)
 
-BoostLib= -L $(BOOST_LIB) -lboost_date_time -lboost_serialization -lboost_iostreams 
+BoostLib= -L $(BOOST_LIB) -lboost_date_time -lboost_serialization -lboost_iostreams
 BoostInclude= -I $(BOOST_INC)
 
 RootInclude=  -I $(ROOT_INC)

--- a/Makefile.UPS
+++ b/Makefile.UPS
@@ -1,0 +1,72 @@
+ToolDAQFrameworkPath=ToolDAQ/ToolDAQFramework
+
+CPPFLAGS= -Wno-reorder -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable
+
+PythonLib= `python-config --libs` -L $(PYTHON_LIB)/../src/Python-2.7.11
+PythonInclude=`python-config --cflags`
+
+ZMQLib= -L $(ZEROMQ_LIB) -lzmq 
+ZMQInclude= -I $(ZEROMQ_INC)
+
+BoostLib= -L $(BOOST_LIB) -lboost_date_time -lboost_serialization -lboost_iostreams 
+BoostInclude= -I $(BOOST_INC)
+
+RootInclude=  -I $(ROOT_INC)
+RootLib= -L $(ROOT_INC)/../lib `root-config --libs` -lMinuit
+
+DataModelInclude = $(RootInclude)
+DataModelLib = $(RootLib)
+
+MyToolsInclude =  $(RootInclude) $(PythonInclude)
+MyToolsLib = $(RootLib) $(PythonLib)
+
+
+all: lib/libMyTools.so lib/libToolChain.so lib/libStore.so include/Tool.h  lib/libServiceDiscovery.so lib/libDataModel.so lib/libLogging.so
+
+	g++ $(CPPFLAGS) -std=c++1y -g src/main.cpp -o Analyse -I include -L lib -lStore -lMyTools -lToolChain -lDataModel -lLogging -lServiceDiscovery -lpthread $(DataModelInclude) $(MyToolsInclude)  $(MyToolsLib) $(ZMQLib) $(ZMQInclude)  $(BoostLib) $(BoostInclude)
+
+
+lib/libStore.so:
+
+	cp $(ToolDAQFrameworkPath)/src/Store/*.h include/
+	g++ $(CPPFLAGS) -std=c++1y -g -fPIC -shared  -I include $(ToolDAQFrameworkPath)/src/Store/*.cpp -o lib/libStore.so $(BoostLib) $(BoostInclude)
+
+
+include/Tool.h:
+
+	cp $(ToolDAQFrameworkPath)/src/Tool/Tool.h include/
+
+
+lib/libToolChain.so: lib/libStore.so include/Tool.h lib/libDataModel.so lib/libMyTools.so lib/libServiceDiscovery.so lib/libLogging.so
+
+	cp $(ToolDAQFrameworkPath)/src/ToolChain/*.h include/
+	g++ $(CPPFLAGS) -std=c++1y -g -fPIC -shared $(ToolDAQFrameworkPath)/src/ToolChain/ToolChain.cpp -I include -lpthread -L lib -lStore -lDataModel -lMyTools -lServiceDiscovery -lLogging -o lib/libToolChain.so $(DataModelInclude) $(ZMQLib) $(ZMQInclude) $(MyToolsInclude)  $(BoostLib) $(BoostInclude)
+
+
+clean: 
+	rm -f include/*.h include/*.hh
+	rm -f lib/*.so
+	rm -f Analyse
+
+lib/libDataModel.so: lib/libStore.so lib/libLogging.so
+
+	cp -L DataModel/*.h include/
+	g++ $(CPPFLAGS) -std=c++1y -g -fPIC -shared DataModel/*.C DataModel/*.cpp -I include -L lib -lStore  -lLogging  -o lib/libDataModel.so $(DataModelInclude) $(DataModelLib) $(ZMQLib) $(ZMQInclude)  $(BoostLib) $(BoostInclude) $(UserLib)
+
+lib/libMyTools.so: lib/libStore.so include/Tool.h lib/libDataModel.so lib/libLogging.so
+
+	cp UserTools/*/*.h include/
+	cp UserTools/Factory/*.h include/
+	g++ $(CPPFLAGS) -std=c++1y -g -fPIC -shared  UserTools/Factory/Factory.cpp -I include -L lib -lStore -lDataModel -lLogging -o lib/libMyTools.so $(MyToolsInclude) $(MyToolsLib) $(DataModelInclude) $(ZMQLib) $(ZMQInclude) $(BoostLib) $(BoostInclude) $(UserLib)
+
+lib/libServiceDiscovery.so: lib/libStore.so
+	cp $(ToolDAQFrameworkPath)/src/ServiceDiscovery/ServiceDiscovery.h include/
+	g++ $(CPPFLAGS) -shared -fPIC -I include $(ToolDAQFrameworkPath)/src/ServiceDiscovery/ServiceDiscovery.cpp -o lib/libServiceDiscovery.so -L lib/ -lStore  $(ZMQInclude) $(ZMQLib) $(BoostLib) $(BoostInclude)
+
+lib/libLogging.so: lib/libStore.so
+	cp $(ToolDAQFrameworkPath)/src/Logging/Logging.h include/
+	g++ $(CPPFLAGS) -shared -fPIC -I include $(ToolDAQFrameworkPath)/src/Logging/Logging.cpp -o lib/libLogging.so -L lib/ -lStore $(ZMQInclude) $(ZMQLib) $(BoostLib) $(BoostInclude)
+
+update:
+	cd $(ToolDAQFrameworkPath); git pull
+	git pull


### PR DESCRIPTION
These changes, combined with some CMake scripts in a separate repository (toolanalysis-ups-build) allow the toolanalysis ups product to be built on the FNAL gpvm machines.