### PR TITLE
LAPPD Parse ACC tool addition

### DIFF
--- a/UserTools/Factory/Factory.cpp
+++ b/UserTools/Factory/Factory.cpp
@@ -13,6 +13,7 @@ if (tool=="ExamplePrintData") ret=new ExamplePrintData;
 if (tool=="ExampleLoadRoot") ret=new ExampleLoadRoot;
 if (tool=="PythonScript") ret=new PythonScript;
 if (tool=="LAPPDParseScope") ret=new LAPPDParseScope;
+if (tool=="LAPPDParseACC") ret=new LAPPDParseACC;
 if (tool=="LAPPDFindPeak") ret=new LAPPDFindPeak;
 if (tool=="LAPPDSave") ret=new LAPPDSave;
 if (tool=="LAPPDSim") ret=new LAPPDSim;

--- a/UserTools/LAPPDParseACC/LAPPDParseACC.cpp
+++ b/UserTools/LAPPDParseACC/LAPPDParseACC.cpp
@@ -1,0 +1,161 @@
+#include "LAPPDParseACC.h"
+
+LAPPDParseACC::LAPPDParseACC():Tool(){}
+
+using namespace std;
+
+
+
+bool LAPPDParseACC::Initialise(std::string configfile, DataModel &data){
+
+  /////////////////// Usefull header ///////////////////////
+  if(configfile!="")  m_variables.Initialise(configfile); //loading config file
+  //m_variables.Print();
+
+  m_data= &data; //assigning transient data pointer
+  /////////////////////////////////////////////////////////////////
+
+
+  m_data->Stores["ANNIEEvent"] = new BoostStore(false, 2);
+
+  /* Get Pedestal Data */
+  string path;
+  m_variables.Get("filepath", path);
+  string name;
+  m_variables.Get("filename", name);
+  string filebase = path + "/" + name;
+
+  string pedpath = filebase + ".ped";
+  ifstream pfs;
+  try {
+    pfs.open(pedpath.c_str());
+  } catch (...) {
+    cout << "Could not load pedestal data file." << endl;
+    return false;
+  }
+
+  /* Determine Number of boards */
+  string line;
+  int board;
+  // Skip header
+  getline(pfs, line);
+  while(!pfs.eof()){
+    pfs >> board;
+    getline(pfs, line);
+    // If the vector does not contain the board entry
+    if(find(boards.begin(), boards.end(), board) == boards.end()) {
+      boards.push_back(board);
+      cout << "Found board " << board << endl;
+    }
+  }
+  pfs.close();
+  pfs.open(pedpath.c_str());
+
+  map<int, vector<Waveform<double>>> rawPedData;
+
+  // Skip header
+  getline(pfs, line);
+
+  int b, c;
+  int key;
+  int samples[NUM_CELLS];
+  while(!pfs.eof()){
+    pfs >> b;
+    pfs >> c;
+    key = b << 4 | c;
+    vector<Waveform<double>> in;
+    for (int i = 0; i < NUM_CELLS; i++) {
+      pfs >> samples[i];
+    }
+    Waveform<double> data;
+    std::vector<double> v(begin(samples), end(samples));
+    data.SetSamples(v);
+    in.push_back(data);
+    rawPedData[key] = in;
+  }
+  pfs.close();
+
+
+  m_data->Stores["ANNIEEvent"]->Set("rawPedData", rawPedData);
+
+  /* Open other file streams */
+
+  string datapath = filebase + ".acdc";
+  try {
+      dfs.open(datapath.c_str());
+  } catch (...) {
+    cout << "Could not load acdc data file." << endl;
+    return false;
+  }
+  getline(dfs, line);
+
+  string metapath = filebase + ".meta";
+  try {
+      mfs.open(metapath.c_str());
+  } catch (...) {
+    cout << "Could not load acdc data file." << endl;
+    return false;
+  }
+  getline(mfs, meta_header);
+
+  event = 0;
+  return true;
+}
+
+
+bool LAPPDParseACC::Execute(){
+  if (dfs.eof() || mfs.eof()) m_data->vars.Set("StopLoop", 1);
+
+  map<int, vector<Waveform<double>>> rawData;
+  /* Data */
+  int e, b, c, key;
+  int samples[NUM_CELLS];
+  for(int k = 0; k < NUM_CHS * boards.size(); k++){
+    dfs >> e; // Event, we can skip this
+    dfs >> b;
+    dfs >> c;
+    key = b << 4 | c;
+    vector<Waveform<double>> in;
+    for (int i = 0; i < NUM_CELLS; i++) {
+      dfs >> samples[i];
+    }
+    Waveform<double> data;
+    std::vector<double> v(begin(samples), end(samples));
+    data.SetSamples(v);
+    in.push_back(data);
+    rawData[key] = in;
+  }
+  m_data->Stores["ANNIEEvent"]->Set("RawLAPPDData", rawData);
+
+  /* Metadata */
+  map<int, map<string, double>> meta;
+  stringstream headers(meta_header);
+  string header;
+  for (int k = 0; k < boards.size(); k++) {
+    map<string, double> values;
+    mfs >> e; // Event, we can skip this
+    mfs >> key;
+    for (int m = 0; headers >> header; m++) {
+      if (m < 2) continue;
+      mfs >> values[header];
+    }
+    meta[key] = values;
+  }
+  m_data->Stores["ANNIEEvent"]->Header->Set("metaData", meta);
+
+  bool print;
+  m_variables.Get("print", print);
+  if (print){
+      m_data->Stores["ANNIEEvent"]->Print();
+  }
+  event++;
+  return true;
+}
+
+
+bool LAPPDParseACC::Finalise(){
+  dfs.close();
+  mfs.close();
+
+  return true;
+}

