### PR TITLE
Add the BeamFetcher tool

### DIFF
--- a/DataModel/ANNIEconstants.h
+++ b/DataModel/ANNIEconstants.h
@@ -17,4 +17,11 @@ constexpr int BOGUS_INT = -9999;
 /// @brief The format code for a multievent binary BoostStore
 constexpr int BOOST_STORE_MULTIEVENT_FORMAT = 2;
 
+// Used to convert from seconds and nanoseconds to milliseconds when
+// creating timestamps in ms while interacting with the Intensity Frontier
+// beam database via the BeamChecker and BeamFetcher tools
+constexpr unsigned long long THOUSAND = 1000ull;
+constexpr unsigned long long MILLION = 1000000ull;
+constexpr unsigned long long BILLION = 1000000000ull;
+
 #endif

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -17,6 +17,7 @@ RUN yum install -y \
     gcc-c++ \
     gcc \
     binutils \
+    libcurl-devel \
     libX11-devel \
     libXpm-devel \
     libXft-devel \

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ DataModelInclude = $(RootInclude)
 DataModelLib = $(RootLib)
 
 MyToolsInclude =  $(RootInclude) `python-config --cflags` $(MrdTrackInclude) $(WCSimInclude)
-MyToolsLib = $(RootLib) `python-config --libs` $(MrdTrackLib) $(WCSimLib)
+MyToolsLib = -lcurl $(RootLib) `python-config --libs` $(MrdTrackLib) $(WCSimLib)
 
 all: lib/libStore.so lib/libLogging.so lib/libDataModel.so include/Tool.h lib/libMyTools.so lib/libServiceDiscovery.so lib/libToolChain.so Analyse
 

--- a/Makefile.FNAL
+++ b/Makefile.FNAL
@@ -26,7 +26,7 @@ MrdTrackLib= -L ToolDAQ/MrdTrackLib/src -lFindMrdTracks
 MrdTrackInclude= -I ToolDAQ/MrdTrackLib/include
 
 
-MyToolsInclude =  $(RootInclude) $(PythonInclude) $(MrdTrackInclude) $(WCSimInclude)
+MyToolsInclude = -lcurl $(RootInclude) $(PythonInclude) $(MrdTrackInclude) $(WCSimInclude)
 MyToolsLib = $(RootLib) $(PythonLib) $(MrdTrackLib) $(WCSimLib)
 
 

