### PR TITLE
Avoid memory corruption problems (for now) by removing code that reads from the TrigData TTree

### DIFF
--- a/DataModel/ANNIEconstants.h
+++ b/DataModel/ANNIEconstants.h
@@ -6,7 +6,7 @@
 constexpr double ADC_IMPEDANCE = 50.; // Ohm
 
 /// @brief Multiplying by this constant converts ADC counts to Volts
-constexpr double ADC_TO_VOLT = 2.415 / std::pow(2., 12);
+const double ADC_TO_VOLT = 2.415 / std::pow(2., 12);
 
 /// @brief The number of nanoseconds per ADC sample
 constexpr unsigned int NS_PER_ADC_SAMPLE = 2; // ns

--- a/UserTools/recoANNIE/RawReadout.h
+++ b/UserTools/recoANNIE/RawReadout.h
@@ -33,7 +33,7 @@ namespace annie {
         const std::vector<unsigned long long>& TriggerCounts,
         const std::vector<unsigned int>& Rates, bool overwrite_ok = false);
 
-      inline const std::map<int, annie::RawCard> cards() const
+      inline const std::map<int, annie::RawCard>& cards() const
         { return cards_; }
 
       inline const annie::RawCard& card(int index) const


### PR DESCRIPTION
Remove code that loads information from the TrigData tree from the
annie::RawReader class (for now). Memory corruption occurs from what
appears to be a ROOT bug when setting the branch addresses for the
variable-length arrays.