--- a/UserTools/LAPPDParseACC/LAPPDParseACC.h
+++ b/UserTools/LAPPDParseACC/LAPPDParseACC.h
@@ -1,0 +1,38 @@
+#ifndef LAPPDParseACC_H
+#define LAPPDParseACC_H
+
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <map>
+
+#include "Tool.h"
+
+#define NUM_CELLS 256
+#define NUM_CHS 30
+
+class LAPPDParseACC: public Tool {
+
+
+ public:
+
+  LAPPDParseACC();
+  bool Initialise(std::string configfile,DataModel &data);
+  bool Execute();
+  bool Finalise();
+
+
+ private:
+   ifstream dfs, mfs;
+   vector<int> boards;
+   int event;
+   string meta_header;
+
+
+
+
+};
+
+
+#endif

--- a/UserTools/LAPPDParseACC/README.md
+++ b/UserTools/LAPPDParseACC/README.md
@@ -1,0 +1,25 @@
+# LAPPDParseACC
+
+This tool is made to parse the files produced from the ANNIE Central Card electronics. The design and format of those files is described at this [github page](https://github.com/lappd-daq/acdc-daq).
+
+
+## Options
+The following need to be defined at configuration level
+```
+filepath <the base folder of the input files>
+filename <the base name of the three files>
+print <true/false> # Verbosity level
+```
+
+an example of this would be
+```
+filepath ./fakedata
+filename test
+print false
+```
+This would read the three following files
+```
+fakedata/test.ped
+fakedata/test.acdc
+fakedata/test.meta
+```

--- a/UserTools/LAPPDSave/LAPPDSave.cpp
+++ b/UserTools/LAPPDSave/LAPPDSave.cpp
@@ -12,13 +12,14 @@ bool LAPPDSave::Initialise(std::string configfile, DataModel &data){
   m_data= &data; //assigning transient data pointer
   /////////////////////////////////////////////////////////////////
 
+  m_variables.Get("path", path);
   return true;
 }
 
 
 bool LAPPDSave::Execute(){
 
-  m_data->Stores["ANNIEEvent"]->Save("./testoutpt");
+  m_data->Stores["ANNIEEvent"]->Save(path);
   m_data->Stores["ANNIEEvent"]->Delete();
 
   return true;

--- a/UserTools/LAPPDSave/LAPPDSave.h
+++ b/UserTools/LAPPDSave/LAPPDSave.h
@@ -18,7 +18,7 @@ class LAPPDSave: public Tool {
 
 
  private:
-
+     std::string path;
 
 
 

--- a/UserTools/LAPPDSave/README.md
+++ b/UserTools/LAPPDSave/README.md
@@ -1,0 +1,9 @@
+# LAPPDSave
+
+This tool will save each ANNIEEvent as it passes through.
+
+## Config Variables
+There should be one config variable passed which will correspond to the output file of the saving. An example would be
+```
+path ./testoutput/events
+```

--- a/UserTools/Unity.cpp
+++ b/UserTools/Unity.cpp
@@ -7,6 +7,7 @@
 #include "Examples/ExampleLoadRoot.cpp"
 #include "PythonScript/PythonScript.cpp"
 #include "LAPPDParseScope/LAPPDParseScope.cpp"
+#include "LAPPDParseACC/LAPPDParseACC.cpp"
 #include "LAPPDFindPeak/LAPPDFindPeak.cpp"
 #include "LAPPDSave/LAPPDSave.cpp"
 #include "LAPPDSim/LAPPDSim.cpp"


### PR DESCRIPTION
This pull request will incorporate a tool for parsing ACC data from the acdc-daq logData output. I have added three files fakedata/test.* for use in testing. These files' data is uniformly random data and does not mimic realistic acdc data but rather matches the data format of the files. I have added a readme to my tool that describes what configuration settings are needed to run it.