### PR TITLE
unit fix - all LoadWCSim, LoadWCSimLAPPD units fixed from [cm] to [m]…

### DIFF
--- a/UserTools/FindMrdTracks/FindMrdTracks.cpp
+++ b/UserTools/FindMrdTracks/FindMrdTracks.cpp
@@ -427,6 +427,7 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 			m_data->Stores["MRDTracks"]->Set("InterceptsTank",atrack->GetInterceptsTank());
 			m_data->Stores["MRDTracks"]->Set("StartTime",atrack->GetStartTime());
 			// convert start posn from TVector3 to ANNIEEVENT Position class
+			// TODO: FIXME XXX CHECK UNITS XXX XXX XXX XXX 
 			Position startpos(atrack->GetStartVertex().X(), 
 							  atrack->GetStartVertex().Y(), 
 							  atrack->GetStartVertex().Z());

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -98,17 +98,17 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	int numlappds = wcsimrootgeom->GetWCNumLAPPD();
 	int nummrdpmts = wcsimrootgeom->GetWCNumMRDPMT();
 	numvetopmts = wcsimrootgeom->GetWCNumFACCPMT();
-	double tank_xcentre = wcsimrootgeom->GetWCOffset(0);
-	double tank_ycentre = wcsimrootgeom->GetWCOffset(1);
-	double tank_zcentre = wcsimrootgeom->GetWCOffset(2);
+	double tank_xcentre = (wcsimrootgeom->GetWCOffset(0)) / 100.;  // convert [cm] to [m]
+	double tank_ycentre = (wcsimrootgeom->GetWCOffset(1)) / 100.;
+	double tank_zcentre = (wcsimrootgeom->GetWCOffset(2)) / 100.;
 	Position tank_centre(tank_xcentre, tank_ycentre, tank_zcentre);
-	double tank_radius = wcsimrootgeom->GetWCCylRadius();
-	double tank_halfheight = wcsimrootgeom->GetWCCylLength();
+	double tank_radius = (wcsimrootgeom->GetWCCylRadius()) / 100.;
+	double tank_halfheight = (wcsimrootgeom->GetWCCylLength()) / 100.;
 	// geometry variables not yet in wcsimrootgeom are in MRDSpecs.hh
-	double mrd_width =  MRDSpecs::MRD_width;
-	double mrd_height = MRDSpecs::MRD_height;
-	double mrd_depth =  MRDSpecs::MRD_depth;
-	double mrd_start =  MRDSpecs::MRD_start;
+	double mrd_width =  (MRDSpecs::MRD_width) / 100.;
+	double mrd_height = (MRDSpecs::MRD_height) / 100.;
+	double mrd_depth =  (MRDSpecs::MRD_depth) / 100.;
+	double mrd_start =  (MRDSpecs::MRD_start) / 100.;
 	if(verbose>1) cout<<"we have "<<numtankpmts<<" tank pmts, "<<nummrdpmts
 					  <<" mrd pmts and "<<numlappds<<" lappds"<<endl;
 	
