### PR TITLE
FindMrdTracks Tool: put tracks into a vector of BoostStores

### DIFF
--- a/DataModel/LAPPDHit.h
+++ b/DataModel/LAPPDHit.h
@@ -13,22 +13,17 @@ class LAPPDHit : public Hit{
 	friend class boost::serialization::access;
 
 	public:
-//  LAPPDHit() : TubeId(0), Time(TimeClass()), Position(0), LocalPosition(0), Charge(0), Tpsec(0){serialise=true;}
-//  LAPPDHit(int tubeid, TimeClass thetime, std::vector<double> Position, std::vector<double> LocalPosition, double charge, double tpsec) : TubeId(tubeid), Time(thetime), Position(Position), LocalPosition(LocalPosition), Charge(charge), Tpsec(tpsec){serialise=true;}
-	LAPPDHit() : Hit(), Position(0), LocalPosition(0), Tpsec(0){serialise=true;}
-	LAPPDHit(int tubeid, double thetime, double charge, std::vector<double> Position, std::vector<double> LocalPosition, double tpsec) : Hit(tubeid,thetime,charge), Position(Position), LocalPosition(LocalPosition), Tpsec(tpsec){serialise=true;}
+	LAPPDHit() : Hit(), Position(0), LocalPosition(0) {serialise=true;}
+	LAPPDHit(int tubeid, double thetime, double charge, std::vector<double> Position, std::vector<double> LocalPosition) : Hit(tubeid,thetime,charge), Position(Position), LocalPosition(LocalPosition) {serialise=true;}
 
-	inline double GetTpsec() const {return Tpsec;}
 	inline std::vector<double> GetPosition() const {return Position;}
 	inline std::vector<double> GetLocalPosition() const {return LocalPosition;}
-	inline void SetTpsec(double tpsec){Tpsec=tpsec;}
 	inline void SetPosition(std::vector<double> pos){Position=pos;}
 	inline void SetLocalPosition(std::vector<double> locpos){LocalPosition=locpos;}
 
 	bool Print() {
 		cout<<"TubeId : "<<TubeId<<endl;
 		cout<<"Time : "<<Time<<endl;
-		cout<<"Time (psec) : "<<Tpsec<<endl;
 		cout<<"X Pos : "<<Position.at(0)<<endl;
 		cout<<"Y Pos : "<<Position.at(1)<<endl;
 		cout<<"Z Pos : "<<Position.at(2)<<endl;
@@ -39,7 +34,6 @@ class LAPPDHit : public Hit{
 	}
 
 	protected:
-	double Tpsec;
 	std::vector<double> Position;
 	std::vector<double> LocalPosition;
 
@@ -51,7 +45,6 @@ class LAPPDHit : public Hit{
 			ar & Position;
 			ar & LocalPosition;
 			ar & Charge;
-			ar & Tpsec;
 		}
 	}
 };

