### PR TITLE
Add method to avoid throwing a particular error in the annie::RawReader class

### DIFF
--- a/UserTools/recoANNIE/RawReader.cc
+++ b/UserTools/recoANNIE/RawReader.cc
@@ -260,9 +260,16 @@ std::unique_ptr<annie::RawReadout> annie::RawReader::load_next_entry(
   // Check that the TrigData tree's SequenceID matches that of the PMTData tree
   // (if not, then we're loading data from two mismatched DAQ readouts!)
   if ( br_TrigData_SequenceID_ != raw_readout->sequence_id() ) {
-    throw std::runtime_error("Mismatched TrigData ("
+    std::string warning_message = "Mismatched TrigData ("
       + std::to_string(br_TrigData_SequenceID_) + ") and PMTData ("
-      + std::to_string( raw_readout->sequence_id() ) + ") SequenceID values");
+      + std::to_string( raw_readout->sequence_id() ) + ") SequenceID values";
+
+    if (throw_on_trig_pmt_sequenceID_mismatch_) {
+      throw std::runtime_error(warning_message);
+    }
+    else {
+      std::cerr << '\n' << "WARNING: " << warning_message << '\n';
+    }
   }
 
   // Remember the SequenceID of the last raw readout to be successfully loaded
@@ -302,4 +309,11 @@ std::unique_ptr<annie::RawReadout> annie::RawReader::load_next_entry(
   raw_readout->set_run_information(run_info);
 
   return raw_readout;
+}
+
+
+void annie::RawReader::set_throw_on_trig_pmt_sequenceID_mismatch(
+  bool should_I_throw)
+{
+  throw_on_trig_pmt_sequenceID_mismatch_ = should_I_throw;
 }

--- a/UserTools/recoANNIE/RawReader.h
+++ b/UserTools/recoANNIE/RawReader.h
@@ -37,6 +37,12 @@ namespace annie {
         return trig_data_chain_.GetFile();
       }
 
+      // Set the flag that determines whether a mismatch between the SequenceID
+      // value recorded in the TrigData TTree and the SequenceID value recorded
+      // in the PMTData TTree should result in a thrown std::runtime_error
+      // or simply a warning message printed to std::cerr.
+      void set_throw_on_trig_pmt_sequenceID_mismatch(bool should_I_throw);
+
       // Attempt to retrieve the readout with the given SequenceID from the
       // input file(s)
       //std::unique_ptr<RawReadout> get_sequence_id(int SequenceID);
@@ -88,6 +94,12 @@ namespace annie {
       std::vector<unsigned long long> br_EventTimes_; // [EventSize]
       std::vector<unsigned int> br_TriggerMasks_; // [TriggerSize]
       std::vector<unsigned int> br_TriggerCounters_; // [TriggerSize]
+
+      // A flag that determines whether a mismatch between the SequenceID
+      // value recorded in the TrigData TTree and the SequenceID value recorded
+      // in the PMTData TTree should result in a thrown std::runtime_error
+      // (true) or simply a warning message printed to std::cerr (false).
+      bool throw_on_trig_pmt_sequenceID_mismatch_ = false;
   };
 }
 


### PR DESCRIPTION
Currently, the annie::RawReader class (from recoANNIE, used by ToolAnalysis in the RawLoader tool) throws a std::runtime_error when it encounters different SequenceID values for a particular entry in the PMTData and TrigData TTrees from a Phase I raw data file. This is inconvenient because, in some instances, the data appear good, but a bogus SequenceID value comes up in the TrigData tree (e.g., SequenceID = 0 on the first entry of RAWDataR636S0p3.root).

This pull request adds code to disable the exception. A warning message is still printed by default. The user can enforce strict checking (and re-enable the exception) by calling the new annie::RawReader::set_throw_on_trig_pmt_sequenceID_mismatch(bool should_I_throw) function before using an annie::RawReader object.