### PR TITLE
Fix typos in Makefile.FNAL

### DIFF
--- a/Makefile.FNAL
+++ b/Makefile.FNAL
@@ -19,11 +19,11 @@ RootLib= -L $(ROOT_INC)/../lib `root-config --libs` -lMinuit
 DataModelInclude = $(RootInclude)
 DataModelLib = $(RootLib)
 
-WCSimLib= -L ToolDAQ/LibWCSim -lWCSimRoot
-WCSimInclude= -I ToolDAQ/LibWCSim/include
+WCSimLib= -L ToolDAQ/WCSimLib -lWCSimRoot
+WCSimInclude= -I ToolDAQ/WCSimLib/include
 
-MrdTrackLib= -L ToolDAQ/LibFindMrdTracks/src -lFindMrdTracks
-MrdTrackInclude= -I ToolDAQ/LibFindMrdTracks/include
+MrdTrackLib= -L ToolDAQ/MrdTrackLib/src -lFindMrdTracks
+MrdTrackInclude= -I ToolDAQ/MrdTrackLib/include
 
 
 MyToolsInclude =  $(RootInclude) $(PythonInclude) $(MrdTrackInclude) $(WCSimInclude)


### PR DESCRIPTION
The names of the directories for the WCSim and MrdTrack libraries are not correct in the FNAL Makefile. This commit fixes them.