--- a/DataModel/LAPPDPulse.h
+++ b/DataModel/LAPPDPulse.h
@@ -13,36 +13,30 @@ class LAPPDPulse : public Hit{
 	friend class boost::serialization::access;
 
 	public:
-  LAPPDPulse() : Hit(), ChannelID(0), Tpsec(0), Peak(0), LowRange(0), HiRange(0) {serialise=true;}
-  LAPPDPulse(int tubeid, int channelid, double thetime, double charge, double tpsec, double peak, double low, double hi) : Hit(tubeid,thetime,charge), ChannelID(channelid), Tpsec(tpsec), Peak(peak), LowRange(low), HiRange(hi),thetime(thetime){serialise=true;}
+  LAPPDPulse() : Hit(), ChannelID(0), Peak(0), LowRange(0), HiRange(0) {serialise=true;}
+  LAPPDPulse(int tubeid, int channelid, double thetime, double charge, double peak, double low, double hi) : Hit(tubeid,thetime,charge), ChannelID(channelid), Peak(peak), LowRange(low), HiRange(hi) {serialise=true;}
 
-	inline double GetTheTime(){return thetime;}
 	inline int GetChannelID(){return ChannelID;}
-	inline double GetTpsec(){return Tpsec;}
 	inline double GetPeak(){return Peak;}
 	inline double GetLowRange(){return LowRange;}
 	inline double GetHiRange(){return HiRange;}
 	inline void SetChannelID(int channelid){ChannelID=channelid;}
-	inline void SetTpsec(double tpsec){Tpsec=tpsec;}
 	inline void SetPeak(double peak){Peak=peak;}
 	inline void SetRange(double low, double hi){LowRange=low; HiRange=hi;}
 
 	bool Print() {
 		cout<<"TubeId : "<<TubeId<<endl;
 		cout<<"ChannelID : "<<ChannelID<<endl;
-		cout<<"Time : "<<thetime<<endl;
+		cout<<"Time : "<<Time<<endl;
 		cout<<"Charge : "<<Charge<<endl;
 		return true;
 	}
 
 	protected:
-	int TubeId;
 	double ChannelID;
-	double Tpsec;
 	double Peak;
 	double LowRange;
 	double HiRange;
-	double thetime;
 
 
 	template<class Archive> void serialize(Archive & ar, const unsigned int version){
@@ -51,7 +45,6 @@ class LAPPDPulse : public Hit{
 			ar & ChannelID;
 			ar & Time;
 			ar & Charge;
-			ar & Tpsec;
 			ar & Peak;
 			ar & LowRange;
 			ar & HiRange;

--- a/DataModel/Position.h
+++ b/DataModel/Position.h
@@ -22,9 +22,22 @@ class Position : public SerialisableObject{
 	inline void SetY(double yy){y=yy;}
 	inline void SetZ(double zz){z=zz;}
 	
-	bool Print() {
-		std::cout<<"("<<x<<", "<<y<<", "<<z<<")"<<std::endl;
+	bool Print(bool withendline) {
+		std::cout<<"("<<x<<", "<<y<<", "<<z<<")";
+		if(withendline) cout<<std::endl;
 		return true;
+	}
+	
+	bool Print(){
+		Print(true);
+	}
+	
+	bool operator==(const Position &a) const {
+		return ((x==a.X()) && (y==a.Y()) && (z==a.Z()));
+	}
+	
+	bool operator!=(const Position &a) const {
+		return ((x!=a.X()) || (y!=a.Y()) || (z!=a.Z()));
 	}
 	
 	private:

--- a/DataModel/Position.h
+++ b/DataModel/Position.h
@@ -29,7 +29,7 @@ class Position : public SerialisableObject{
 	}
 	
 	bool Print(){
-		Print(true);
+		return Print(true);
 	}
 	
 	bool operator==(const Position &a) const {

--- a/DataModel/TimeClass.h
+++ b/DataModel/TimeClass.h
@@ -13,28 +13,34 @@ class TimeClass : public SerialisableObject{
 	
 	public:
   TimeClass() : unixns(0) {serialise=true;}
-  TimeClass(uint64_t timens) : unixns(timens) {serialise=true;}
+  TimeClass(uint64_t timens) : unixns(timens), ps(0) {serialise=true;}
 	
 	inline uint64_t GetNs() const {return unixns;}
+	inline uint32_t GetPsPart() const {return ps;}
 	inline void SetNs(uint64_t tns){unixns=tns;}
+	inline void SetPsPart(uint32_t tps){ps=tps;}
 	
 	bool Print() {
 		cout<<"unixns : "<<unixns<<endl;
+		cout<<"ps : "<<ps<<endl;
 		
 		return true;
 	}
 	
 	private:
 	uint64_t unixns;
+	uint32_t ps;
 	
 	template<class Archive> void serialize(Archive & ar, const unsigned int version){
 		if(serialise){
 			ar & unixns;
+			ar & ps;
 		}
 	}
 	
 	void Clear(){
 		unixns = 0;
+		ps = 0;
 	}
 	
 };
@@ -43,7 +49,7 @@ class TimeClass : public SerialisableObject{
 // a TimeClass object to a std::ostream
 inline std::ostream& operator<<(std::ostream& out, const TimeClass& tc)
 {
-  out << tc.GetNs();
+  out << tc.GetNs()<<"."<<tc.GetPsPart();
   return out;
 }
 

--- a/DataModel/TimeClass.h
+++ b/DataModel/TimeClass.h
@@ -13,34 +13,28 @@ class TimeClass : public SerialisableObject{
 	
 	public:
   TimeClass() : unixns(0) {serialise=true;}
-  TimeClass(uint64_t timens) : unixns(timens), ps(0) {serialise=true;}
+  TimeClass(uint64_t timens) : unixns(timens) {serialise=true;}
 	
 	inline uint64_t GetNs() const {return unixns;}
-	inline uint32_t GetPsPart() const {return ps;}
 	inline void SetNs(uint64_t tns){unixns=tns;}
-	inline void SetPsPart(uint32_t tps){ps=tps;}
 	
 	bool Print() {
 		cout<<"unixns : "<<unixns<<endl;
-		cout<<"ps : "<<ps<<endl;
 		
 		return true;
 	}
 	
 	private:
 	uint64_t unixns;
-	uint32_t ps;
 	
 	template<class Archive> void serialize(Archive & ar, const unsigned int version){
 		if(serialise){
 			ar & unixns;
-			ar & ps;
 		}
 	}
 	
 	void Clear(){
 		unixns = 0;
-		ps = 0;
 	}
 	
 };
@@ -49,7 +43,7 @@ class TimeClass : public SerialisableObject{
 // a TimeClass object to a std::ostream
 inline std::ostream& operator<<(std::ostream& out, const TimeClass& tc)
 {
-  out << tc.GetNs()<<"."<<tc.GetPsPart();
+  out << tc.GetNs();
   return out;
 }
 

--- a/UserTools/Factory/Factory.cpp
+++ b/UserTools/Factory/Factory.cpp
@@ -41,7 +41,7 @@ if (tool=="BeamFetcher") ret=new BeamFetcher;
 if (tool=="FindTrackLengthInWater") ret=new FindTrackLengthInWater;
 if (tool=="LoadANNIEEvent") ret=new LoadANNIEEvent;
 if (tool=="PhaseITreeMaker") ret=new PhaseITreeMaker;
-//if (tool=="MrdPaddlePlot") ret=new MrdPaddlePlot;
+if (tool=="MrdPaddlePlot") ret=new MrdPaddlePlot;
 if (tool=="LoadWCSimLAPPD") ret=new LoadWCSimLAPPD;
 if (tool=="WCSimDemo") ret=new WCSimDemo;
 if (tool=="LAPPDlasertestHitFinder") ret=new LAPPDlasertestHitFinder;

--- a/UserTools/FindMrdTracks/FindMrdTracks.h
+++ b/UserTools/FindMrdTracks/FindMrdTracks.h
@@ -17,10 +17,6 @@
 #include "TTree.h"
 #include "TClonesArray.h"
 
-// for drawing
-#include "TApplication.h"
-#include "TSystem.h"
-
 class FindMrdTracks: public Tool {
 	
 public:
@@ -80,7 +76,6 @@ private:
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	bool DrawTruthTracks;
 	std::vector<MCParticle>* MCParticles=nullptr;
-	TApplication* mrdTrackDrawApp;
 };
 
 

--- a/UserTools/FindMrdTracks/FindMrdTracks.h
+++ b/UserTools/FindMrdTracks/FindMrdTracks.h
@@ -35,7 +35,7 @@ private:
 	
 	// Variables stored in Config file
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	int verbose=1;
+	int verbosity=1;
 	int minimumdigits;
 	double maxsubeventduration;
 	std::string outputdir="";
@@ -72,9 +72,13 @@ private:
 	TBranch* subeventsinthiseventb=0;
 	TClonesArray* SubEventArray=0;
 	
+	// For saving to the BoostStore to pass between Tools
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	std::vector<BoostStore>* theMrdTracks;
+	
 	// For Debug Drawing Tracks During Looping
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	bool DEBUG_DRAW_MRD_TRACKS;
+	bool DrawTruthTracks;
 	std::vector<MCParticle>* MCParticles=nullptr;
 	TApplication* mrdTrackDrawApp;
 };

--- a/UserTools/GenerateHits/GenerateHits.cpp
+++ b/UserTools/GenerateHits/GenerateHits.cpp
@@ -25,19 +25,17 @@ bool GenerateHits::Execute(){
   int TubeID =0;
   std::vector<double> pos;
   std::vector<double> relpos;
-  double ptime,Q;
-  double tc;
+  double tc,Q;
 
   // MC truth hit 1
-  ptime = 50;
   Q=1.;
   pos.push_back(10.);
   pos.push_back(5.);
   pos.push_back(0.);
   relpos.push_back(10.);
   relpos.push_back(5.);
-  tc = 1;
-  LAPPDHit ahit1(TubeID,tc,Q,pos,relpos,ptime);
+  tc = 1.050;
+  LAPPDHit ahit1(TubeID,tc,Q,pos,relpos);
 
   // clear vectors
   pos.clear();
@@ -45,15 +43,14 @@ bool GenerateHits::Execute(){
 
 /*
   // MC truth hit 2
-  ptime = 140.;
+  tc = 1.140;
   Q=1.;
   pos.push_back(20.);
   pos.push_back(10.);
   pos.push_back(0.);
   relpos.push_back(20.);
   relpos.push_back(10.);
-  tc.SetNs(1);
-  LAPPDHit ahit2(TubeID,tc,Q,pos,relpos,ptime);
+  LAPPDHit ahit2(TubeID,tc,Q,pos,relpos);
 */
 
   vector<LAPPDHit> hits;

--- a/UserTools/LAPPDFindPeak/LAPPDFindPeak.cpp
+++ b/UserTools/LAPPDFindPeak/LAPPDFindPeak.cpp
@@ -115,7 +115,6 @@ std::vector<LAPPDPulse> LAPPDFindPeak::FindPulses_TOT(std::vector<double> *theWa
   double low=0.;
   double hi=0.;
   double tc=0;
-  double tp=0.;
 
   bool pulsestarted=false;
 	double threshold = TotThreshold*2;
@@ -140,7 +139,7 @@ std::vector<LAPPDPulse> LAPPDFindPeak::FindPulses_TOT(std::vector<double> *theWa
 			if(length<MinimumTotBin) {length=0; Q=0; pulsestarted=false; low=0; hi=0; peak=0;}
 			else {
         npeaks++; length = 0; hi=(double)i;
-        LAPPDPulse apulse(0,0,tc,Q,tp,peak,low,hi);
+        LAPPDPulse apulse(0,0,tc,Q,peak,low,hi);
         thepulses.push_back(apulse);
         pulsestarted=false;
         peak=0; Q=0; low=0; hi=0;

--- a/UserTools/LAPPDSaveROOT/LAPPDSaveROOT.cpp
+++ b/UserTools/LAPPDSaveROOT/LAPPDSaveROOT.cpp
@@ -100,7 +100,7 @@ LAPPDTree->Branch("PulseNum",&PulseNum);
     if(tempPulse.GetChannelID()==0)
     {
       ampCH1=LAPPDHitPulses.at(i).GetPeak();
-      tpsecCH1=LAPPDHitPulses.at(i).GetTpsec();
+      tpsecCH1=LAPPDHitPulses.at(i).GetTime()*1000.;
       chrgCH1=LAPPDHitPulses.at(i).GetCharge();
        std::cout<<"Amp 1 "<<ampCH1<<endl;
        std::cout<<"Tpsec 1 "<<tpsecCH1<<endl;
@@ -109,7 +109,7 @@ LAPPDTree->Branch("PulseNum",&PulseNum);
      if(tempPulse.GetChannelID()==1)
     {
       ampCH2=LAPPDHitPulses.at(i).GetPeak();
-      tpsecCH2=LAPPDHitPulses.at(i).GetTpsec();
+      tpsecCH2=LAPPDHitPulses.at(i).GetTime()*1000.;
       chrgCH2=LAPPDHitPulses.at(i).GetCharge();
       std::cout<<"Amp 2 "<<ampCH2<<endl;
  std::cout<<"Tpsec 2 " <<tpsecCH2<<endl;
@@ -118,7 +118,7 @@ LAPPDTree->Branch("PulseNum",&PulseNum);
     if(tempPulse.GetChannelID()==2)
     {
       ampCH3=LAPPDHitPulses.at(i).GetPeak();
-      tpsecCH3=LAPPDHitPulses.at(i).GetTpsec();
+      tpsecCH3=LAPPDHitPulses.at(i).GetTime()*1000.;
       chrgCH3=LAPPDHitPulses.at(i).GetCharge();
       std::cout<<"Amp 3 "<<ampCH3<<endl;
  std::cout<<"Tpsec 3 "<<tpsecCH3<<endl;
@@ -194,11 +194,11 @@ LAPPDTree->Branch("PulseNum",&PulseNum);
 
         if(channelno>=0&&channelno<NChannel){
             hAmp[channelno]->Fill(thepulse.GetPeak());
-            hTime[channelno]->Fill(thepulse.GetTpsec());
+            hTime[channelno]->Fill(thepulse.GetTime()*1000.);
         }
 
         chno=channelno;
-        cfdtime=thepulse.GetTpsec();
+        cfdtime=thepulse.GetTime()*1000.;
         amp=thepulse.GetPeak();
         twidth=(thepulse.GetHiRange()-thepulse.GetLowRange())*Deltat;
         outtree->Fill();

--- a/UserTools/LAPPDSim/LAPPDSim.cpp
+++ b/UserTools/LAPPDSim/LAPPDSim.cpp
@@ -62,7 +62,7 @@ bool LAPPDSim::Execute(){
       // and input them in 5 channels
 
       LAPPDHit ahit = mchits.at(j);
-      double atime = ahit.GetTpsec();
+      double atime = ahit.GetTime()*1000.;
       pulsetimes.push_back(atime) ;
       vector<double> localpos = ahit.GetLocalPosition();  //SD
       double trans = localpos.at(1);         //SD

--- a/UserTools/LAPPDSim/LAPPDresponse.cpp
+++ b/UserTools/LAPPDSim/LAPPDresponse.cpp
@@ -84,7 +84,6 @@ void LAPPDresponse::AddSinglePhotonTrace(double trans, double para, double time)
     //signal has to be larger than 0.5 mV
     if( (wspeak>0.5) && (wstrip>0) && (wstrip<31) ) {
       int tubeid = 0;
-      double thetime=0;
       double charge =0;
       double low = 0;
       double hi = 0;
@@ -92,7 +91,7 @@ void LAPPDresponse::AddSinglePhotonTrace(double trans, double para, double time)
       //std::cout<<"which strip "<<wstrip<<" peakvalue"<<wspeak<<std::endl;
 
 
-      LAPPDPulse pulse(tubeid, wstrip, thetime, charge, time + righttime, wspeak, low, hi);  //SD
+      LAPPDPulse pulse(tubeid, wstrip, (time + righttime)/1000., charge, wspeak, low, hi);  //SD
       if(LAPPDPulseCluster.count(wstrip)==1){
         std::vector<LAPPDPulse> tempVector;
         tempVector = LAPPDPulseCluster.at(wstrip);
@@ -108,7 +107,7 @@ void LAPPDresponse::AddSinglePhotonTrace(double trans, double para, double time)
       }
 
       pulse.SetChannelID(-1.0*wstrip); //SD
-      pulse.SetTpsec((time +lefttime)); //SD
+      pulse.SetTime((time +lefttime)/1000.); //SD
       if(LAPPDPulseCluster.count(-wstrip)==1){
         std::vector<LAPPDPulse> tempVector;
         tempVector = LAPPDPulseCluster.at(-wstrip);
@@ -177,7 +176,7 @@ Waveform<double> LAPPDresponse::GetTrace(int CHnumber, double starttime, double 
       double thetime=0;
       double ptime= thetime;
       //transit time of the pulse along the strip
-      double stime=tempoVector.at(k).GetTpsec();
+      double stime=tempoVector.at(k).GetTime()*1000.;
       //looking at the signal to the left (parity=-1) or right (parity=1)?
 
       //if(parity<0) stime = mpulse->Getlefttime();

--- a/UserTools/LAPPDcfd/LAPPDcfd.cpp
+++ b/UserTools/LAPPDcfd/LAPPDcfd.cpp
@@ -98,8 +98,7 @@ bool LAPPDcfd::Execute(){
           //std::cout<<"for pulse #"<<j<<" (Q="<<(Vpulses.at(j)).GetCharge()<<",Amp="<<(Vpulses.at(j)).GetPeak()<<",LowRange="<<(Vpulses.at(j)).GetLowRange()<<",HiRange="<<(Vpulses.at(j)).GetHiRange()<<") "<<"  cfd_time="<<cfdtime<<std::endl;
 
           // Store the reconstructed time in a new LAPPDPulse
-          double tc(0);
-          LAPPDPulse apulse(0,channelno,tc,(Vpulses.at(j)).GetCharge(),cfdtime,(Vpulses.at(j)).GetPeak(),(Vpulses.at(j)).GetLowRange(),(Vpulses.at(j)).GetHiRange());
+          LAPPDPulse apulse(0,channelno,(cfdtime/1000.),(Vpulses.at(j)).GetCharge(),(Vpulses.at(j)).GetPeak(),(Vpulses.at(j)).GetLowRange(),(Vpulses.at(j)).GetHiRange());
           thepulses.push_back(apulse);
         }
       }

--- a/UserTools/LAPPDlasertestHitFinder/LAPPDlasertestHitFinder.cpp
+++ b/UserTools/LAPPDlasertestHitFinder/LAPPDlasertestHitFinder.cpp
@@ -60,7 +60,7 @@ double MaxAmp =-1.0;
      std::cout<<"Temp Vector Size "<<TempVector.size()<<endl;
      //     std::cout<<"Temp Vector Channel "<<TempVector.at(i).GetChannelID()<<endl;
     for (int j = 0; j < TempVector.size(); j++){
-      if (TempVector.at(j).GetTpsec() >= MinTimeWindow && TempVector.at(j).GetTpsec() <= MaxTimeWindow){
+      if (TempVector.at(j).GetTime()*1000. >= MinTimeWindow && TempVector.at(j).GetTime()*1000. <= MaxTimeWindow){
         if (TempVector.at(j).GetPeak() > MaxAmp){
           MaxAmp = TempVector.at(j).GetPeak();
           MaxPulse = LAPPDPulseCluster.at(i).at(j);
@@ -94,18 +94,18 @@ LAPPDPulse OpposPulse;
     LAPPDPulse OpposPulse;
     for (int j = 0; j < negaVector.size(); j++){
     //Find pulse inside this vector that has the same peak and thetime
-      if (fabs(negaVector.at(j).GetTpsec() - MaxPulse.GetTpsec()) < PTRange && (fabs(negaVector.at(j).GetPeak() - MaxAmp) / MaxAmp) <= 0.1){
+      if (fabs(negaVector.at(j).GetTime()*1000. - MaxPulse.GetTime()*1000.) < PTRange && (fabs(negaVector.at(j).GetPeak() - MaxAmp) / MaxAmp) <= 0.1){
         OpposPulse = negaVector.at(j);
-        Deltatime = (MaxPulse.GetTpsec() - OpposPulse.GetTpsec());
+        Deltatime = (MaxPulse.GetTime()*1000. - OpposPulse.GetTime()*1000.);
       }
       ParaPosition = Deltatime*c;
       LocalPosition.push_back(ParaPosition);
-      HitTime = (MaxPulse.GetTpsec() + OpposPulse.GetTpsec())/2;
+      HitTime = (MaxPulse.GetTime()*1000. + OpposPulse.GetTime()*1000.)/2;
     }
   }
   else {
     ParaPosition = 0;
-    HitTime = MaxPulse.GetTpsec();
+    HitTime = MaxPulse.GetTime()*1000.;
     LocalPosition.push_back(ParaPosition);
   }
 
@@ -123,7 +123,7 @@ LAPPDPulse OpposPulse;
       neighbourVector = LAPPDPulseCluster.at(i);
 
       for (int j = 0; j < neighbourVector.size(); j++){
-        if (fabs(neighbourVector.at(j).GetTpsec() - MaxPulse.GetTpsec()) < PTRange){
+        if (fabs(neighbourVector.at(j).GetTime()*1000. - MaxPulse.GetTime()*1000.) < PTRange){
 
 	   NeighboursPulses.push_back(neighbourVector.at(j));
         }
@@ -159,7 +159,7 @@ LAPPDPulse OpposPulse;
       for(int i =0; i<3; i++){
 	if(i!=MaxPulse.GetChannelID() && i!=OpposPulse.GetChannelID()){
 	  for (int j = 0; j < LAPPDPulseCluster.at(i).size(); j++){
-	    if (fabs(LAPPDPulseCluster.at(i).at(j).GetTpsec() - MaxPulse.GetTpsec()) < PTRange){
+	    if (fabs(LAPPDPulseCluster.at(i).at(j).GetTime()*1000. - MaxPulse.GetTime()*1000.) < PTRange){
 	       NeighboursPulses.push_back(LAPPDPulseCluster.at(i).at(j));
 	     }
 	   }
@@ -174,7 +174,7 @@ LAPPDPulse OpposPulse;
  std::cout<<stripID.at(2)<<endl;
 
   //Store data in LAPPDHit
-  LAPPDHit kHit(MaxPulse.GetChannelID(), MaxPulse.GetTheTime(), MaxPulse.GetPeak(), AbsPosition, LocalPosition, MaxPulse.GetTpsec());
+  LAPPDHit kHit(MaxPulse.GetChannelID(), MaxPulse.GetTime(), MaxPulse.GetPeak(), AbsPosition, LocalPosition);
   std::cout<<"Hit created "<<endl;
   int PulseNum;
   m_data->Stores["ANNIEEvent"]->Set("RecoLaserTestHit",kHit);

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -52,6 +52,7 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	wcsimtree= (TTree*) file->Get("wcsimT");
 	NumEvents=wcsimtree->GetEntries();
 	WCSimEntry= new wcsimT(wcsimtree);
+	gROOT->cd();
 	wcsimrootgeom = WCSimEntry->wcsimrootgeom;
 	wcsimrootopts = WCSimEntry->wcsimrootopts;
 	int pretriggerwindow=wcsimrootopts->GetNDigitsPreTriggerWindow();
@@ -155,7 +156,7 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	Geometry* anniegeom = new Geometry(Detectors, WCSimGeometryVer, tank_centre, tank_radius,
 	                           tank_halfheight, mrd_width, mrd_height, mrd_depth, mrd_start,
 	                           numtankpmts, nummrdpmts, numvetopmts, numlappds, detectorstatus::ON);
-	if(verbose>1) cout<<"constructed anniegom at "<<anniegeom<<endl;
+	if(verbose>1){ cout<<"constructed anniegom at "<<anniegeom<<" with tank origin "; tank_centre.Print(); }
 	m_data->Stores.at("ANNIEEvent")->Header->Set("AnnieGeometry",anniegeom,true);
 	
 	// Set run-level information in the ANNIEEvent
@@ -272,11 +273,13 @@ bool LoadWCSim::Execute(){
 			//nextrack->GetFlag()!=-1 ????? do we need to skip/override anything for these?
 			// e.g. primary neutrino time is -1, but TimeClass accepts uint64_t - UNSIGNED = becomes 18446744073709551615
 			
+			TimeClass trackstarttime=nextrack->GetTime();
+			trackstarttime.SetPsPart(floor(nextrack->GetTime()*1000.));
 			MCParticle thisparticle(
 				nextrack->GetIpnu(), nextrack->GetE(), nextrack->GetEndE(),
 				Position(nextrack->GetStart(0) / 100., nextrack->GetStart(1) / 100., nextrack->GetStart(2) / 100.),
 				Position(nextrack->GetStop(0) / 100., nextrack->GetStop(1) / 100., nextrack->GetStop(2) / 100.),
-				TimeClass(nextrack->GetTime()), TimeClass(nextrack->GetStopTime()),
+				trackstarttime, TimeClass(nextrack->GetStopTime()),
 				Direction(nextrack->GetDir(0), nextrack->GetDir(1), nextrack->GetDir(2)),
 				(sqrt(pow(nextrack->GetStop(0)-nextrack->GetStart(0),2.)+
 					 pow(nextrack->GetStop(1)-nextrack->GetStart(1),2.)+

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -271,15 +271,12 @@ bool LoadWCSim::Execute(){
 			tracktype startstoptype = tracktype::UNDEFINED;
 			
 			//nextrack->GetFlag()!=-1 ????? do we need to skip/override anything for these?
-			// e.g. primary neutrino time is -1, but TimeClass accepts uint64_t - UNSIGNED = becomes 18446744073709551615
 			
-			TimeClass trackstarttime=nextrack->GetTime();
-			trackstarttime.SetPsPart(floor(nextrack->GetTime()*1000.));
 			MCParticle thisparticle(
 				nextrack->GetIpnu(), nextrack->GetE(), nextrack->GetEndE(),
 				Position(nextrack->GetStart(0) / 100., nextrack->GetStart(1) / 100., nextrack->GetStart(2) / 100.),
 				Position(nextrack->GetStop(0) / 100., nextrack->GetStop(1) / 100., nextrack->GetStop(2) / 100.),
-				trackstarttime, TimeClass(nextrack->GetStopTime()),
+				(static_cast<double>(nextrack->GetTime())), (static_cast<double>(nextrack->GetStopTime())),
 				Direction(nextrack->GetDir(0), nextrack->GetDir(1), nextrack->GetDir(2)),
 				(sqrt(pow(nextrack->GetStop(0)-nextrack->GetStart(0),2.)+
 					 pow(nextrack->GetStop(1)-nextrack->GetStart(1),2.)+
@@ -301,8 +298,8 @@ bool LoadWCSim::Execute(){
 			if(verbose>2) cout<<"next digihit at "<<digihit<<endl;
 			int tubeid = digihit->GetTubeId();
 			if(verbose>2) cout<<"tubeid="<<tubeid<<endl;
-			double digittime(digihit->GetT()); // add trigger time to make absolute
-			if(verbose>2){ cout<<"digittime is "<<digittime<<endl; }
+			double digittime(static_cast<double>(digihit->GetT())); // relative to trigger
+			if(verbose>2){ cout<<"digittime is "<<digittime<<" [ns] from Trigger"<<endl; }
 			float digiq = digihit->GetQ();
 			if(verbose>2) cout<<"digit Q is "<<digiq<<endl;
 			
@@ -324,8 +321,8 @@ bool LoadWCSim::Execute(){
 			if(verbose>2) cout<<"next digihit at "<<digihit<<endl;
 			int tubeid = digihit->GetTubeId() + numvetopmts;
 			if(verbose>2) cout<<"tubeid="<<tubeid<<endl;
-			double digittime(digihit->GetT()); // add trigger time to make absolute
-			if(verbose>2){ cout<<"digittime is "<<digittime<<endl; }
+			double digittime(static_cast<double>(digihit->GetT())); // relative to trigger
+			if(verbose>2){ cout<<"digittime is "<<digittime<<" [ns] from Trigger"<<endl; }
 			float digiq = digihit->GetQ();
 			if(verbose>2) cout<<"digit Q is "<<digiq<<endl;
 			
@@ -347,8 +344,8 @@ bool LoadWCSim::Execute(){
 			if(verbose>2) cout<<"next digihit at "<<digihit<<endl;
 			int tubeid = digihit->GetTubeId();
 			if(verbose>2) cout<<"tubeid="<<tubeid<<endl;
-			double digittime(digihit->GetT()); // add trigger time to make absolute
-			if(verbose>2){ cout<<"digittime is "<<digittime<<endl; }
+			double digittime(static_cast<double>(digihit->GetT())); // relative to trigger
+			if(verbose>2){ cout<<"digittime is "<<digittime<<" [ns] from Trigger"<<endl; }
 			float digiq = digihit->GetQ();
 			if(verbose>2) cout<<"digit Q is "<<digiq<<endl;
 			

--- a/UserTools/LoadWCSim/wcsimT.h
+++ b/UserTools/LoadWCSim/wcsimT.h
@@ -20,8 +20,6 @@
 #include "WCSimRootGeom.hh"
 #include "WCSimRootOptions.hh"
 
-#define SINGLE_TREE    // TODO TODO TODO TODO shouldn't need this define
-
 using namespace std;
 
 class wcsimT {
@@ -44,6 +42,7 @@ public :
    WCSimRootGeom      *wcsimrootgeom=nullptr;
    WCSimRootOptions   *wcsimrootopts=nullptr;
    
+   // TODO implement a verbosity arg
    int             verbose=1;
 
    // List of branches
@@ -77,42 +76,26 @@ wcsimT::wcsimT(TTree *tree) : fChain(0)
 {
 // if parameter tree is not specified (or zero), connect the file
 // used to generate this class and read the Tree.
-#ifdef SINGLE_TREE
-   // The following code should be used if you want this class to access
-   // a single tree instead of a chain
-   // TODO implement a verbosity arg
+   TFile* f=nullptr; 
    TTree* geotree=nullptr;
    TTree* optstree=nullptr;
-   TFile *f=nullptr;
-   if (tree == 0) {
-      f = (TFile*)gROOT->GetListOfFiles()->FindObject("/pnfs/annie/persistent/users/moflaher/wcsim_lappd_24-09-17_BNB_Water_10k_22-05-17/wcsim_0.0.0.root");
-      if (!f || !f->IsOpen()) {
-         f = new TFile("/pnfs/annie/persistent/users/moflaher/wcsim_lappd_24-09-17_BNB_Water_10k_22-05-17/wcsim_0.0.0.root");
-      }
-      if(!f){ cerr<<"no wcsim file to load"<<endl; return; }
-      f->GetObject("wcsimT",tree);
-   } else {
-      f = tree->GetCurrentFile();
-   }
-   f->GetObject("wcsimGeoT",geotree);
-   f->GetObject("wcsimRootOptionsT",optstree);
-   if(verbose) cout<<"constructed wcsimT class with file "<<f->GetName()<<endl;
-#else // not SINGLE_TREE
-   // The following code should be used if you want this class to access a chain of trees.
    if(tree == 0) {
+/*
       TChain * chain = new TChain("wcsimT","");
       std::string pattern="/pnfs/annie/persistent/users/moflaher/wcsim_lappd_24-09-17_BNB_Water_10k_22-05-17/wcsim_0.*.root";  // TODO TODO TODO make this an argument
       if(verbose) cout<<"creating chain from files "<<pattern<<endl;
       chain->Add(pattern.c_str());
       tree = chain;
+*/
+      cerr<<"wcsimT constructed in Chain mode with null TChain!"<<endl;
+      return;
+   } else {
+     LoadTree(0); // need to load the tree from first file
+     f = tree->GetCurrentFile();
    }
-   LoadTree(0); // need to load the tree for the first file
-   TFile* f = tree->GetCurrentFile();
-   TTree* geotree=nullptr;
-   TTree* optstree=nullptr;
    f->GetObject("wcsimGeoT",geotree);
    f->GetObject("wcsimRootOptionsT",optstree);
-#endif // SINGLE_TREE
+   if(verbose) cout<<"constructed wcsimT class from TChain within files "<<f->GetName()<<endl;
    
    Init(tree, geotree, optstree);
 }

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
@@ -87,6 +87,7 @@ bool LoadWCSimLAPPD::Initialise(std::string configfile, DataModel &data){
 		digixpos = new TH1D("digixpos","digixpos",100,-2,2);
 		digiypos = new TH1D("digiypos","digiypos",100,-2.5,2.5);
 		digizpos = new TH1D("digizpos","digizpos",100,0.,4.);
+		digits = new TH1D("digits","digits",100,0,50);
 	}
 	
 	return true;
@@ -239,6 +240,7 @@ bool LoadWCSimLAPPD::Execute(){
 					digixpos->Fill(digitsx);
 					digiypos->Fill(digitsy);
 					digizpos->Fill(digitsz);
+					digits->Fill(digittime+(digitstps/1000.));
 				}
 				
 				// we now have all the necessary info about this LAPPD hit:
@@ -281,31 +283,35 @@ bool LoadWCSimLAPPD::Finalise(){
 		lappdRootCanvas = new TCanvas("lappdRootCanvas","lappdRootCanvas",canvwidth,canvheight);
 		lappdRootCanvas->SetWindowSize(canvwidth,canvheight);
 		lappdRootCanvas->cd();
-	
+		
 		digixpos->Draw();
 		lappdRootCanvas->Update();
 		lappdRootCanvas->SaveAs("digixpos.png");
-	
+		
 		digiypos->Draw();
 		lappdRootCanvas->Update();
 		lappdRootCanvas->SaveAs("digiypos.png");
-	
+		
 		digizpos->Draw();
 		lappdRootCanvas->Update();
 		lappdRootCanvas->SaveAs("digizpos.png");
-	
+		
+		digits->Draw();
+		lappdRootCanvas->Update();
+		lappdRootCanvas->SaveAs("digits.png");
+		
 		lappdRootCanvas->Clear();
 		gStyle->SetOptStat(0);
 		// need to create axes to add to the TPolyMarker3D
 		TH3F *frame3d = new TH3F("frame3d","frame3d",10,-1.5,1.5,10,0,3.3,10,-2.5,2.5);
 		frame3d->Draw();
-	
+		
 		lappdhitshist->Draw();
 		frame3d->SetTitle("LAPPD Hits - Isometric View");
 		lappdRootCanvas->Modified();
 		lappdRootCanvas->Update();
 		lappdRootCanvas->SaveAs("lappdhits_isometricview.png");
-	
+		
 		frame3d->SetTitle("LAPPD Hits - Top View");
 		frame3d->GetXaxis()->SetLabelOffset(-0.1);
 		lappdRootCanvas->SetPhi(0);
@@ -313,7 +319,7 @@ bool LoadWCSimLAPPD::Finalise(){
 		lappdRootCanvas->Modified();
 		lappdRootCanvas->Update();
 		lappdRootCanvas->SaveAs("lappdhits_topview.png");
-	
+		
 		lappdRootCanvas->SetWindowSize(canvheight, canvwidth);
 		frame3d->SetTitle("LAPPD Hits - Side View");
 		//frame3d->GetXaxis()->SetLabelOffset(-0.1);
@@ -326,7 +332,7 @@ bool LoadWCSimLAPPD::Finalise(){
 		//lappdRootDrawApp->Run();
 		//std::this_thread::sleep_for (std::chrono::seconds(5));
 		//lappdRootDrawApp->Terminate(0);
-	
+		
 		delete digixpos;
 		delete digiypos;
 		delete digizpos;

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.h
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.h
@@ -54,7 +54,7 @@ class LoadWCSimLAPPD: public Tool {
 	TApplication* lappdRootDrawApp;
 	TCanvas* lappdRootCanvas;
 	TPolyMarker3D* lappdhitshist;
-	TH1D *digixpos, *digiypos, *digizpos;
+	TH1D *digixpos, *digiypos, *digizpos, *digits;
 	
 	////////////////
 	// things that will be filled into the store from this WCSim LAPPD file.

--- a/UserTools/MrdPaddlePlot/MrdPaddlePlot.cpp
+++ b/UserTools/MrdPaddlePlot/MrdPaddlePlot.cpp
@@ -2,7 +2,9 @@
 #include "MrdPaddlePlot.h"
 #include "TCanvas.h"
 #include "TGeoManager.h"
+#ifdef GOT_EVE
 #include "TEveLine.h"
+#endif
 #include "TGLViewer.h"
 #include <thread>         // std::this_thread::sleep_for
 #include <chrono>         // std::chrono::seconds
@@ -230,8 +232,10 @@ bool MrdPaddlePlot::Execute(){
 	int numtracksdrawn=0;
 	int numtracksrunningtot=0;
 	// clear the track lines from the last event before adding new ones
+#ifdef GOT_EVE
 	if(verbosity>2) cout<<"deleting TEveLines"<<endl;
 	for(TEveLine* aline : thiseventstracks){ delete aline; }
+#endif
 	thiseventstracks.clear();
 	
 	if(verbosity>2) cout<<"Printing "<<numsubevs<<" MRD subevents in event "<<EventNumber<<endl;
@@ -332,6 +336,7 @@ bool MrdPaddlePlot::Execute(){
 									 pep->Y()-buildingoffset.Y(),
 									 pep->Z()-buildingoffset.Z());
 				
+#ifdef GOT_EVE
 				if(verbosity>2) cout<<"adding track "<<thetracki<<" to event display"<<endl;
 				TEveLine* evl = new TEveLine("track1",2);
 				evl->SetLineWidth(4);
@@ -351,6 +356,7 @@ bool MrdPaddlePlot::Execute(){
 					//if(abs(pep->X())>450.) earlyexit=true;
 				}
 				thiseventstracks.push_back(evl);
+#endif
 				numtracksdrawn++;
 				//if(numtracksdrawn>100) earlyexit=true;
 				
@@ -372,6 +378,7 @@ bool MrdPaddlePlot::Execute(){
 		// if gdml overlay is being drawn, draw it here
 		if(drawGdmlOverlay){
 			gdmlcanv->cd();
+#ifdef GOT_EVE
 			for(TEveLine* aline : thiseventstracks){
 				//cout<<"drawing track at "<<aline<<" from ("<<aline->GetLineStart().fX
 				//<<", "<<aline->GetLineStart().fY<<", "<<aline->GetLineStart().fZ<<") to ("
@@ -379,6 +386,7 @@ bool MrdPaddlePlot::Execute(){
 				//<<endl;
 				aline->Draw();
 			}
+#endif
 			gdmlcanv->Update();
 			//gEve->Redraw3D(kTRUE);
 		}

--- a/UserTools/MrdPaddlePlot/MrdPaddlePlot.cpp
+++ b/UserTools/MrdPaddlePlot/MrdPaddlePlot.cpp
@@ -3,16 +3,17 @@
 #include "TCanvas.h"
 #include "TGeoManager.h"
 #include "TEveLine.h"
- #include "TGLViewer.h"
+#include "TGLViewer.h"
 #include <thread>         // std::this_thread::sleep_for
 #include <chrono>         // std::chrono::seconds
 #include <time.h>         // clock_t, clock, CLOCKS_PER_SEC
+#include <algorithm>      // for std::replace
 
 MrdPaddlePlot::MrdPaddlePlot():Tool(){}
 
 bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 
-	if(verbose) cout<<"Initializing tool MrdPaddlePlot"<<endl;
+	if(verbosity) cout<<"Initializing tool MrdPaddlePlot"<<endl;
 
 	/////////////////// Usefull header ///////////////////////
 	if(configfile!="")  m_variables.Initialise(configfile); //loading config file
@@ -22,9 +23,29 @@ bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 	/////////////////////////////////////////////////////////////////
 	
 	// get configuration variables for this tool
-	m_variables.Get("verbose",verbose);
+	m_variables.Get("verbosity",verbosity);
 	m_variables.Get("gdmlpath",gdmlpath);
 	m_variables.Get("saveimages",saveimages);
+	std::string plotDirectoryString;
+	m_variables.Get("plotDirectory",plotDirectoryString);
+	plotDirectory = plotDirectoryString.c_str();
+	m_variables.Get("drawCanvases",enableTApplication);
+	if(enableTApplication){
+		m_variables.Get("drawPaddlePlot",drawPaddlePlot);
+		m_variables.Get("drawGdmlOverlay",drawGdmlOverlay);
+		
+		// for gdml overlay
+		double buildingoffsetx, buildingoffsety, buildingoffsetz;
+		m_variables.Get("buildingoffsetx",buildingoffsetx);
+		m_variables.Get("buildingoffsety",buildingoffsety);
+		m_variables.Get("buildingoffsetz",buildingoffsetz);
+		buildingoffset = Position(buildingoffsetx,buildingoffsety,buildingoffsetz);
+	} else {
+		drawPaddlePlot=false;
+		drawGdmlOverlay=false;
+	}
+	m_variables.Get("printTracks",printTracks);  // from the BoostStore
+	m_variables.Get("printTClonesTracks",printTClonesTracks); // from the FindMrdTracks Tool
 	
 	//////////////////////////////////////////////////////////////////
 	
@@ -36,6 +57,7 @@ bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 	numtankintercepts=0;
 	numtankmisses=0;
 	
+	// TODO fix ranges
 	hnumsubevs = new TH1F("numsubevs","Number of MRD SubEvents",20,0,10);
 	hnumtracks = new TH1F("numtracks","Number of MRD Tracks",10,0,10);
 	hrun = new TH1F("run","Run Number Histogram",20,0,9);
@@ -71,17 +93,31 @@ bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 	htrackstop->SetMarkerStyle(20);
 	htrackstop->SetMarkerColor(kBlue);
 	hpep->SetMarkerStyle(20);
-
 	
-	// Import the gdml geometry for the detector:
-//	TGeoManager::Import(gdmlpath.c_str());
-//	// make all the materials semi-transparent so we can see the tracks going through them:
-//	TList* matlist = gGeoManager->GetListOfMaterials();
-//	TIter nextmaterial(matlist);
-//	while(TGeoMixture* amaterial=(TGeoMixture*)nextmaterial()) amaterial->SetTransparency(90);
-//	cout<<"drawing top volume"<<endl;
-//	gGeoManager->GetVolume("WORLD2_LV")->Draw("ogl");
-//	gdmlcanv = (TCanvas*)gROOT->FindObject("c1");
+	Double_t canvwidth = 700;
+	Double_t canvheight = 600;
+	if(enableTApplication){
+		// create the ROOT application to show histograms
+		if(verbosity>3) cout<<"Tool MrdPaddlePlot: constructing TApplication"<<endl;
+		int myargc=0;
+		char *myargv[] = {(const char*)"somestring2"};
+		mrdPaddlePlotApp = new TApplication("mrdPaddlePlotApp",&myargc,myargv);
+	}
+	
+	if(drawGdmlOverlay){
+		// Import the gdml geometry for the detector:
+		TGeoManager::Import(gdmlpath.c_str());
+		// make all the materials semi-transparent so we can see the tracks going through them:
+		TList* matlist = gGeoManager->GetListOfMaterials();
+		TIter nextmaterial(matlist);
+		while(TGeoMixture* amaterial=(TGeoMixture*)nextmaterial()) amaterial->SetTransparency(90);
+		gdmlcanv = new TCanvas("gdmlcanv","gdmlcanv",canvwidth,canvheight);
+		gdmlcanv->cd();
+		gGeoManager->GetVolume("WORLD2_LV")->Draw("ogl");
+		
+		// A canvas for other MRD track stats plots: TODO decouple from gdml
+		mrdTrackCanv = new TCanvas("mrdTrackCanv","mrdTrackCanv",canvwidth,canvheight);
+	}
 	
 	// Get a pointer to the TClonesArray filled by FindMrdTracks
 	//m_data->CStore.Get("MrdSubEventTClonesArray",thesubeventarray);
@@ -99,7 +135,7 @@ bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 
 bool MrdPaddlePlot::Execute(){
 	
-	if(verbose) cout<<"executing tool MrdPaddlePlot"<<endl;
+	if(verbosity) cout<<"executing tool MrdPaddlePlot"<<endl;
 	
 	// Get the ANNIE event and extract information
 	// Maybe this information could be added to plots for reference
@@ -110,96 +146,125 @@ bool MrdPaddlePlot::Execute(){
 	m_data->Stores["ANNIEEvent"]->Get("TriggerNumber",MCTriggernum);
 	m_data->Stores["ANNIEEvent"]->Get("MCEventNum",MCEventNum);
 	
-	// TODO: figure out how to number with 2 different event numberings 
-	// (event / mcevent+trigger+mrdsubevent...)
-	
-	// Since the TClonesArray isn't cleared (tracks aren't deleted) between fillings
-	// How do we know how many tracks were updated as they were in this event?
-	// Perhaps the user needs to store it separately?
+	// demonstrate retrieving tracks from the BoostStore
 	m_data->Stores["MRDTracks"]->Get("NumMrdSubEvents",numsubevs);
 	m_data->Stores["MRDTracks"]->Get("NumMrdTracks",numtracksinev);
 	
-//	// a version to plot tracks retrieved from the BoostStore would have only one level
-//	// as tracks are not nested within subevents
-//	for(int tracki=0; tracki<numtracksinev; tracki++){
-//		
-//		// Get the track details from the BoostStore
-//		m_data->Stores["MRDTracks"]->Get("MRDTrackID",MRDTrackID);
-//		m_data->Stores["MRDTracks"]->Get("MrdSubEventID",MrdSubEventID);
-//		m_data->Stores["MRDTracks"]->Get("InterceptsTank",InterceptsTank);
-//		m_data->Stores["MRDTracks"]->Get("StartTime",StartTime);
-//		m_data->Stores["MRDTracks"]->Get("StartVertex",StartVertex);
-//		m_data->Stores["MRDTracks"]->Get("StopVertex",StopVertex);
-//		m_data->Stores["MRDTracks"]->Get("TrackAngle",TrackAngle);
-//		m_data->Stores["MRDTracks"]->Get("TrackAngleError",TrackAngleError);
-//		m_data->Stores["MRDTracks"]->Get("LayersHit",LayersHit);
-//		m_data->Stores["MRDTracks"]->Get("TrackLength",TrackLength);
-//		m_data->Stores["MRDTracks"]->Get("IsMrdPenetrating",IsMrdPenetrating);
-//		m_data->Stores["MRDTracks"]->Get("IsMrdStopped",IsMrdStopped);
-//		m_data->Stores["MRDTracks"]->Get("IsMrdSideExit",IsMrdSideExit);
-//		m_data->Stores["MRDTracks"]->Get("PenetrationDepth",PenetrationDepth);
-//		m_data->Stores["MRDTracks"]->Get("HtrackFitChi2",HtrackFitChi2);
-//		m_data->Stores["MRDTracks"]->Get("HtrackFitCov",HtrackFitCov);
-//		m_data->Stores["MRDTracks"]->Get("VtrackFitChi2",VtrackFitChi2);
-//		m_data->Stores["MRDTracks"]->Get("VtrackFitCov",VtrackFitCov);
-//		m_data->Stores["MRDTracks"]->Get("PMTsHit",PMTsHit);
-//		
-//		// Plot the track
-//		// todoooooooo
-//		// . . .
-//	}
+	cout<<"Event "<<EventNumber<<" had "<<numtracksinev<<" tracks in "<<numsubevs<<" subevents"<<endl;
+	int got_ok = m_data->Stores["MRDTracks"]->Get("MRDTracks", theMrdTracks);
+	if(not got_ok){
+		cerr<<"No MRDTracks member of the MRDTracks BoostStore!"<<endl;
+		cout<<"MRDTracks store contents:"<<endl;
+		m_data->Stores["MRDTracks"]->Print(false);
+		return false;
+	}
+	if(theMrdTracks->size()<numtracksinev){
+		cerr<<"Too few entries in MRDTracks vector relative to NumMrdTracks!"<<endl;
+		// more is fine as we don't shrink for efficiency
+	}
 	
-	
-//	maybe we can use these:
-//	TEveViewer *ev = gEve->GetDefaultViewer();
-//	TGLViewer  *gv = ev->GetGLViewer();
-//	gv->SetGuideState(TGLUtil::kAxesOrigin, kTRUE, kFALSE, 0);
-//	gEve->Redraw3D(kTRUE);
-//	gSystem->ProcessEvents();
-//	gv->CurrentCamera().RotateRad(-0.5, 1.4);
-//	gv->RequestDraw();
+	if(verbosity>2) cout<<"looping over theMrdTracks"<<endl;
+	for(int tracki=0; tracki<numtracksinev; tracki++){
+		BoostStore* thisTrackAsBoostStore = &(theMrdTracks->at(tracki));
+		if(verbosity>3) cout<<"track "<<tracki<<" at "<<thisTrackAsBoostStore<<endl;
+		// Get the track details from the BoostStore
+		thisTrackAsBoostStore->Get("MrdTrackID",MrdTrackID);
+		thisTrackAsBoostStore->Get("MrdSubEventID",MrdSubEventID);
+		thisTrackAsBoostStore->Get("InterceptsTank",InterceptsTank);
+		thisTrackAsBoostStore->Get("StartTime",StartTime);
+		thisTrackAsBoostStore->Get("StartVertex",StartVertex);
+		thisTrackAsBoostStore->Get("StopVertex",StopVertex);
+		thisTrackAsBoostStore->Get("TrackAngle",TrackAngle);
+		thisTrackAsBoostStore->Get("TrackAngleError",TrackAngleError);
+		thisTrackAsBoostStore->Get("LayersHit",LayersHit);
+		thisTrackAsBoostStore->Get("TrackLength",TrackLength);
+		thisTrackAsBoostStore->Get("IsMrdPenetrating",IsMrdPenetrating);
+		thisTrackAsBoostStore->Get("IsMrdStopped",IsMrdStopped);
+		thisTrackAsBoostStore->Get("IsMrdSideExit",IsMrdSideExit);
+		thisTrackAsBoostStore->Get("PenetrationDepth",PenetrationDepth);
+		thisTrackAsBoostStore->Get("HtrackFitChi2",HtrackFitChi2);
+		thisTrackAsBoostStore->Get("HtrackFitCov",HtrackFitCov);
+		thisTrackAsBoostStore->Get("VtrackFitChi2",VtrackFitChi2);
+		thisTrackAsBoostStore->Get("VtrackFitCov",VtrackFitCov);
+		thisTrackAsBoostStore->Get("PMTsHit",PMTsHit);
+		
+		// Print the track info
+		if(printTracks){
+			cout<<"MrdTrack "<<MrdTrackID<<" in subevent "<<MrdSubEventID<<" was reconstructed from "
+				<<PMTsHit.size()<<" MRD PMTs hit in "<<LayersHit.size()
+				<<" layers for a total penetration depth of "<<PenetrationDepth<<" [m]."<<endl;
+			cout<<"The track went from ";
+			StartVertex.Print(false);
+			cout<<" [m] to ";
+			StopVertex.Print(false);
+			cout<<" [m] starting at time "<<StartTime<<" [ns], travelling "<<TrackLength
+				<<" [m] through the MRD at an angle of "<<TrackAngle
+				<<" +/- "<<abs(TrackAngleError)<<" [rads] to the beam axis, before ";
+			if(IsMrdStopped) cout<<"stopping in the MRD";
+			if(IsMrdPenetrating) cout<<"penetrating the MRD";
+			if(IsMrdSideExit) cout<<"leaving through the side of the MRD";
+			cout<<endl<<"Back-projection suggests this track ";
+			if(InterceptsTank) cout<<"intercepted"; else cout<<"did not intercept";
+			cout<<" the tank."<<endl;
+		}
+	}
 	
 	// ##############################################################################
-	// Actual drawing code
+	// Track drawing and Histogram Filling code
 	// This works entirely with the TClonesArray created by FindMrdTracks Tool
-	// (tracks are not retrieved from the BoostStore)
+	// since the MRDTrack classes have plotting tools built-in
+	// TODO: move the histogramming to use BoostStore to separate the two
 	// ##############################################################################
 	
-	std::vector<TEveLine*> thiseventstracks;
-	// loop over events
-	int numtracksdrawn=0;
+//	// we may need to re-retrieve the pointer??... shouldn't do, as SubEventArray gets reused
+//	intptr_t subevptr;
+//	bool returnval = m_data->CStore.Get("MrdSubEventTClonesArray",subevptr);
+//	if(!returnval){
+//		cerr<<"Failed to get MrdSubEventTClonesArray from CStore!!"<<endl;
+//		return false;
+//	}
+//	thesubeventarray = reinterpret_cast<TClonesArray*>(subevptr);
+	
 	bool earlyexit=false; // could be used to trigger interesting events
-	
-	hnumsubevs->Fill(numsubevs);
-	int numtracksrunningtot=0;
-	
 	int thetracki=-1;
-	// loop over subevents (collections of hits on the MRD within a narrow time window)
-	if(verbose>2) cout<<"Printing  "<<numsubevs<<" MRD subevents in event "<<EventNumber<<endl;
-	if(verbose>3) cout<<"TClonesArray says it has "<<thesubeventarray->GetEntries()<<" entries"<<endl;
+	int numtracksdrawn=0;
+	int numtracksrunningtot=0;
+	// clear the track lines from the last event before adding new ones
+	if(verbosity>2) cout<<"deleting TEveLines"<<endl;
+	for(TEveLine* aline : thiseventstracks){ delete aline; }
+	thiseventstracks.clear();
+	
+	if(verbosity>2) cout<<"Printing "<<numsubevs<<" MRD subevents in event "<<EventNumber<<endl;
+	if(verbosity>3) cout<<"TClonesArray says it has "<<thesubeventarray->GetEntries()<<" entries"<<endl;
 	if(thesubeventarray->GetEntries()!=numsubevs){
 		cerr<<"mismatch between MRDTrack TClonesArray size and ANNIEEVENT recorded number of MRD Subevents!"<<endl;
 		return false;
 	}
+	
+	hnumsubevs->Fill(numsubevs);
+	
+	// loop over subevents (collections of hits on the MRD within a narrow time window)
 	for(int subevi=0; subevi<numsubevs; subevi++){
 		cMRDSubEvent* thesubevent = (cMRDSubEvent*)thesubeventarray->At(subevi);
-		if(verbose>3) cout<<"printing subevent "<<subevi<<endl;
-		thesubevent->Print();
+		if(printTClonesTracks){
+			if(verbosity>3) cout<<"printing subevent "<<subevi<<endl;
+			thesubevent->Print();
+		}
 		
 		std::vector<cMRDTrack>* tracksthissubevent = thesubevent->GetTracks();
-		// there are no subevents (since we can't nest boost stores
-		// so we just retrieve next track and note when it's subeventid changes
 		int numtracks = tracksthissubevent->size();
-		hnumtracks->Fill(numtracks);
-		numtracksrunningtot+=numtracks;
-		totnumtracks+=numtracks;
-		//cout<<"event "<<evi<<", subevent "<<subevi<<" had "<<numtracks<<" tracks"<<endl;
-		// loop over tracks (collections of hits in a line within a subevent)
-		if(verbose>2) cout<<"scanning "<<numtracks<<" tracks in subevent "<<subevi<<endl;
+		hnumtracks->Fill(numtracks);     // num tracks in a given MRD subevent - (a short time window)
+		numtracksrunningtot+=numtracks;  // num tracks within all subevents in this event
+		totnumtracks+=numtracks;         // total number of tracks analysed in this ToolChain run
+		
+		// loop over tracks within this subevent
+		if(verbosity>2) cout<<"scanning "<<numtracks<<" tracks in subevent "<<subevi<<endl;
 		for(auto&& thetrack : *tracksthissubevent){
 			thetracki++;
-			if(verbose>3) cout<<"printing next track"<<endl;
-			thetrack.Print2(false); // do not re-print file/run/subrun/trigger/event num
+			if(printTClonesTracks){
+				if(verbosity>3) cout<<"printing next track"<<endl;
+				thetrack.Print2(false); // false: do not re-print subevent info
+			}
 			
 			if(thetrack.ispenetrating) numpenetrated++;
 			else if(thetrack.isstopped) numstopped++;
@@ -245,6 +310,7 @@ bool MrdPaddlePlot::Execute(){
 			htrackpenvseloss->Fill(thetrack.penetrationdepth,thetrack.EnergyLoss);
 			htracklenvseloss->Fill(thetrack.mutracklengthinMRD,thetrack.EnergyLoss);
 			
+			// N.B. track positions are in cm!
 			TVector3* sttv = &thetrack.trackfitstart;
 			TVector3* stpv = &thetrack.trackfitstop;
 			TVector3* pep = &thetrack.projectedtankexitpoint;
@@ -253,61 +319,107 @@ bool MrdPaddlePlot::Execute(){
 			//cout<<"track "<<thetracki<<" started at ("<<sttv->X()<<", "<<sttv->Y()<<", "<<sttv->Z()<<")"
 			//	<<" and ended at ("<<stpv->X()<<", "<<stpv->Y()<<", "<<stpv->Z()<<")"<<endl;
 			
-			if(verbose) cout<<"adding track "<<thetracki<<" to event display"<<endl;
-			TEveLine* evl = new TEveLine("track1",2);
-			evl->SetLineWidth(4);
-			evl->SetLineStyle(1);
-			evl->SetMarkerColor(kRed);
-			evl->SetRnrPoints(kTRUE);  // enable rendering of points
-			//int icolour = thetracki;
-			//while(icolour>=cMRDSubEvent::trackcolours.size()) icolour-=cMRDSubEvent::trackcolours.size();
-			//evl->SetLineColor(cMRDSubEvent::trackcolours.at(icolour));
-			evl->SetPoint(0,sttv->X(),sttv->Y(),sttv->Z());
-			evl->SetPoint(1,stpv->X(),stpv->Y(),stpv->Z());
-			if(!(pep->X()==0&&pep->Y()==0&&pep->Z()==0)){
-				evl->SetPoint(2,pep->X(),pep->Y(),pep->Z());
-				hpep->Fill(pep->X(),pep->Z(),pep->Y());
-				if(verbose) cout<<"back projected point intercepts the tank at ("
-					<<pep->X()<<", "<<pep->Y()<<", "<<pep->Z()<<")"<<endl;
-				//if(abs(pep->X())>450.) earlyexit=true;
+			// If gdml track overlay is being drawn, construct the TEveLine for this track
+			if(drawGdmlOverlay){
+				// ONLY to overlay on gdml plot, we need to shift tracks to the same gdml coordinate system!
+				(*sttv) =  TVector3(sttv->X()-buildingoffset.X(),
+									sttv->Y()-buildingoffset.Y(),
+									sttv->Z()-buildingoffset.Z());
+				(*stpv) =  TVector3(stpv->X()-buildingoffset.X(),
+									stpv->Y()-buildingoffset.Y(),
+									stpv->Z()-buildingoffset.Z());
+				(*pep)  =  TVector3( pep->X()-buildingoffset.X(),
+									 pep->Y()-buildingoffset.Y(),
+									 pep->Z()-buildingoffset.Z());
+				
+				if(verbosity>2) cout<<"adding track "<<thetracki<<" to event display"<<endl;
+				TEveLine* evl = new TEveLine("track1",2);
+				evl->SetLineWidth(4);
+				evl->SetLineStyle(1);
+				evl->SetMarkerColor(kRed);
+				evl->SetRnrPoints(kTRUE);  // enable rendering of points
+				//int icolour = thetracki;
+				//while(icolour>=cMRDSubEvent::trackcolours.size()) icolour-=cMRDSubEvent::trackcolours.size();
+				//evl->SetLineColor(cMRDSubEvent::trackcolours.at(icolour));
+				evl->SetPoint(0,sttv->X(),sttv->Y(),sttv->Z());
+				evl->SetPoint(1,stpv->X(),stpv->Y(),stpv->Z());
+				if(!(pep->X()==0&&pep->Y()==0&&pep->Z()==0)){
+					evl->SetPoint(2,pep->X(),pep->Y(),pep->Z());
+					hpep->Fill(pep->X(),pep->Z(),pep->Y());
+					if(verbosity>2) cout<<"back projected point intercepts the tank at ("
+						<<pep->X()<<", "<<pep->Y()<<", "<<pep->Z()<<")"<<endl;
+					//if(abs(pep->X())>450.) earlyexit=true;
+				}
+				thiseventstracks.push_back(evl);
+				numtracksdrawn++;
+				//if(numtracksdrawn>100) earlyexit=true;
+				
+//				// draw the track -- either need to make trackarrows public,
+//				// or make cMRDSubEvent method to call draw a given track... 
+//				// or we can draw all tracks via DrawTracks().
+//				int trackcolourindex=thetrack.MRDtrackID+1; // element 0 is black
+//				while(trackcolourindex+1>=cMRDSubEvent::trackcolours.size()) 
+//					trackcolourindex-=cMRDSubEvent::trackcolours.size();
+//				EColor thistrackscolour = cMRDSubEvent::trackcolours.at(trackcolourindex);
+//				EColor fittrackscolour = cMRDSubEvent::trackcolours.at(trackcolourindex+1);
+//				thetrack.DrawReco(thesubevent->imgcanvas, thesubevent->trackarrows, thistrackscolour, thesubevent->paddlepointers);
+//				thetrack.DrawFit(thesubevent->imgcanvas, thesubevent->trackfitarrows, fittrackscolour);
 			}
-			thiseventstracks.push_back(evl);
-			numtracksdrawn++;
-			//cout<<"eveline constructed at "<<evl<<endl;
-			//if(numtracksdrawn>100) earlyexit=true;
 			
-			
-			/*
-			// draw the track
-			int trackcolourindex=thetrack.MRDtrackID+1; // element 0 is black
-			while(trackcolourindex+1>=cMRDSubEvent::trackcolours.size()) 
-				trackcolourindex-=cMRDSubEvent::trackcolours.size();
-			EColor thistrackscolour = cMRDSubEvent::trackcolours.at(trackcolourindex);
-			EColor fittrackscolour = cMRDSubEvent::trackcolours.at(trackcolourindex+1);
-			thetrack->DrawReco(imgcanvas, trackarrows, thistrackscolour, paddlepointers);
-			thetrack->DrawFit(imgcanvas, trackfitarrows, fittrackscolour);
-			*/
 			if(earlyexit) break;
 		} // end loop over tracks
 		
-//		gdmlcanv->cd();
-//		cout<<"drawing event display"<<endl;
-//		for(auto&& aline : thiseventstracks){
-//			//cout<<"drawing track at "<<aline<<" from ("<<aline->GetLineStart().fX
-//			//<<", "<<aline->GetLineStart().fY<<", "<<aline->GetLineStart().fZ<<") to ("
-//			//<<aline->GetLineEnd().fX<<", "<<aline->GetLineEnd().fY<<", "<<aline->GetLineEnd().fZ<<")"
-//			//<<endl;
-//			aline->Draw();
-//		}
+		// if gdml overlay is being drawn, draw it here
+		if(drawGdmlOverlay){
+			gdmlcanv->cd();
+			for(TEveLine* aline : thiseventstracks){
+				//cout<<"drawing track at "<<aline<<" from ("<<aline->GetLineStart().fX
+				//<<", "<<aline->GetLineStart().fY<<", "<<aline->GetLineStart().fZ<<") to ("
+				//<<aline->GetLineEnd().fX<<", "<<aline->GetLineEnd().fY<<", "<<aline->GetLineEnd().fZ<<")"
+				//<<endl;
+				aline->Draw();
+			}
+			gdmlcanv->Update();
+			//gEve->Redraw3D(kTRUE);
+		}
 		
+		if(drawPaddlePlot){
+			if(verbosity>2) cout<<"Drawing paddle plot"<<endl;
+			thesubevent->DrawMrdCanvases();  // creates the canvas with the digits TODO optimise this
+			thesubevent->DrawTracks();       // adds the CA tracks and their fit
+			thesubevent->DrawTrueTracks();   // draws true tracks over the event
+			
+//			// FIXME for some reason when both plots are drawn the Reco Fit arrows aren't shown???
+			thesubevent->imgcanvas->Modified();
+			for(int subpad=1; subpad<3; subpad++){
+				thesubevent->imgcanvas->GetPad(subpad)->Modified();
+				thesubevent->imgcanvas->GetPad(subpad)->Update();
+			}
+//			gSystem->ProcessEvents();
+
+//			for(int subpad=1; subpad<3; subpad++){ // loop over the top and side views
+//				TList* imgcanvasprimaries = thesubevent->imgcanvas->GetPad(subpad)->GetListOfPrimitives();
+//				//imgcanvasprimaries->ls();
+//				TIter primaryiterator(imgcanvasprimaries);
+//				int numarrows=0;
+//				while(TObject* aprimary = primaryiterator()){
+//					TString primarytype = aprimary->ClassName();
+//					if(primarytype=="TArrow"){
+//						numarrows++;
+//					}
+//				}
+//				cout<<"Found "<<numarrows<<" arrows drawn on the subevent canvas"<<endl;
+			
+			if(saveimages){
+				thesubevent->imgcanvas->SaveAs(TString::Format("%s/checkmrdtracks_%d_%d.png",
+												plotDirectory,EventNumber,subevi));
+			}
+		}
 		
-		thesubevent->DrawMrdCanvases();  // creates the canvas with the digits
-		thesubevent->DrawTracks();       // adds the CA tracks and their fit
-		thesubevent->DrawTrueTracks();   // draws true tracks over the event
-		if(saveimages) 
-			thesubevent->imgcanvas->SaveAs(TString::Format("checkmrdtracks_%d_%d.png",EventNumber,subevi));
+		//gSystem->ProcessEvents();
+		//gPad->WaitPrimitive();
+		if(enableTApplication) std::this_thread::sleep_for (std::chrono::seconds(2));
 		
-		thesubevent->RemoveArrows();
 		//if(earlyexit) break;
 	} // end loop over subevents
 	
@@ -315,78 +427,10 @@ bool MrdPaddlePlot::Execute(){
 		cerr<<"number of tracks in event does not correspond to sum of tracks in subevents!"<<endl;
 	}
 	
-//	gdmlcanv->Update();
-	
-	c2.cd();
-	hnumsubevs->Draw();
-	c3.cd();
-	hnumtracks->Draw();
-	c4.cd();
-	hrun->Draw();
-	c5.cd();
-	hevent->Draw();
-	c6.cd();
-	hmrdsubev->Draw();
-	c7.cd();
-	htrigger->Draw();
-	c8.cd();
-	hnumhclusters->Draw();
-	c9.cd();
-	hnumvclusters->Draw();
-	c10.cd();
-	hnumhcells->Draw();
-	c11.cd();
-	hnumvcells->Draw();
-	c12.cd();
-	hpaddleids->Draw();
-	c13.cd();
-	hdigittimes->Draw();
-	c14.cd();
-	hhangle->Draw();
-	c15.cd();
-	hhangleerr->Draw();
-	c16.cd();
-	hvangle->Draw();
-	c17.cd();
-	hvangleerr->Draw();
-	c18.cd();
-	htotangle->Draw();
-	c19.cd();
-	htotangleerr->Draw();
-	c20.cd();
-	henergyloss->Draw();
-	c21.cd();
-	henergylosserr->Draw();
-	c22.cd();
-	htracklength->Draw();
-	c23.cd();
-	htrackpen->Draw();
-	c24.cd();
-	htrackpenvseloss->Draw();
-	c25.cd();
-	htracklenvseloss->Draw();
-	// should put these on the same canvas V
-	c26.cd();
-	htrackstart->Draw();
-	c27.cd();
-	htrackstop->Draw();
-	c28.cd();
-	hpep->Draw();
-	
-	//gPad->WaitPrimitive();
-	//std::this_thread::sleep_for (std::chrono::seconds(5));
-	
-//	struct timespec timeOut,remains;
-//	
-//	timeOut.tv_sec = 0;
-//	timeOut.tv_nsec = 500000000; /* 50 milliseconds */
-//	nanosleep(&timeOut, &remains);
-	
 	numents++;
 	
 	return true;
 }
-
 
 bool MrdPaddlePlot::Finalise(){
 	
@@ -396,5 +440,141 @@ bool MrdPaddlePlot::Finalise(){
 		<<"Back projection suggests "<<numtankintercepts<<" tracks would have originated in the tank, while "
 		<<numtankmisses<<" would not intercept the tank through back projection."<<endl;
 	
+	// make summary plots
+	if(drawGdmlOverlay){  // TODO separate this from GDML overlay
+		// FIXME: Why not being saved???
+		std::string imgname;
+		mrdTrackCanv->cd();
+		hnumsubevs->Draw();
+		imgname=hnumsubevs->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hnumtracks->Draw();
+		imgname=hnumtracks->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hrun->Draw();
+		imgname=hrun->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hevent->Draw();
+		imgname=hevent->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hmrdsubev->Draw();
+		imgname=hmrdsubev->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		htrigger->Draw();
+		imgname=htrigger->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hnumhclusters->Draw();
+		imgname=hnumhclusters->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hnumvclusters->Draw();
+		imgname=hnumvclusters->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hnumhcells->Draw();
+		imgname=hnumhcells->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hnumvcells->Draw();
+		imgname=hnumvcells->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hpaddleids->Draw();
+		imgname=hpaddleids->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hdigittimes->Draw();
+		imgname=hdigittimes->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hhangle->Draw();
+		imgname=hhangle->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hhangleerr->Draw();
+		imgname=hhangleerr->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hvangle->Draw();
+		imgname=hvangle->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hvangleerr->Draw();
+		imgname=hvangleerr->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		htotangle->Draw();
+		imgname=htotangle->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		htotangleerr->Draw();
+		imgname=htotangleerr->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		henergyloss->Draw();
+		imgname=henergyloss->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		henergylosserr->Draw();
+		imgname=henergylosserr->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		htracklength->Draw();
+		imgname=htracklength->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		htrackpen->Draw();
+		imgname=htrackpen->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		htrackpenvseloss->Draw();
+		imgname=htrackpenvseloss->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		htracklenvseloss->Draw();
+		imgname=htracklenvseloss->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		// should put these on the same canvas V
+		htrackstart->Draw();
+		imgname=htrackstart->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		htrackstop->Draw();
+		imgname=htrackstop->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+		hpep->Draw();
+		imgname=hpep->GetTitle();
+		std::replace(imgname.begin(), imgname.end(), ' ', '_');
+		mrdTrackCanv->SaveAs(TString::Format("%s/%s.png",plotDirectory,imgname.c_str()));
+	}
+	
+	if(enableTApplication){
+		// cleanup track drawing TApplication
+		gSystem->ProcessEvents();
+		delete mrdPaddlePlotApp;
+	}
+	
 	return true;
 }
+
+//	maybe we can use these:
+//	TEveViewer *ev = gEve->GetDefaultViewer();
+//	TGLViewer  *gv = ev->GetGLViewer();
+//	gv->SetGuideState(TGLUtil::kAxesOrigin, kTRUE, kFALSE, 0);
+//	gEve->Redraw3D(kTRUE);
+//	gSystem->ProcessEvents();
+//	gv->CurrentCamera().RotateRad(-0.5, 1.4);
+//	gv->RequestDraw();
+
+//	struct timespec timeOut,remains;
+//	timeOut.tv_sec = 0;
+//	timeOut.tv_nsec = 500000000; /* 50 milliseconds */
+//	nanosleep(&timeOut, &remains);

--- a/UserTools/MrdPaddlePlot/MrdPaddlePlot.cpp
+++ b/UserTools/MrdPaddlePlot/MrdPaddlePlot.cpp
@@ -4,8 +4,8 @@
 #include "TGeoManager.h"
 #ifdef GOT_EVE
 #include "TEveLine.h"
-#endif
 #include "TGLViewer.h"
+#endif
 #include <thread>         // std::this_thread::sleep_for
 #include <chrono>         // std::chrono::seconds
 #include <time.h>         // clock_t, clock, CLOCKS_PER_SEC

--- a/UserTools/MrdPaddlePlot/MrdPaddlePlot.h
+++ b/UserTools/MrdPaddlePlot/MrdPaddlePlot.h
@@ -85,43 +85,43 @@ class MrdPaddlePlot: public Tool {
 	bool enableTApplication;
 	bool drawPaddlePlot;
 	bool drawGdmlOverlay;
-	TApplication* mrdPaddlePlotApp;
+	TApplication* mrdPaddlePlotApp=nullptr;
 	
-	TCanvas* gdmlcanv;
-	TCanvas* mrdTrackCanv;
+	TCanvas* gdmlcanv=nullptr;
+	TCanvas* mrdTrackCanv=nullptr;
 	TClonesArray* thesubeventarray;  // retrieve from track finder
 	std::vector<TEveLine*> thiseventstracks;
 	
 	// Summary histograms on tracks found
-	TH1F* hnumsubevs;
-	TH1F* hnumtracks;
-	TH1F* hrun;
-	TH1F* hevent;
-	TH1F* hmrdsubev;
-	TH1F* htrigger;
-	TH1F* hnumhclusters;
-	TH1F* hnumvclusters;
-	TH1F* hnumhcells;
-	TH1F* hnumvcells;
-	TH1F* hpaddleids;
-	TH1F* hpaddleinlayeridsh;
-	TH1F* hpaddleinlayeridsv;
-	TH1D* hdigittimes;
-	TH1F* hhangle;
-	TH1F* hhangleerr;
-	TH1F* hvangle;
-	TH1F* hvangleerr;
-	TH1F* htotangle;
-	TH1F* htotangleerr;
-	TH1F* henergyloss;
-	TH1F* henergylosserr;
-	TH1F* htracklength;
-	TH1F* htrackpen;
-	TH2F* htrackpenvseloss;
-	TH2F* htracklenvseloss;
-	TH3D* htrackstart;
-	TH3D* htrackstop;
-	TH3D* hpep;
+	TH1F* hnumsubevs=nullptr;
+	TH1F* hnumtracks=nullptr;
+	TH1F* hrun=nullptr;
+	TH1F* hevent=nullptr;
+	TH1F* hmrdsubev=nullptr;
+	TH1F* htrigger=nullptr;
+	TH1F* hnumhclusters=nullptr;
+	TH1F* hnumvclusters=nullptr;
+	TH1F* hnumhcells=nullptr;
+	TH1F* hnumvcells=nullptr;
+	TH1F* hpaddleids=nullptr;
+	TH1F* hpaddleinlayeridsh=nullptr;
+	TH1F* hpaddleinlayeridsv=nullptr;
+	TH1D* hdigittimes=nullptr;
+	TH1F* hhangle=nullptr;
+	TH1F* hhangleerr=nullptr;
+	TH1F* hvangle=nullptr;
+	TH1F* hvangleerr=nullptr;
+	TH1F* htotangle=nullptr;
+	TH1F* htotangleerr=nullptr;
+	TH1F* henergyloss=nullptr;
+	TH1F* henergylosserr=nullptr;
+	TH1F* htracklength=nullptr;
+	TH1F* htrackpen=nullptr;
+	TH2F* htrackpenvseloss=nullptr;
+	TH2F* htracklenvseloss=nullptr;
+	TH3D* htrackstart=nullptr;
+	TH3D* htrackstop=nullptr;
+	TH3D* hpep=nullptr;
 	
 };
 

--- a/UserTools/MrdPaddlePlot/MrdPaddlePlot.h
+++ b/UserTools/MrdPaddlePlot/MrdPaddlePlot.h
@@ -8,6 +8,11 @@
 #include "TClonesArray.h"
 #include "MRDSubEventClass.hh"      // a class for defining subevents
 #include "MRDTrackClass.hh"         // a class for defining MRD tracks
+// for drawing
+#include "TApplication.h"
+#include "TSystem.h"
+//#include "TEveLine.h"
+class TEveLine;
 
 class MrdPaddlePlot: public Tool {
 
@@ -23,18 +28,42 @@ class MrdPaddlePlot: public Tool {
 
 	// Variables stored in Config file
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	int verbose=1;
+	int verbosity=1;
 	std::string gdmlpath;
 	bool saveimages;
+	const char* plotDirectory;  // where to save images and plots
 	
 	// Variables from ANNIEEVENT
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~
-	std::string MCFile;      //-> currentfilestring
+	std::string MCFile;     //-> currentfilestring
 	uint32_t RunNumber;     // -> runnum     (keep as the type is different: TODO align types)
 	uint32_t SubrunNumber;  // -> subrunnum  ( " " )
 	uint32_t EventNumber;   // -> eventnum   ( " " )
 	uint16_t MCTriggernum;  // -> triggernum ( " " )
 	uint64_t MCEventNum;    // not yet in MRDTrackClass 
+	
+	// Variables from MRDTracks BoostStore
+	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	std::vector<BoostStore>* theMrdTracks; // the actual tracks
+	uint16_t MrdTrackID;
+	uint16_t MrdSubEventID;
+	bool InterceptsTank;
+	double StartTime;
+	Position StartVertex;
+	Position StopVertex;
+	double TrackAngle;
+	double TrackAngleError;
+	std::vector<int> LayersHit;
+	double TrackLength;
+	bool IsMrdPenetrating;
+	bool IsMrdStopped;
+	bool IsMrdSideExit;
+	double PenetrationDepth;
+	double HtrackFitChi2;
+	double HtrackFitCov;
+	double VtrackFitChi2;
+	double VtrackFitCov;
+	std::vector<int> PMTsHit;
 	
 	// MRD TRACK DRAWING
 	// ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -48,8 +77,20 @@ class MrdPaddlePlot: public Tool {
 	int numtankintercepts=0;
 	int numtankmisses=0;
 	
+	// we need to subtract the an offset to draw TEveLines over gdml
+	Position buildingoffset;
+	
+	bool printTracks;
+	bool printTClonesTracks;
+	bool enableTApplication;
+	bool drawPaddlePlot;
+	bool drawGdmlOverlay;
+	TApplication* mrdPaddlePlotApp;
+	
 	TCanvas* gdmlcanv;
+	TCanvas* mrdTrackCanv;
 	TClonesArray* thesubeventarray;  // retrieve from track finder
+	std::vector<TEveLine*> thiseventstracks;
 	
 	// Summary histograms on tracks found
 	TH1F* hnumsubevs;
@@ -81,34 +122,6 @@ class MrdPaddlePlot: public Tool {
 	TH3D* htrackstart;
 	TH3D* htrackstop;
 	TH3D* hpep;
-	
-	TCanvas c2;
-	TCanvas c3;
-	TCanvas c4;
-	TCanvas c5;
-	TCanvas c6;
-	TCanvas c7;
-	TCanvas c8;
-	TCanvas c9;
-	TCanvas c10;
-	TCanvas c11;
-	TCanvas c12;
-	TCanvas c13;
-	TCanvas c14;
-	TCanvas c15;
-	TCanvas c16;
-	TCanvas c17;
-	TCanvas c18;
-	TCanvas c19;
-	TCanvas c20;
-	TCanvas c21;
-	TCanvas c22;
-	TCanvas c23;
-	TCanvas c24;
-	TCanvas c25;
-	TCanvas c26;
-	TCanvas c27;
-	TCanvas c28;
 	
 };
 

--- a/UserTools/Unity.cpp
+++ b/UserTools/Unity.cpp
@@ -44,7 +44,7 @@
 #include "FindTrackLengthInWater/FindTrackLengthInWater.cpp"
 #include "LoadANNIEEvent/LoadANNIEEvent.cpp"
 #include "PhaseITreeMaker/PhaseITreeMaker.cpp"
-//#include "MrdPaddlePlot/MrdPaddlePlot.cpp"
+#include "MrdPaddlePlot/MrdPaddlePlot.cpp"
 #include "LoadWCSimLAPPD/LoadWCSimLAPPD.cpp"
 #include "LoadWCSimLAPPD/LAPPDTree.cpp"
 #include "WCSimDemo/WCSimDemo.cpp"

--- a/configfiles/FindMrdTracks/FindMrdTracksConfig
+++ b/configfiles/FindMrdTracks/FindMrdTracksConfig
@@ -2,8 +2,9 @@
 # all variables retrieved with m_variables.Get() must be defined here!
 
 OutputDirectory .
-verbose 1
+verbosity 1
 MinDigitsForTrack 4
 MaxMrdSubEventDuration 30  # [ns]
 WriteTracksToFile 1
-DrawTracks 0 # whether to draw track visualization
+DrawTruthTracks 0 # whether to add MC Truth track info for drawing in MrdPaddlePlot Tool
+                  ## note you need to run that tool to actually view the tracks!

--- a/configfiles/FindMrdTracks/LoadWCSimLAPPDConfig
+++ b/configfiles/FindMrdTracks/LoadWCSimLAPPDConfig
@@ -1,0 +1,9 @@
+#LoadWCSimLAPPD Config File
+# all variables retrieved with m_variables.Get() must be defined here!
+
+verbose 1
+InputFile /pnfs/annie/persistent/users/moflaher/wcsim_lappd_24-09-17_BNB_Water_10k_22-05-17/wcsim_lappd_0.0.0.root
+# octagonal inner structure radius in m (from drawings 106.64")
+InnerStructureRadius 1.3545
+HistoricTriggeroffset 950
+DrawDebugGraphs 0 # whether to draw TPolyMarker3D's of hits

--- a/configfiles/FindMrdTracks/PlotMrdTracksConfig
+++ b/configfiles/FindMrdTracks/PlotMrdTracksConfig
@@ -2,7 +2,22 @@
 # all variables retrieved with m_variables.Get() must be defined here!
 
 OutputDirectory /annie/app/users/moflaher/ToolAnalysis/toolAnalysisOutputs/FindMrdTracksTest
-verbose 100
+verbosity 1
 gdmlpath /pnfs/annie/persistent/users/moflaher/annie_v04.gdml
+## because we're only interested in drawing tracks over the gdml subvolume representing the hall, 
+## (not the world entirely), but we want the coordinates to match those from WCSim
+## (which match the world), we need to offset our WCSim positions by the position of the hall within the world
+#gdmlpath /annie/app/users/moflaher/wcsim/root_work/annie_v04_aligned.gdml ## has buildingoffsets included
+## units cm
+buildingoffsetx 206.82
+buildingoffsety 54.3225
+buildingoffsetz 243.43894
+
 # save images of hit paddles in each track identified. ONLY FOR SMALL NUM TRACKS AS DEBUG!
-saveimages true
+drawCanvases 0          # required for ANY kind of graphical output
+drawPaddlePlot 0        # draw the top/side view paddle plot of tracks
+drawGdmlOverlay 0       # draw a 3D representation of the ANNIE detector overlaid with MRD tracks
+saveimages 0            # save the paddle plots as images. Currently not working...
+plotDirectory /annie/app/users/moflaher/ToolAnalysis/ToolAnalysis/MrdPlots  # where to save plot images
+printTracks 1           # verbose printout of track information from BoostStore
+printTClonesTracks 0    # verbose printout of track information from TClonesArray

--- a/configfiles/FindMrdTracks/ToolsConfig
+++ b/configfiles/FindMrdTracks/ToolsConfig
@@ -2,5 +2,5 @@ myLoadWCSim LoadWCSim ./configfiles/FindMrdTracks/LoadWCSimConfig
 #myLoadWCSimLAPPD LoadWCSimLAPPD ./configfiles/FindMrdTracks/LoadWCSimLAPPDConfig
 #myPrintANNIEEvent PrintANNIEEvent ./configfiles/FindMrdTracks/PrintANNIEEventConfig
 myFindMrdTracks FindMrdTracks ./configfiles/FindMrdTracks/FindMrdTracksConfig
-#myMrdTrackPlotter MrdPaddlePlot ./configfiles/FindMrdTracks/PlotMrdTracksConfig
+myMrdTrackPlotter MrdPaddlePlot ./configfiles/FindMrdTracks/PlotMrdTracksConfig
 


### PR DESCRIPTION
Fix FindMrdTracks to fill found tracks into a vector of single-entry BoostStores instead of a multi-entry BoostStore.
Finish MrdPaddlePlot tool for demonstrating MRD Track retrieval and drawing.

Add ps component to TimeClass, required for precision of track times for reconstruction.

Add hit time plot to the set of debug plots for LoadWCSimLAPPD tool.