### PR TITLE
Removal of WCSim historic digit offset

### DIFF
--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -19,6 +19,7 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	// ====================================
 	m_variables.Get("verbose",verbose);
 	m_variables.Get("InputFile",MCFile);
+	m_variables.Get("HistoricTriggeroffset",HistoricTriggeroffset);
 	
 	// Short Stores README
 	//////////////////////
@@ -298,7 +299,7 @@ bool LoadWCSim::Execute(){
 			if(verbose>2) cout<<"next digihit at "<<digihit<<endl;
 			int tubeid = digihit->GetTubeId();
 			if(verbose>2) cout<<"tubeid="<<tubeid<<endl;
-			double digittime(static_cast<double>(digihit->GetT())); // relative to trigger
+			double digittime(static_cast<double>(digihit->GetT()-HistoricTriggeroffset)); // relative to trigger
 			if(verbose>2){ cout<<"digittime is "<<digittime<<" [ns] from Trigger"<<endl; }
 			float digiq = digihit->GetQ();
 			if(verbose>2) cout<<"digit Q is "<<digiq<<endl;
@@ -321,7 +322,7 @@ bool LoadWCSim::Execute(){
 			if(verbose>2) cout<<"next digihit at "<<digihit<<endl;
 			int tubeid = digihit->GetTubeId() + numvetopmts;
 			if(verbose>2) cout<<"tubeid="<<tubeid<<endl;
-			double digittime(static_cast<double>(digihit->GetT())); // relative to trigger
+			double digittime(static_cast<double>(digihit->GetT()-HistoricTriggeroffset)); // relative to trigger
 			if(verbose>2){ cout<<"digittime is "<<digittime<<" [ns] from Trigger"<<endl; }
 			float digiq = digihit->GetQ();
 			if(verbose>2) cout<<"digit Q is "<<digiq<<endl;
@@ -344,7 +345,7 @@ bool LoadWCSim::Execute(){
 			if(verbose>2) cout<<"next digihit at "<<digihit<<endl;
 			int tubeid = digihit->GetTubeId();
 			if(verbose>2) cout<<"tubeid="<<tubeid<<endl;
-			double digittime(static_cast<double>(digihit->GetT())); // relative to trigger
+			double digittime(static_cast<double>(digihit->GetT()-HistoricTriggeroffset)); // relative to trigger
 			if(verbose>2){ cout<<"digittime is "<<digittime<<" [ns] from Trigger"<<endl; }
 			float digiq = digihit->GetQ();
 			if(verbose>2) cout<<"digit Q is "<<digiq<<endl;

--- a/UserTools/LoadWCSim/LoadWCSim.h
+++ b/UserTools/LoadWCSim/LoadWCSim.h
@@ -30,6 +30,7 @@ public:
 private:
 
 	int verbose=1;
+	int HistoricTriggeroffset;
 	// WCSim variables
 	TFile* file;
 	TTree* wcsimtree;

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
@@ -40,7 +40,6 @@ bool LoadWCSimLAPPD::Initialise(std::string configfile, DataModel &data){
 	//verbose=10;
 	m_variables.Get("InputFile",MCFile);
 	m_variables.Get("InnerStructureRadius",Rinnerstruct);
-	m_variables.Get("HistoricTriggeroffset",triggeroffset);
 	m_variables.Get("DrawDebugGraphs",DEBUG_DRAW_LAPPD_HITS);
 	m_variables.Get("FileVersion",FILE_VERSION);
 	
@@ -97,7 +96,7 @@ bool LoadWCSimLAPPD::Initialise(std::string configfile, DataModel &data){
 		digixpos = new TH1D("digixpos","digixpos",100,-2,2);
 		digiypos = new TH1D("digiypos","digiypos",100,-2.5,2.5);
 		digizpos = new TH1D("digizpos","digizpos",100,0.,4.);
-		digits = new TH1D("digits","digits",100,triggeroffset-50,triggeroffset+100);
+		digits = new TH1D("digits","digits",100,-50,100);
 	}
 	
 	return true;
@@ -233,7 +232,7 @@ bool LoadWCSimLAPPD::Execute(){
 				
 				// calculate relative time within trigger
 				double digitst  = LAPPDEntry->lappdhit_stripcoort->at(runningcount);
-				double relativedigitst=digitst+triggeroffset-wcsimtriggertime;
+				double relativedigitst=digitst-wcsimtriggertime;
 				
 				float digiq = 0; // N/A
 				ChannelKey key(subdetector::LAPPD,LAPPDID);

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.h
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.h
@@ -31,7 +31,6 @@ class LoadWCSimLAPPD: public Tool {
 	int verbose=1;
 	std::string MCFile;
 	double Rinnerstruct;    // cm octagonal inner structure radius
-	int triggeroffset;      // whether the historic 950ns offset was included
 	
 	// LAPPDTree variables
 	TFile* file=nullptr;

--- a/configfiles/LoadWCSim/LoadWCSimConfig
+++ b/configfiles/LoadWCSim/LoadWCSimConfig
@@ -3,3 +3,4 @@
 
 verbose 1
 InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_24-09-17_BNB_Water_10k_22-05-17/wcsim_0.0.0.root
+HistoricTriggeroffset 950

--- a/configfiles/LoadWCSim/LoadWCSimLAPPDConfig
+++ b/configfiles/LoadWCSim/LoadWCSimLAPPDConfig
@@ -5,5 +5,4 @@ verbose 3
 InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_24-09-17_BNB_Water_10k_22-05-17/wcsim_lappd_0.0.0.root
 # octagonal inner structure radius in m (from drawings 106.64")
 InnerStructureRadius 1.3545
-HistoricTriggeroffset 950
 DrawDebugGraphs 0 # whether to draw TPolyMarker3D's of hits


### PR DESCRIPTION
Currently LoadWCSimLAPPD tool takes the historic offset and adds it to digit times, to bring them in line with PMT digit times. 
This switches it round and instead passes the historic offset via config file to the LoadWCSim tool and subtracts it from PMT digit times.
Not really sure why it wasn't this way to begin with... 