--- a/UserTools/BeamChecker/BeamChecker.cpp
+++ b/UserTools/BeamChecker/BeamChecker.cpp
@@ -13,10 +13,6 @@
 // Definitions local to this source file
 namespace {
 
-  // Used to convert from seconds and nanoseconds to milliseconds below
-  constexpr uint64_t THOUSAND = 1000ull;
-  constexpr uint64_t MILLION = 1000000ull;
-
   std::string make_time_string(uint64_t ms_since_epoch) {
     time_t s_since_epoch = ms_since_epoch / THOUSAND;
     std::string time_string = asctime(gmtime(&s_since_epoch));

--- a/UserTools/BeamFetcher/BeamFetcher.cpp
+++ b/UserTools/BeamFetcher/BeamFetcher.cpp
@@ -1,0 +1,180 @@
+// standard library includes
+#include <ctime>
+#include <limits>
+
+// ToolAnalysis includes
+#include "BeamFetcher.h"
+#include "IFBeamDBInterface.h"
+
+namespace {
+  constexpr unsigned long long TWO_HOURS = 7200000ull; // ms
+  constexpr unsigned long long THIRTY_SECONDS = 30000ull; // ms
+}
+
+BeamFetcher::BeamFetcher() : Tool(),
+  beam_db_store_(false, BOOST_STORE_MULTIEVENT_FORMAT)
+{}
+
+bool BeamFetcher::Initialise(std::string config_filename, DataModel& data)
+{
+  // Load configuration file variables
+  if ( !config_filename.empty() ) m_variables.Initialise(config_filename);
+
+  // Assign a transient data pointer
+  m_data = &data;
+
+  m_variables.Get("verbose", verbosity_);
+
+  bool got_db_filename = m_variables.Get("OutputFile", db_filename_);
+
+  // Check for problems
+  if ( !got_db_filename ) {
+    Log("Error: Missing output filename in the configuration for the"
+      " BeamFetcher tool", 0, verbosity_);
+    return false;
+  }
+
+  // Check if the beam database file already exists using a dummy std::ifstream
+  std::ifstream dummy_in_file(db_filename_);
+  if ( dummy_in_file.good() ) {
+    Log("Error: BeamFetcher output file \"" + db_filename_
+     + "\" already exists", 0, verbosity_);
+    return false;
+  }
+  dummy_in_file.close();
+
+
+  return true;
+}
+
+bool BeamFetcher::Execute() {
+
+  unsigned long long start_ms_since_epoch;
+  bool got_start_ms = m_variables.Get("StartMillisecondsSinceEpoch",
+    start_ms_since_epoch);
+
+  if ( !got_start_ms ) {
+    Log("Error: Missing setting for the StartMillisecondsSinceEpoch"
+      " configuration file option", 0, verbosity_);
+    return false;
+  }
+
+  unsigned long long end_ms_since_epoch;
+  bool got_end_ms = m_variables.Get("EndMillisecondsSinceEpoch",
+    end_ms_since_epoch);
+
+  if ( !got_end_ms ) {
+    Log("Error: Missing setting for the EndMillisecondsSinceEpoch"
+      " configuration file option", 0, verbosity_);
+    return false;
+  }
+
+  if ( start_ms_since_epoch >= end_ms_since_epoch ) {
+    Log("Error: The start time for the BeamFetch tool must be less than"
+      " the end time", 0, verbosity_);
+    return false;
+  }
+
+  unsigned long long chunk_step_ms;
+  bool got_time_step = m_variables.Get("TimeChunkStepInMilliseconds",
+    chunk_step_ms);
+
+  if ( !got_time_step ) {
+    Log("Error: Missing setting for the TimeChunkStepInMilliseconds"
+      " configuration file option", 0, verbosity_);
+    return false;
+  }
+
+  return fetch_beam_data(start_ms_since_epoch, end_ms_since_epoch,
+    chunk_step_ms);
+}
+
+
+bool BeamFetcher::Finalise() {
+
+  return true;
+}
+
+bool BeamFetcher::fetch_beam_data(unsigned long long start_ms_since_epoch,
+  unsigned long long end_ms_since_epoch, unsigned long long chunk_step_ms)
+{
+  // Get POT information backwards moving from the end time to the start
+  // time in large chunks. Chunk sizes of two hours or so are recommended.
+  // Chunks significantly longer than that will reliably cause some
+  // database queries to fail.
+  unsigned long long current_time = end_ms_since_epoch;
+
+  // Get a const reference to the beam database interface
+  const auto& db = IFBeamDBInterface::Instance();
+
+  // Storage for parsed data from the IF beam database
+  std::map<std::string, std::map<unsigned long long, BeamDataPoint> >
+    beam_data;
+
+  // Index to save in the BoostStore header. Allows easy searching of the
+  // BeamDB entries later
+  std::map<int, std::pair<unsigned long long, unsigned long long> >
+    beam_db_index;
+
+  int current_entry = 0;
+
+  while (current_time >= start_ms_since_epoch) {
+
+    if (current_entry > 0) current_time -= chunk_step_ms;
+
+    time_t s_since_epoch = current_time / THOUSAND;
+    std::string time_string = asctime(gmtime(&s_since_epoch));
+
+    Log("Loading new beam data for " + time_string, 2, verbosity_);
+
+    // Have a small overlap (THIRTY_SECONDS) between entries so that we
+    // can be sure not to miss any time interval in the desired range
+    beam_data = db.QueryBeamDB(current_time - chunk_step_ms,
+      current_time + THIRTY_SECONDS);
+
+    // TODO: remove hard-coded device name here
+    const auto& pot_map = beam_data.at("E:TOR875");
+
+    // Find the range of times for which E:TOR875 data exist in the
+    // current beam database chunk
+    unsigned long long start_ms
+      = std::numeric_limits<unsigned long long>::max();
+    unsigned long long end_ms = 0ull;
+    for (const auto& pair : pot_map) {
+      if (pair.first < start_ms) start_ms = pair.first;
+      if (pair.first > end_ms) end_ms = pair.first;
+    }
+
+    beam_db_index[current_entry] = std::pair<unsigned long long,
+      unsigned long long>(start_ms, end_ms);
+
+    beam_db_store_.Set("BeamDB", beam_data);
+    beam_db_store_.Save(db_filename_);
+    beam_db_store_.Delete();
+
+    ++current_entry;
+  }
+
+  beam_db_store_.Header->Set("BeamDBIndex", beam_db_index);
+
+  // Find the range of times covered by the entire downloaded database
+  unsigned long long overall_start_ms
+      = std::numeric_limits<unsigned long long>::max();
+  unsigned long long overall_end_ms = 0ull;
+
+  for (const auto& pair : beam_db_index) {
+    unsigned long long temp_start_ms = pair.second.first;
+    unsigned long long temp_end_ms = pair.second.second;
+    if (temp_start_ms < overall_start_ms) overall_start_ms = temp_start_ms;
+    if (temp_end_ms > overall_end_ms) overall_end_ms = temp_end_ms;
+  }
+
+  beam_db_store_.Header->Set("StartMillisecondsSinceEpoch", overall_start_ms);
+  beam_db_store_.Header->Set("EndMillisecondsSinceEpoch", overall_end_ms);
+
+  beam_db_store_.Close();
+
+  Log("Retrieval of beam status data complete.", 1, verbosity_);
+
+  return true;
+}

--- a/UserTools/BeamFetcher/BeamFetcher.h
+++ b/UserTools/BeamFetcher/BeamFetcher.h
@@ -1,0 +1,42 @@
+// Tool to download beam information from the Intensity Frontier
+// beam database and save it in a BoostStore file for later retrieval
+// by the BeamChecker tool
+//
+// Steven Gardiner <sjgardiner@ucdavis.edu>
+#pragma once
+
+// standard library includes
+#include <iostream>
+#include <string>
+
+// ToolAnalysis includes
+#include "Tool.h"
+
+class BeamFetcher: public Tool {
+
+  public:
+
+    BeamFetcher();
+    bool Initialise(std::string configfile, DataModel& data);
+    bool Execute();
+    bool Finalise();
+
+  protected:
+
+    /// @brief The verbosity to use when printing logging messages
+    /// @details A larger value corresponds to more verbose output
+    int verbosity_;
+
+    /// @brief Transient BoostStore used to save downloaded information
+    /// from the Intensity Frontier beam database to disk
+    BoostStore beam_db_store_;
+
+    /// @brief Helper function that downloads and processes the beam
+    /// information
+    bool fetch_beam_data(unsigned long long start_ms_since_epoch,
+      unsigned long long end_ms_since_epoch, unsigned long long chunk_step_ms);
+
+    /// @brief Name of the output file in which the beam database information
+    /// will be saved
+    std::string db_filename_;
+};

--- a/UserTools/BeamFetcher/IFBeamDBInterface.cpp
+++ b/UserTools/BeamFetcher/IFBeamDBInterface.cpp
@@ -1,0 +1,279 @@
+// standard library includes
+#include <algorithm>
+#include <array>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <sstream>
+
+// ToolAnalysis includes
+#include "ANNIEconstants.h"
+#include "IFBeamDBInterface.h"
+
+IFBeamDBInterface::IFBeamDBInterface()
+{
+  fCurl = curl_easy_init();
+  if (!fCurl) throw std::runtime_error("IFBeamDBInterface failed to"
+    " initialize libcurl");
+}
+
+IFBeamDBInterface::~IFBeamDBInterface()
+{
+  curl_easy_cleanup(fCurl);
+}
+
+const IFBeamDBInterface& IFBeamDBInterface::Instance() {
+
+  // Create the IFBeamDBInterface using a static variable. This ensures that
+  // the singleton instance is only created once.
+  static std::unique_ptr<IFBeamDBInterface> the_instance(
+    new IFBeamDBInterface());
+
+  // Return a reference to the singleton instance
+  return *the_instance;
+}
+
+std::map<std::string, std::map<unsigned long long, BeamDataPoint> >
+  IFBeamDBInterface::QueryBeamDB(unsigned long long t0, unsigned long long t1)
+  const
+{
+  // Temporary storage for the response from the IF beam database
+  std::string response;
+
+  int code = QueryBeamDB(t0, t1, response);
+
+  if (code != CURLE_OK) throw std::runtime_error("Error accessing"
+    " IF beam database. Please check your internet connection.");
+
+  auto beam_data = ParseDBResponse(response);
+
+  return beam_data;
+}
+
+int IFBeamDBInterface::QueryBeamDB(unsigned long long t0,
+  unsigned long long t1, std::string& response_string) const
+{
+  if (!fCurl) {
+    throw std::runtime_error("IFBeamDBInterface::QueryBeamDB() called"
+      " without inititalizing libcurl");
+    return -1;
+  }
+
+  constexpr char BNB_URL_START[] = "http://ifb-data.fnal.gov:8100/ifbeam/"
+    "data/data?e=e%2C1d&b=BNBBPMTOR&f=csv&tz=&action=Show+device&t0=";
+
+  std::stringstream url_stream;
+
+  url_stream << BNB_URL_START;
+  url_stream << std::fixed << std::setprecision(3) << (t0 - 1)/1000.;
+  url_stream << "&t1=" << (t1 + 1)/1000.;
+
+  curl_easy_setopt(fCurl, CURLOPT_URL, url_stream.str().c_str());
+
+  response_string.clear();
+
+  curl_easy_setopt(fCurl, CURLOPT_WRITEFUNCTION,
+    static_cast<size_t(*)(char*, size_t, size_t, std::string*)>(
+      [](char* ptr, size_t size,
+        size_t num_members, std::string* data) -> size_t
+      {
+        data->append(ptr, size * num_members);
+        return size * num_members;
+      }
+    )
+  );
+  curl_easy_setopt(fCurl, CURLOPT_WRITEDATA, &response_string);
+
+  int code = curl_easy_perform(fCurl);
+
+  // Check the HTTP response code from the IF beam database server. If
+  // it's not 200, then throw an exception (something went wrong).
+  // For more information about the possible HTTP status codes, see
+  // this Wikipedia article: http://tinyurl.com/8yqvhwf
+  long http_response_code;
+  constexpr long HTTP_OK = 200;
+  curl_easy_getinfo(fCurl, CURLINFO_RESPONSE_CODE, &http_response_code);
+  if (http_response_code != HTTP_OK) {
+    throw std::runtime_error("HTTP error (code "
+      + std::to_string(http_response_code) + ") encountered while querying"
+      " the IF beam database");
+  }
+
+  return code;
+}
+
+// Here's some documentation for some of the parameters stored in the beam
+// database. It's taken from the MicroBooNE operations wiki:
+// http://tinyurl.com/z3c4mxs
+//
+// The status page shows the present reading of beamline instrumentation. All
+// of this data is being stored to IF beam Database. The "IF Beam DB
+// dashboard":http://dbweb4.fnal.gov:8080/ifbeam/app/BNBDash/index provides
+// another view of beam data. Some of it is redundant to the status page, but
+// it verifies that the data is being stored in the database. At present the
+// page shows following devices:
+//   * TOR860, TOR875 - two toroids in BNB measuring beam intensity. TOR860 is
+//     at the beginning of the beamline, and TOR875 is at the end.
+//   * THCURR - horn current
+//   * HWTOUT - horn water temperature coming out of the horn.
+//   * BTJT2 - target temperature
+//   * HP875, VP875 - beam horizontal and vertical positions at the 875
+//     location, about 4.5 m upstream of the target center.
+//   * HPTG1, VPTG1 - beam horizontal and vertical positions immediately
+//     (about 2.5 m) upstream of the target center.
+//   * HPTG2, VPTG2 - beam horizontal and vertical positions more immediately
+//     (about 1.5 m) upstream of the target center.
+//   * Because there are no optics between H/VP875 and H/VPTG2, the movements
+//     on these monitors should scale with the difference in distances.
+//   * BTJT2 - target air cooling temperature. Four RTD measure the return
+//     temperature of the cooling air. This is the one closest to the target.
+//   * BTH2T2 - target air cooling temperature. This is the temperature of the
+//     air going into the horn.
+
+std::map<std::string, std::map<unsigned long long, BeamDataPoint> >
+  IFBeamDBInterface::ParseDBResponse(const std::string& response) const
+{
+  // Create an empty map to store the parsed data.
+  std::map<std::string, std::map<unsigned long long,
+    BeamDataPoint> > beam_data;
+
+  // Use a stringstream to parse the data
+  std::istringstream response_stream(response);
+
+  // Temporary storage for the comma-separated fields in the database response
+  // string
+  unsigned long long time_stamp;
+  std::string data_type;
+  std::string unit;
+  double value;
+
+  // Skip the first line (which gives textual column headers)
+  std::getline(response_stream, unit, '\n');
+
+  // Parse each line of the response and load the map with the parsed data
+  while (response_stream >> time_stamp) {
+    response_stream.ignore(1);
+    std::getline(response_stream, data_type, ',');
+    std::getline(response_stream, unit, ',');
+    response_stream >> value;
+
+    // If there were any input problems, give up
+    if (!response_stream) break;
+
+    // Otherwise, load the new data into the map
+    beam_data[data_type][time_stamp] = BeamDataPoint(value, unit);
+  }
+
+  PostprocessParsedResponse(beam_data);
+
+  return beam_data;
+}
+
+void IFBeamDBInterface::PostprocessParsedResponse(std::map<std::string,
+  std::map<unsigned long long, BeamDataPoint> >& parsed_response) const
+{
+  // Perform postprocessing for the given device names
+  // The only two devices currently selected for postprocessing are toroids
+  // used to measure the protons-on-target (POT)
+  constexpr std::array<const char*, 2> devices = { "E:TOR860", "E:TOR875" };
+
+  std::stringstream ss;
+  double value;
+
+  // Check whether each device name is found in the parsed response map
+  for (const auto& device : devices) {
+    auto iter = parsed_response.find(device);
+
+    // If it is, append the unit (which is known for these devices to be of the
+    // form "E12") to the end of the numerical value, then convert the entire
+    // string back to a number. Replace the given unit with "POT" (for "protons
+    // on target") and update the map with the new value and unit.
+    if (iter != parsed_response.end()) {
+      for (auto& pair : iter->second) {
+
+        // Clear and reset the string stream
+        ss.str("");
+        ss.clear();
+
+        // Do the conversion to a numerical value using the exponent from the
+        // "E12" unit
+        ss << pair.second.value << pair.second.unit;
+        ss >> value;
+
+        // Update the map with the new value and unit
+        pair.second.value = value;
+        pair.second.unit = "POT";
+      }
+    }
+  }
+}
+
+BeamStatus IFBeamDBInterface::GetBeamStatus(unsigned long long time) const
+{
+  constexpr unsigned long long TIME_OFFSET = 5000ull; // ms
+
+  // The exact time given by the user might not appear in the database, so
+  // look for entries on the interval [time - TIME_OFFSET, time + TIME_OFFSET]
+  unsigned long long t0 = time - TIME_OFFSET;
+  unsigned long long t1 = time + TIME_OFFSET;
+
+  // Ask the beam database for information about the time window of interest.
+  // If there are any problems, then return a bogus BeamStatus object.
+  try {
+
+    auto beam_data = QueryBeamDB(t0, t1);
+
+    // TODO: remove hard-coded device name here
+    // Get protons-on-target (POT) information from the parsed data
+    const auto& pot_map = beam_data.at("E:TOR875");
+
+    // Find the POT entry with the closest time to that requested by the
+    // user, and use it to create the BeamStatus object that will be returned
+    const auto low = pot_map.lower_bound(time);
+
+    if (low == pot_map.cend()) {
+      std::cerr << "WARNING: IF beam database did not have any information"
+        " for " << time << " ms after the Unix epoch\n";
+
+      return BeamStatus(TimeClass(time * MILLION), 0., BeamCondition::Missing);
+    }
+
+    else if (low == pot_map.cbegin()) {
+      // TODO: add checks for BeamCondition::Bad here?
+      return BeamStatus(TimeClass( low->first * MILLION ), low->second.value,
+        BeamCondition::Ok);
+    }
+
+    // We're between two time values, so we need to figure out which is closest
+    // to the value requested by the user
+    else {
+
+      auto prev = low;
+      --prev;
+
+      if ((time - prev->first) < (low->first - time)) {
+        // TODO: add checks for BeamCondition::Bad here?
+        return BeamStatus(TimeClass( prev->first * MILLION ),
+          prev->second.value, BeamCondition::Ok);
+      }
+      else {
+        // TODO: add checks for BeamCondition::Bad here?
+        return BeamStatus(TimeClass( low->first * MILLION ), low->second.value,
+          BeamCondition::Ok);
+      }
+    }
+
+  }
+
+  catch (const std::exception& e) {
+    std::cerr << "WARNING: problem encountered while querying IF beam"
+      " database:\n  " << e.what() << '\n';
+
+    // Return a default-constructed BeamStatus object since there was a
+    // problem. The fOk member will be set to false by default, which will
+    // flag the object as problematic.
+    return BeamStatus(TimeClass( time ), 0., BeamCondition::Missing);
+  }
+
+}

--- a/UserTools/BeamFetcher/IFBeamDBInterface.h
+++ b/UserTools/BeamFetcher/IFBeamDBInterface.h
@@ -1,0 +1,89 @@
+#pragma once
+// Singleton class used by the BeamFetcher tool to communicate with the
+// Fermilab Intensity Frontier beam database
+// (see http://ifb-data.fnal.gov:8100/ifbeam/data)
+//
+// Steven Gardiner (sjgardiner@ucdavis.edu)
+
+// standard library includes
+#include <map>
+#include <string>
+
+// libcurl includes
+#include <curl/curl.h>
+
+// ToolAnalysis includes
+#include "BeamDataPoint.h"
+
+/// @brief Singleton used to interact with the Intensity Frontier beam database
+/// at Fermilab
+class IFBeamDBInterface {
+
+  public:
+
+    /// @brief Clean up libcurl stuff as the IFBeamDBInterface object is
+    /// destroyed
+    ~IFBeamDBInterface();
+
+    /// @brief Deleted copy constructor
+    IFBeamDBInterface(const IFBeamDBInterface&) = delete;
+
+    /// @brief Deleted move constructor
+    IFBeamDBInterface(IFBeamDBInterface&&) = delete;
+
+    /// @brief Deleted copy assignment operator
+    IFBeamDBInterface& operator=(const IFBeamDBInterface&) = delete;
+
+    /// @brief Deleted move assignment operator
+    IFBeamDBInterface& operator=(IFBeamDBInterface&&) = delete;
+
+    /// @brief Get a const reference to the singleton instance of the
+    /// IFBeamDBInterface
+    static const IFBeamDBInterface& Instance();
+
+    /// @brief Get information about the Booster Neutrino Beam (BNB) state from
+    /// the database for the time interval [t0, t1]
+    /// @param t0 Starting timestamp (milliseconds since the Unix epoch)
+    /// @param t1 Starting timestamp (milliseconds since the Unix epoch)
+    /// @return A nested map containing the parsed data. Keys of the outer map
+    /// are device names, values are inner maps. Keys of the inner map are
+    /// timestamps (milliseconds since the Unix epoch), values are
+    /// BeamDataPoint structs that hold a numerical value and a unit string.
+    /// @note An easy way to get the current milliseconds since the Unix epoch
+    /// is to use the terminal utility date like this: @verbatim date +%s%3N
+    /// @endverbatim
+    /// I found this handy trick here: http://unix.stackexchange.com/a/123764
+    std::map<std::string, std::map<unsigned long long, BeamDataPoint> >
+      QueryBeamDB(unsigned long long t0, unsigned long long t1) const;
+
+    /// @brief Get information about the BNB state from the database for the
+    /// time interval [t0, t1]
+    /// @param t0 Starting timestamp (milliseconds since the Unix epoch)
+    /// @param t1 Starting timestamp (milliseconds since the Unix epoch)
+    /// @param[out] response_string A string that will be loaded with the
+    /// csv-format data from the database
+    /// @return The libcurl integer return code for the query (zero if
+    /// everything worked ok, or nonzero if an error occurred)
+    int QueryBeamDB(unsigned long long t0, unsigned long long t1,
+      std::string& response_string) const;
+
+    /// @brief Get information about the BNB state from the database as close
+    /// as possible to a given time
+    /// @param time Timestamp (milliseconds since the Unix epoch) to use when
+    /// searching the database
+    BeamStatus GetBeamStatus(unsigned long long time) const;
+
+  protected:
+
+    /// @brief Create the singleton IFBeamDBInterface object
+    IFBeamDBInterface();
+
+    std::map<std::string, std::map<unsigned long long, BeamDataPoint> >
+      ParseDBResponse(const std::string& response) const;
+
+    void PostprocessParsedResponse(std::map<std::string,
+      std::map<unsigned long long, BeamDataPoint> >& parsed_response) const;
+
+    /// @brief Pointer used to interact with libcurl
+    CURL* fCurl = nullptr;
+};

--- a/UserTools/BeamFetcher/README.md
+++ b/UserTools/BeamFetcher/README.md
@@ -1,0 +1,19 @@
+# BeamFetcher
+
+BeamFetcher
+
+## Data
+
+Describe any data formats BeamFetcher creates, destroys, changes, or analyzes. E.G.
+
+**RawLAPPDData** `map<Geometry, vector<Waveform<double>>>`
+* Takes this data from the `ANNIEEvent` store and finds the number of peaks
+
+## Configuration
+
+Describe any configuration variables for BeamFetcher.
+
+```
+param1 value1
+param2 value2
+```

--- a/UserTools/Factory/Factory.cpp
+++ b/UserTools/Factory/Factory.cpp
@@ -32,5 +32,6 @@ if (tool=="LAPPDIntegratePulse") ret=new LAPPDIntegratePulse;
 if (tool=="ADCCalibrator") ret=new ADCCalibrator;
 if (tool=="ADCHitFinder") ret=new ADCHitFinder;
 if (tool=="BeamChecker") ret=new BeamChecker;
+if (tool=="BeamFetcher") ret=new BeamFetcher;
 return ret;
 }

--- a/UserTools/Unity.cpp
+++ b/UserTools/Unity.cpp
@@ -34,3 +34,5 @@
 #include "ADCCalibrator/ADCCalibrator.cpp"
 #include "ADCHitFinder/ADCHitFinder.cpp"
 #include "BeamChecker/BeamChecker.cpp"
+#include "BeamFetcher/IFBeamDBInterface.cpp"
+#include "BeamFetcher/BeamFetcher.cpp"

--- a/UserTools/recoANNIE/RawCard.cc
+++ b/UserTools/recoANNIE/RawCard.cc
@@ -4,10 +4,10 @@
 // reco-annie includes
 #include "RawCard.h"
 
-namespace {
-  // Used to convert between seconds and nanoseconds
-  constexpr unsigned long long BILLION = 1000000000;
+// ToolAnalysis includes
+#include "ANNIEconstants.h"
 
+namespace {
   // The cards have clock frequencies of 125 MHz, so they take
   // samples every 8 ns.
   constexpr unsigned long long CLOCK_TICK = 8; // ns

--- a/configfiles/PhaseI/BeamCheckerConfig
+++ b/configfiles/PhaseI/BeamCheckerConfig
@@ -1,4 +1,5 @@
 # Dummy config file
 verbose 2
 BadPOTMax 1e11
-BeamDBFile /annie/app/users/gardiner/phase1_beam_db.data
+#BeamDBFile /annie/app/users/gardiner/phase1_beam_db.data
+BeamDBFile ./my_beam_db.data

--- a/configfiles/PhaseI/BeamFetcherConfig
+++ b/configfiles/PhaseI/BeamFetcherConfig
@@ -1,0 +1,6 @@
+# Dummy config file
+verbose 2
+OutputFile ./my_beam_db.data
+StartMillisecondsSinceEpoch 1491132659000 # 6:30:49 AM 2 April 2017 (FNAL time)
+EndMillisecondsSinceEpoch   1491164001000 # 3:13:21 PM 2 April 2017 (FNAL time)
+TimeChunkStepInMilliseconds       7200000 # two hours

--- a/configfiles/PhaseI/ToolChainConfig
+++ b/configfiles/PhaseI/ToolChainConfig
@@ -2,7 +2,7 @@
 
 ##### Runtime Paramiters #####
 verbose 1 ## Verbosity level of ToolChain
-error_level 2 # 0= do not exit, 1= exit on unhandled errors only, 2= exit on unhandled errors and handled errors
+error_level 1 # 0= do not exit, 1= exit on unhandled errors only, 2= exit on unhandled errors and handled errors
 attempt_recover 1 ## 1= will attempt to finalise if an execute fails
 
 ###### Logging #####

--- a/configfiles/PhaseI/ToolsConfig
+++ b/configfiles/PhaseI/ToolsConfig
@@ -4,3 +4,4 @@ adc_hit_finder ADCHitFinder configfiles/PhaseI/ADCHitFinderConfig
 beam_checker BeamChecker configfiles/PhaseI/BeamCheckerConfig
 #save LAPPDSave configfiles/PhaseI/LAPPDSaveConfig
 # test2 DummyTool configfiles/DummyToolConfig
+#beam_fetcher BeamFetcher configfiles/PhaseI/BeamFetcherConfig


### PR DESCRIPTION
This tool downloads beam status data from the Intensity Frontier beam database, processes it, and stores it in a BoostStore-based output file. The output files produced by the BeamFetcher tool may be used by the BeamChecker tool to create BeamStatus objects in the ANNIEEvent Store.

Note that the BeamFetcher tool requires libcurl and its associated header files. I've updated Dockerfile.base to ensure that the needed centos package (libcurl-devel) is installed in Docker.