@@ -118,7 +118,7 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	for(int i=0; i<numtankpmts; i++){
 		ChannelKey akey(subdetector::ADC, i);
 		WCSimRootPMT apmt = wcsimrootgeom->GetPMT(i);
-		Detector adet("Tank", Position(apmt.GetPosition(0),apmt.GetPosition(1),apmt.GetPosition(2)), 
+		Detector adet("Tank", Position(apmt.GetPosition(0) / 100.,apmt.GetPosition(1) / 100.,apmt.GetPosition(2) / 100.), 
 		               Direction(apmt.GetOrientation(0),apmt.GetOrientation(1),apmt.GetOrientation(2)), 
 		               i, apmt.GetName(), detectorstatus::ON, 0.);
 		Detectors.emplace(akey,adet);
@@ -127,7 +127,7 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	for(int i=0; i<nummrdpmts; i++){
 		ChannelKey akey(subdetector::TDC, i);
 		WCSimRootPMT apmt = wcsimrootgeom->GetMRDPMT(i);
-		Detector adet("MRD", Position(apmt.GetPosition(0),apmt.GetPosition(1),apmt.GetPosition(2)), 
+		Detector adet("MRD", Position(apmt.GetPosition(0) / 100.,apmt.GetPosition(1) / 100.,apmt.GetPosition(2) / 100.), 
 		              Direction(apmt.GetOrientation(0),apmt.GetOrientation(1),apmt.GetOrientation(2)), 
 		              i, apmt.GetName(), detectorstatus::ON, 0.);
 		Detectors.emplace(akey,adet);
@@ -136,7 +136,7 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	for(int i=0; i<numvetopmts; i++){
 		ChannelKey akey(subdetector::TDC, i);
 		WCSimRootPMT apmt = wcsimrootgeom->GetFACCPMT(i);
-		Detector adet("Veto", Position(apmt.GetPosition(0),apmt.GetPosition(1),apmt.GetPosition(2)), 
+		Detector adet("Veto", Position(apmt.GetPosition(0) / 100.,apmt.GetPosition(1) / 100.,apmt.GetPosition(2) / 100.), 
 		              Direction(apmt.GetOrientation(0),apmt.GetOrientation(1),apmt.GetOrientation(2)), 
 		              i, apmt.GetName(), detectorstatus::ON, 0.);
 		Detectors.emplace(akey,adet);
@@ -145,7 +145,7 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	for(int i=0; i<numlappds; i++){
 		ChannelKey akey(subdetector::LAPPD, i);
 		WCSimRootPMT apmt = wcsimrootgeom->GetLAPPD(i);
-		Detector adet("Tank", Position(apmt.GetPosition(0),apmt.GetPosition(1),apmt.GetPosition(2)), 
+		Detector adet("Tank", Position(apmt.GetPosition(0) / 100.,apmt.GetPosition(1) / 100.,apmt.GetPosition(2) / 100.), 
 		              Direction(apmt.GetOrientation(0),apmt.GetOrientation(1),apmt.GetOrientation(2)), 
 		              i, apmt.GetName(), detectorstatus::ON, 0.);
 		Detectors.emplace(akey,adet);
@@ -274,13 +274,13 @@ bool LoadWCSim::Execute(){
 			
 			MCParticle thisparticle(
 				nextrack->GetIpnu(), nextrack->GetE(), nextrack->GetEndE(),
-				Position(nextrack->GetStart(0), nextrack->GetStart(1), nextrack->GetStart(2)),
-				Position(nextrack->GetStop(0), nextrack->GetStop(1), nextrack->GetStop(2)),
+				Position(nextrack->GetStart(0) / 100., nextrack->GetStart(1) / 100., nextrack->GetStart(2) / 100.),
+				Position(nextrack->GetStop(0) / 100., nextrack->GetStop(1) / 100., nextrack->GetStop(2) / 100.),
 				TimeClass(nextrack->GetTime()), TimeClass(nextrack->GetStopTime()),
 				Direction(nextrack->GetDir(0), nextrack->GetDir(1), nextrack->GetDir(2)),
-				sqrt(pow(nextrack->GetStop(0)-nextrack->GetStart(0),2.)+
+				(sqrt(pow(nextrack->GetStop(0)-nextrack->GetStart(0),2.)+
 					 pow(nextrack->GetStop(1)-nextrack->GetStart(1),2.)+
-					 pow(nextrack->GetStop(2)-nextrack->GetStart(2),2.)),
+					 pow(nextrack->GetStop(2)-nextrack->GetStart(2),2.))) / 100.,
 					 startstoptype, tracki, nextrack->GetParenttype());
 			
 			MCParticles->push_back(thisparticle);

--- a/UserTools/LoadWCSimLAPPD/LAPPDTree.h
+++ b/UserTools/LoadWCSimLAPPD/LAPPDTree.h
@@ -39,7 +39,7 @@ public :
    Int_t           lappdevt;                          // event number
    Int_t           lappd_numhits;                     // number of LAPPDs hit this evt
    Int_t           lappdhit_objnum[180];              //[lappd_numhits], hit LAPPD number
-   Double_t        lappdhit_x[180];                   //[lappd_numhits], hit LAPPD x position
+   Double_t        lappdhit_x[180];                   //[lappd_numhits], hit LAPPD x position, [mm]
    Double_t        lappdhit_y[180];                   //[lappd_numhits]
    Double_t        lappdhit_z[180];                   //[lappd_numhits]
    vector<double>  *lappdhit_stripcoorx;              // x pos within tile [mm]

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
@@ -136,9 +136,9 @@ bool LoadWCSimLAPPD::Execute(){
 		for(int lappdi=0; lappdi<LAPPDEntry->lappd_numhits; lappdi++){
 			// loop over LAPPDs that had at least one hit
 			int LAPPDID = LAPPDEntry->lappdhit_objnum[lappdi];
-			double pmtx = LAPPDEntry->lappdhit_x[lappdi];  // position of LAPPD in global coords
-			double pmty = LAPPDEntry->lappdhit_y[lappdi];
-			double pmtz = LAPPDEntry->lappdhit_z[lappdi];
+			double pmtx = (LAPPDEntry->lappdhit_x[lappdi]) / 1000.;  // position of LAPPD in global coords, convert mm to m
+			double pmty = (LAPPDEntry->lappdhit_y[lappdi]) / 1000.;
+			double pmtz = (LAPPDEntry->lappdhit_z[lappdi]) / 1000.;
 			
 #if FILE_VERSION<3  // manual calculation of global hit position part 1
 			WCSimRootPMT lappdobj = geo->GetLAPPD(LAPPDID-1);
@@ -172,8 +172,8 @@ bool LoadWCSimLAPPD::Execute(){
 			int lastrunningcount=runningcount;
 			// loop over all the hits on this lappd
 			for(;runningcount<(lastrunningcount+numhitsthislappd); runningcount++){
-				double peposx = LAPPDEntry->lappdhit_stripcoorx->at(runningcount);  // posn on tile
-				double peposy = LAPPDEntry->lappdhit_stripcoory->at(runningcount);
+				double peposx = (LAPPDEntry->lappdhit_stripcoorx->at(runningcount)) / 1000.;  // posn on tile
+				double peposy = (LAPPDEntry->lappdhit_stripcoory->at(runningcount)) / 1000.;  // convert mm to meters
 				
 #if FILE_VERSION<3  // manual calculation of global hit position part 2
 				double digitsx, digitsy, digitsz;
@@ -200,9 +200,9 @@ bool LoadWCSimLAPPD::Execute(){
 				}
 #else // if FILE_VERSION<3
 				
-				double digitsx=LAPPDEntry->lappdhit_globalcoorx->at(runningcount);
-				double digitsy=LAPPDEntry->lappdhit_globalcoory->at(runningcount);
-				double digitsz=LAPPDEntry->lappdhit_globalcoorz->at(runningcount);
+				double digitsx= (LAPPDEntry->lappdhit_globalcoorx->at(runningcount)) / 1000.;  // global WCSim coords - convert mm to m
+				double digitsy= (LAPPDEntry->lappdhit_globalcoory->at(runningcount)) / 1000.;
+				double digitsz= (LAPPDEntry->lappdhit_globalcoorz->at(runningcount)) / 1000.;
 #endif // FILE_VERSION<3
 				
 				// calculate relative time within trigger
@@ -215,7 +215,7 @@ bool LoadWCSimLAPPD::Execute(){
 				TimeClass digittime(digitstns); // absolute time
 				float digiq = 0; // N/A
 				ChannelKey key(subdetector::LAPPD,LAPPDID);
-				std::vector<double> globalpos{digitsx/10.,digitsy/10.,digitsz/10.}; // converted to cm
+				std::vector<double> globalpos{digitsx,digitsy,digitsz};
 				std::vector<double> localpos{peposx, peposy};
 				//LAPPDHit nexthit(LAPPDID, digittime, digiq, globalpos, localpos, digitstps);
 				
@@ -243,9 +243,6 @@ bool LoadWCSimLAPPD::Execute(){
 	}         // end if MCTriggernum == 0
 	
 	if(verbose>3) cout<<"Saving MCLAPPDHits to ANNIEEvent"<<endl;
-	ChannelKey key(subdetector::LAPPD,666.);
-	LAPPDHit nexthit(666, 666., 666., std::vector<double>{6.,6.,6.}, std::vector<double>{6.,6.}, 6.);
-	if(MCLAPPDHits->size()==0) MCLAPPDHits->emplace(key, std::vector<LAPPDHit>{nexthit});
 	m_data->Stores.at("ANNIEEvent")->Set("MCLAPPDHits",MCLAPPDHits,true);
 	
 	return true;

--- a/configfiles/WCSimDemo/LoadWCSimLAPPDConfig
+++ b/configfiles/WCSimDemo/LoadWCSimLAPPDConfig
@@ -3,6 +3,6 @@
 
 verbose 1
 InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_24-09-17_BNB_Water_10k_22-05-17/wcsim_lappd_0.0.0.root
-# octagonal inner structure radius in cm (from drawings 106.64")
-InnerStructureRadius 135.45
+# octagonal inner structure radius in m (from drawings 106.64")
+InnerStructureRadius 1.3545
 HistoricTriggeroffset 950


### PR DESCRIPTION
…. This affects the LAPPD tile position and globalpos calculation for older files.
Previously: 
WCSim geometry, PMT positions, and MCParticle units were in cm
WCSim LAPPDHit globalpos was in cm, localpos was in mm. 
globalpos would have been incorrect on file versions < 3. 
Now:
All lengths are in meters.