### PR TITLE
Fix memory corruption bug in the RawReader class from recoANNIE

### DIFF
--- a/UserTools/recoANNIE/RawReader.cc
+++ b/UserTools/recoANNIE/RawReader.cc
@@ -143,6 +143,18 @@ std::unique_ptr<annie::RawReadout> annie::RawReader::load_next_entry(
     temp_tree->SetBranchAddress("TriggerCounts", br_TriggerCounts_.data());
     temp_tree->SetBranchAddress("Rates", br_Rates_.data());
 
+    // Memory corruption can occur if we call GetEntry with a zero-length
+    // branch enabled. We've already resized the vectors to zero above,
+    // so just disable their branches for the zero-length case here as needed.
+    if (fbs_temp == 0) temp_tree->SetBranchStatus("Data", false);
+    else temp_tree->SetBranchStatus("Data", true);
+
+    if (tn_temp == 0) temp_tree->SetBranchStatus("TriggerCounts", false);
+    else temp_tree->SetBranchStatus("TriggerCounts", true);
+
+    if (cs_temp == 0) temp_tree->SetBranchStatus("Rates", false);
+    else temp_tree->SetBranchStatus("Rates", true);
+
     temp_tree->GetEntry(local_entry);
 
     // If this is the first card to be loaded, store its SequenceID for
@@ -216,6 +228,27 @@ std::unique_ptr<annie::RawReadout> annie::RawReader::load_next_entry(
   temp_tree->SetBranchAddress("EventTimes", br_EventTimes_.data());
   temp_tree->SetBranchAddress("TriggerMasks", br_TriggerMasks_.data());
   temp_tree->SetBranchAddress("TriggerCounters", br_TriggerCounters_.data());
+
+  // Memory corruption can occur if we call GetEntry with a zero-length
+  // branch enabled. We've already resized the vectors to zero above,
+  // so just disable their branches for the zero-length case here as needed.
+  if (es_temp == 0) {
+    temp_tree->SetBranchStatus("EventIDs", false);
+    temp_tree->SetBranchStatus("EventTimes", false);
+  }
+  else {
+    temp_tree->SetBranchStatus("EventIDs", true);
+    temp_tree->SetBranchStatus("EventTimes", true);
+  }
+
+  if (ts_temp == 0) {
+    temp_tree->SetBranchStatus("TriggerMasks", false);
+    temp_tree->SetBranchStatus("TriggerCounters", false);
+  }
+  else {
+    temp_tree->SetBranchStatus("TriggerMasks", true);
+    temp_tree->SetBranchStatus("TriggerCounters", true);
+  }
 
   temp_tree->GetEntry(local_entry);
 

--- a/configfiles/PhaseI/BeamCheckerConfig
+++ b/configfiles/PhaseI/BeamCheckerConfig
@@ -1,5 +1,4 @@
 # Dummy config file
 verbose 2
 BadPOTMax 1e11
-#BeamDBFile /annie/app/users/gardiner/phase1_beam_db.data
-BeamDBFile ./my_beam_db.data
+BeamDBFile /pnfs/annie/persistent/users/gardiner/phase1_beam_db.data


### PR DESCRIPTION
This problem occurs when one of the variable-length arrays in the raw data file has zero elements. The call to TChain::GetEntry corrupts memory managed by the std::vector objects used to store the arrays
in this case. The solution (implemented here) is to disable fetching the corresponding branch when an array has zero elements. This is an unusual situation, so it wasn't caught in earlier testing.