### PR TITLE
Remove time class

### DIFF
--- a/DataModel/ADCPulse.cpp
+++ b/DataModel/ADCPulse.cpp
@@ -4,7 +4,7 @@
 // Time and start_time.
 // TODO: think about changing this
 // TODO: consider adding the pulse end time as a data member for this class
-ADCPulse::ADCPulse(int TubeId, double start_time, TimeClass peak_time,
+ADCPulse::ADCPulse(int TubeId, double start_time, double peak_time,
   double baseline, double sigma_baseline, unsigned long area,
   unsigned short raw_amplitude, double calibrated_amplitude,
   double charge) : Hit(TubeId, start_time, charge),

--- a/DataModel/ADCPulse.h
+++ b/DataModel/ADCPulse.h
@@ -9,7 +9,6 @@
 // ToolAnalysis includes
 #include "ChannelKey.h"
 #include "Hit.h"
-#include "TimeClass.h"
 
 class ADCPulse : public Hit {
 
@@ -21,7 +20,7 @@ class ADCPulse : public Hit {
 
     // TODO: consider using a ChannelKey object instead of the Hit class's
     // int TubeId member
-    ADCPulse(int TubeId, double start_time, TimeClass peak_time,
+    ADCPulse(int TubeId, double start_time, double peak_time,
       double baseline, double sigma_baseline, unsigned long raw_area,
       unsigned short raw_amplitude, double calibrated_amplitude,
       double charge);
@@ -32,7 +31,7 @@ class ADCPulse : public Hit {
 
     // @brief Returns the peak time (ns) of the pulse relative to the
     // start of its minibuffer
-    inline TimeClass peak_time() const { return peak_time_; }
+    inline double peak_time() const { return peak_time_; }
 
     // @brief Returns the approximate baseline (ADC) used to calibrate the
     // pulse
@@ -77,7 +76,7 @@ class ADCPulse : public Hit {
   protected:
 
     double start_time_; // ns since beginning of minibuffer
-    TimeClass peak_time_; // ns since beginning of minibuffer
+    double peak_time_; // ns since beginning of minibuffer
     double baseline_; // mean (ADC)
     double sigma_baseline_; // standard deviation (ADC)
     unsigned long raw_area_; // (ADC * samples)

--- a/DataModel/CalibratedADCWaveform.h
+++ b/DataModel/CalibratedADCWaveform.h
@@ -10,7 +10,7 @@ template <typename T> class CalibratedADCWaveform : public Waveform<T> {
 
     CalibratedADCWaveform() : Waveform<T>(), fBaseline(0.),
       fSigmaBaseline(0.) {}
-    CalibratedADCWaveform(const TimeClass& tc, const std::vector<T>& samples,
+    CalibratedADCWaveform(const double& tc, const std::vector<T>& samples,
       double baseline, double sigma_bl)
       : Waveform<T>(tc, samples), fBaseline(baseline),
       fSigmaBaseline(sigma_bl) {}

--- a/DataModel/Hit.h
+++ b/DataModel/Hit.h
@@ -3,7 +3,6 @@
 #define HITCLASS_H
 
 #include<SerialisableObject.h>
-#include "TimeClass.h"
 
 using namespace std;
 
@@ -54,7 +53,7 @@ class TDCHit : public Hit {
 
 class RecoHit : public Hit {
 	public:
-	RecoHit(TimeClass thetime, double thecharge) : Time(thetime), Charge(thecharge){};
+	RecoHit(double thetime, double thecharge) : Time(thetime), Charge(thecharge){};
 
 	inline double GetCharge(){return Charge;}
 	inline void SetCharge(double chg){Charge=chg;}

--- a/DataModel/LAPPDHit.h
+++ b/DataModel/LAPPDHit.h
@@ -4,7 +4,6 @@
 
 #include<Hit.h>
 #include<SerialisableObject.h>
-#include "TimeClass.h"
 
 using namespace std;
 
@@ -59,7 +58,7 @@ class TDCHit : public Hit {
 
 class RecoHit : public Hit {
 	public:
-	RecoHit(TimeClass thetime, double thecharge) : Time(thetime), Charge(thecharge){};
+	RecoHit(double thetime, double thecharge) : Time(thetime), Charge(thecharge){};
 
 	inline double GetCharge(){return Charge;}
 	inline void SetCharge(double chg){Charge=chg;}

--- a/DataModel/LAPPDPulse.h
+++ b/DataModel/LAPPDPulse.h
@@ -4,7 +4,6 @@
 
 #include<Hit.h>
 #include<SerialisableObject.h>
-#include "TimeClass.h"
 
 using namespace std;
 
@@ -62,7 +61,7 @@ class TDCHit : public Hit {
 
 class RecoHit : public Hit {
 	public:
-	RecoHit(TimeClass thetime, double thecharge) : Time(thetime), Charge(thecharge){};
+	RecoHit(double thetime, double thecharge) : Time(thetime), Charge(thecharge){};
 
 	inline double GetCharge(){return Charge;}
 	inline void SetCharge(double chg){Charge=chg;}

--- a/DataModel/Particle.h
+++ b/DataModel/Particle.h
@@ -10,7 +10,6 @@
 #include<SerialisableObject.h>
 #include "Position.h"
 #include "Direction.h"
-#include "TimeClass.h"
 
 using namespace std;
 // world extent in WCSim is +-600cm in all directions!
@@ -27,7 +26,7 @@ class Particle : public SerialisableObject{
 		     trackLength(0), StartStopType(tracktype::UNDEFINED) {serialise=true;}
 	
 	Particle(int pdg, double sttE, double stpE, Position sttpos, Position stppos, 
-	  TimeClass sttt, TimeClass stpt, Direction startdir, double len, tracktype tracktypein) 
+	  double sttt, double stpt, Direction startdir, double len, tracktype tracktypein) 
 	: ParticlePDG(pdg), startEnergy(sttE), stopEnergy(stpE), startVertex(sttpos),
 	  stopVertex(stppos), startTime(sttt), stopTime(stpt), startDirection(startdir),
 	  trackLength(len) {
@@ -48,8 +47,8 @@ class Particle : public SerialisableObject{
 	inline void SetStopEnergy(double E){stopEnergy=E;}
 	inline void SetStartVertex(Position pos){startVertex=pos;}
 	inline void SetStopVertex(Position pos){stopVertex=pos;}
-	inline void SetStartTime(TimeClass stime){startTime=stime;}
-	inline void SetStopTime(TimeClass stime){stopTime=stime;}
+	inline void SetStartTime(double stime){startTime=stime;}
+	inline void SetStopTime(double stime){stopTime=stime;}
 	inline void SetstartDirection(Direction dir){startDirection=dir;}
 	inline void SetTrackLength(double len){trackLength=len;}
 	inline void SetTrackStartStopType(tracktype tracktypein){StartStopType=tracktypein;}
@@ -59,8 +58,8 @@ class Particle : public SerialisableObject{
 	inline double GetStopEnergy(){return stopEnergy;}
 	inline Position GetStartVertex(){return startVertex;}
 	inline Position GetStopVertex(){return stopVertex;}
-	inline TimeClass GetStartTime(){return startTime;}
-	inline TimeClass GetStopTime(){return stopTime;}
+	inline double GetStartTime(){return startTime;}
+	inline double GetStopTime(){return stopTime;}
 	inline Direction GetStartDirection(){return startDirection;}
 	inline double GetTrackLength(){return trackLength;}
 	inline tracktype GetStartStopType(){return StartStopType;}
@@ -72,8 +71,8 @@ class Particle : public SerialisableObject{
 		std::cout<<"stopEnergy : "<<stopEnergy<<std::endl;
 		std::cout<<"startVertex : "; startVertex.Print();
 		std::cout<<"stopVertex : "; stopVertex.Print();
-		std::cout<<"startTime : "; startTime.Print();
-		std::cout<<"stopTime : "; stopTime.Print();
+		std::cout<<"startTime : "<<startTime<<std::endl;
+		std::cout<<"stopTime : "<<stopTime<<std::endl;
 		std::cout<<"startDirection : "; startDirection.Print();
 		std::cout<<"trackLength : "<<trackLength<<std::endl;
 		std::cout<<"StartStopType : "; PrintStartStopType(StartStopType);
@@ -105,8 +104,8 @@ class Particle : public SerialisableObject{
 	double stopEnergy;
 	Position startVertex;            // meters
 	Position stopVertex;
-	TimeClass startTime;
-	TimeClass stopTime;
+	double startTime;                // ns since Trigger time
+	double stopTime;                 //
 	Direction startDirection;        // for primary particle initial scattering dir is most important.
 	double trackLength;              // meters
 	
@@ -136,11 +135,11 @@ class MCParticle : public Particle {
 	
 	public:
 	
-	MCParticle() : Particle(0, 0., 0., Position(), Position(), TimeClass(), TimeClass(), Direction(), 0.,
+	MCParticle() : Particle(0, 0., 0., Position(), Position(), 0., 0., Direction(), 0.,
 				tracktype::UNCONTAINED), ParticleID(0), ParentPdg(0) {serialise=true;}
 	
 	MCParticle(int pdg, double sttE, double stpE, Position sttpos, Position stppos, 
-	  TimeClass sttt, TimeClass stpt, Direction startdir, double len, tracktype tracktypein,
+	  double sttt, double stpt, Direction startdir, double len, tracktype tracktypein,
 	  int partid, int parentpdg) 
 	: Particle(pdg, sttE, stpE, sttpos, stppos, sttt, stpt, startdir, len, tracktypein), 
 	  ParticleID(partid), ParentPdg(parentpdg){
@@ -180,8 +179,8 @@ class MCParticle : public Particle {
 		std::cout<<"stopEnergy : "<<stopEnergy<<std::endl;
 		std::cout<<"startVertex : "; startVertex.Print();
 		std::cout<<"stopVertex : "; stopVertex.Print();
-		std::cout<<"startTime : "; startTime.Print();
-		std::cout<<"stopTime : "; stopTime.Print();
+		std::cout<<"startTime : "<<startTime<<std::endl;;
+		std::cout<<"stopTime : "<<stopTime<<std::endl;
 		std::cout<<"startDirection : "; startDirection.Print();
 		std::cout<<"trackLength : "<<trackLength<<std::endl;
 		std::cout<<"StartStopType : "; PrintStartStopType(StartStopType);

--- a/DataModel/RecoDigit.h
+++ b/DataModel/RecoDigit.h
@@ -4,7 +4,6 @@
 #define RECODIGITCLASS_H
 
 #include<SerialisableObject.h>
-#include "TimeClass.h"
 #include "Position.h"
 #include "ANNIERecoObjectTable.h"
 

--- a/DataModel/Waveform.h
+++ b/DataModel/Waveform.h
@@ -3,7 +3,6 @@
 #define WAVEFORMCLASS_H
 
 #include<SerialisableObject.h>
-#include "TimeClass.h"
 
 using namespace std;
 
@@ -14,21 +13,21 @@ class Waveform : public SerialisableObject{
 
 	public:
   Waveform() : fStartTime(), fSamples(std::vector<T>{}) {serialise=true;}
-  Waveform(TimeClass tsin, std::vector<T> samplesin) : fStartTime(tsin), fSamples(samplesin){serialise=true;}
+  Waveform(double tsin, std::vector<T> samplesin) : fStartTime(tsin), fSamples(samplesin){serialise=true;}
 
-	inline TimeClass GetStartTime() const {return fStartTime;}
+	inline double GetStartTime() const {return fStartTime;}
 	inline std::vector<T>* GetSamples() {return &fSamples;}
 	inline const std::vector<T>& Samples() const { return fSamples; }
 	inline T GetSample(int i) const {return fSamples.at(i);}
 
-	inline void SetStartTime(TimeClass ts) {fStartTime=ts;}
+	inline void SetStartTime(double ts) {fStartTime=ts;}
 	inline void SetSamples(std::vector<T> sam) {fSamples=sam;}
 	inline void PushSample(T asample) {fSamples.push_back(asample);}
 	inline void ClearSamples() {fSamples.clear();}
 
 	bool Print() {
 		int verbose=0;
-		cout<<"StartTime : "; fStartTime.Print();
+		cout<<"StartTime : "<<fStartTime<<endl;
 		cout<<"NSamples : "<<fSamples.size()<<endl;
 		if(verbose){
 			cout<<"Samples : {";
@@ -43,7 +42,7 @@ class Waveform : public SerialisableObject{
 	}
 
 	protected:
-	TimeClass fStartTime;
+	double fStartTime;
 	std::vector<T> fSamples;
 
 	template<class Archive> void serialize(Archive & ar, const unsigned int version){

--- a/UserTools/ADCHitFinder/ADCHitFinder.cpp
+++ b/UserTools/ADCHitFinder/ADCHitFinder.cpp
@@ -230,7 +230,7 @@ std::vector<ADCPulse> ADCHitFinder::find_pulses(
       // Store the freshly made pulse in the vector of found pulses
       pulses.emplace_back(channel_key.GetDetectorElementIndex(),
         ( pulse_start_sample * NS_PER_SAMPLE ),
-        TimeClass( peak_sample * NS_PER_SAMPLE ),
+        peak_sample * NS_PER_SAMPLE,
         calibrated_minibuffer_data.GetBaseline(),
         calibrated_minibuffer_data.GetSigmaBaseline(),
         raw_area, max_ADC, calibrated_amplitude, charge);

--- a/UserTools/DigitBuilder/DigitBuilder.h
+++ b/UserTools/DigitBuilder/DigitBuilder.h
@@ -81,7 +81,6 @@ class DigitBuilder: public Tool {
 	std::map<ChannelKey,std::vector<Hit>>* fMCHits=nullptr;             ///< PMT hits
 	std::map<ChannelKey,std::vector<LAPPDHit>>* fMCLAPPDHits=nullptr;   ///< LAPPD hits
 	std::map<ChannelKey,std::vector<Hit>>* fTDCData=nullptr;            ///< MRD & veto hits
-	TimeClass* fEventTime=nullptr;    ///< NDigits trigger time in ns from when the particles were generated
 	TRandom3 frand;  ///< Random number generator
 	
 	/// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -134,9 +134,9 @@ RecoVertex* EventSelector::FindTrueVertexFromMC() {
   
   // retrieve desired information from the particle
   Position muonstartpos = primarymuon.GetStartVertex();    // only true if the muon is primary
-  double muonstarttime = primarymuon.GetStartTime().GetNs();
+  double muonstarttime = primarymuon.GetStartTime();
   Position muonstoppos = primarymuon.GetStopVertex();    // only true if the muon is primary
-  double muonstoptime = primarymuon.GetStopTime().GetNs();
+  double muonstoptime = primarymuon.GetStopTime();
   
   Direction muondirection = primarymuon.GetStartDirection();
   double muonenergy = primarymuon.GetStartEnergy();

--- a/UserTools/FindMrdTracks/FindMrdTracks.cpp
+++ b/UserTools/FindMrdTracks/FindMrdTracks.cpp
@@ -103,7 +103,7 @@ bool FindMrdTracks::Execute(){
 		/*
 		digihit is of type std::pair<ChannelKey,vector<TDCHit>>,
 		ChannelKey has members SubDetectorIndex (uint) and DetectorElementIndex (uint)
-		TDCHit has members Time (type Timeclass),
+		TDCHit has members Time,
 		*/
 		
 		ChannelKey chankey = anmrdpmt.first;

--- a/UserTools/FindMrdTracks/FindMrdTracks.cpp
+++ b/UserTools/FindMrdTracks/FindMrdTracks.cpp
@@ -338,7 +338,7 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 				if(DrawTruthTracks){
 					for(int truetracki=0; truetracki<numtracks; truetracki++){
 						MCParticle nextrack = MCParticles->at(truetracki);
-						if((subeventnumthisevent2.at(truetracki)<0)&&(nextrack.GetStartTime().GetNs()<endtime)
+						if((subeventnumthisevent2.at(truetracki)<0)&&(nextrack.GetStartTime()<endtime)
 							&&(nextrack.GetPdgCode()!=11)){
 							Position startvp = nextrack.GetStartVertex();
 							TVector3 startv(startvp.X()*100.,startvp.Y()*100.,startvp.Z()*100.);

--- a/UserTools/FindMrdTracks/FindMrdTracks.h
+++ b/UserTools/FindMrdTracks/FindMrdTracks.h
@@ -7,7 +7,6 @@
 #include "Tool.h"
 #include "Geometry.h"
 #include "ChannelKey.h"
-#include "TimeClass.h"
 #include "Hit.h"
 #include "MRDSubEventClass.hh"      // a class for defining subevents
 #include "MRDTrackClass.hh"         // a class for defining MRD tracks

--- a/UserTools/HistogramsRootLAPPDData/HistogramsRootLAPPDData.h
+++ b/UserTools/HistogramsRootLAPPDData/HistogramsRootLAPPDData.h
@@ -10,7 +10,6 @@
 #include "Tool.h"
 #include "LAPPDHit.h"
 #include "LAPPDresponse.hh"
-#include "TimeClass.h"
 #include "LAPPDPulse.h"
 class HistogramsRootLAPPDData: public Tool {
 

--- a/UserTools/HistogramsRootLAPPDData/LAPPDresponse.cpp
+++ b/UserTools/HistogramsRootLAPPDData/LAPPDresponse.cpp
@@ -4,7 +4,6 @@
 #include "TFile.h"
 #include "TH1.h"
 #include "TF1.h"
-#include "TimeClass.h"
 #include <vector>
 #include <iostream>
 #include <cmath>

--- a/UserTools/LAPPDSim/LAPPDresponse.cpp
+++ b/UserTools/LAPPDSim/LAPPDresponse.cpp
@@ -4,7 +4,6 @@
 #include "TFile.h"
 #include "TH1.h"
 #include "TF1.h"
-#include "TimeClass.h"
 #include <vector>
 #include <iostream>
 #include <cmath>

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp.trial
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp.trial
@@ -2,7 +2,6 @@
 
 #include "LoadWCSimLAPPD.h"
 #include <numeric>  // iota
-#include "TimeClass.h"
 
 LoadWCSimLAPPD::LoadWCSimLAPPD():Tool(){}
 
@@ -79,9 +78,9 @@ bool LoadWCSimLAPPD::Execute(){
   	
 	if(verbose) cout<<"Tool LoadWCSimLAPPD getting next entry "<<endl;
 	
-	//LAPPDHit(int tubeid, TimeClass thetime, double charge, std::vector<double> Position, std::vector<double> LocalPosition, double tpsec)
+	//LAPPDHit(int tubeid, double thetime, double charge, std::vector<double> Position, std::vector<double> LocalPosition, double tpsec)
 	int lappdid=1;
-	TimeClass timens(1.);
+	double timens(1.);
 	double charge=1.;
 	std::vector<double> globalpos{1.,1.,1.};
 	std::vector<double> localpos{1.,1.};

--- a/UserTools/MRDPulseFinder/MRDPulseFinder.cpp
+++ b/UserTools/MRDPulseFinder/MRDPulseFinder.cpp
@@ -77,7 +77,7 @@ std::vector<ADCPulse> MRDPulseFinder::FindPulse(vector<short unsigned int>* some
   int binfin=0;
   double Q=0.;
   double peak=0.;
-  TimeClass peaktime(0);
+  double peaktime=0;
   double low=0.;
   double hi=0.;
   double pktime=0.;
@@ -192,7 +192,7 @@ std::vector<ADCPulse> MRDPulseFinder::FindPulse(vector<short unsigned int>* some
     if((curval-bline)>thresh){
 
       length++;
-      if((curval-bline)>peak){peak=(curval-bline); peaktime=TimeClass(bbb); pktime=2*((double)bbb);}
+      if((curval-bline)>peak){peak=(curval-bline); peaktime=bbb; pktime=2*((double)bbb);}
       Q+=((*someWave)[bbb]);
       if(!pulsebeg) low=2*((double)bbb);
       pulsebeg=true;

--- a/UserTools/MRDPulseFinder/MRDPulseFinder.h
+++ b/UserTools/MRDPulseFinder/MRDPulseFinder.h
@@ -8,7 +8,6 @@
 #include "ChannelKey.h"
 #include "Waveform.h"
 #include "ADCPulse.h"
-#include "TimeClass.h"
 #include "CalibratedADCWaveform.h"
 
 class MRDPulseFinder: public Tool {

--- a/UserTools/RawLoader/RawLoader.cpp
+++ b/UserTools/RawLoader/RawLoader.cpp
@@ -269,7 +269,7 @@ bool RawLoader::Execute() {
         }
 
         // Create a new raw waveform object for the current minibuffer
-        raw_waveforms.emplace_back( TimeClass(ns_since_epoch), minibuffer_data);
+        raw_waveforms.emplace_back( ns_since_epoch, minibuffer_data);
       }
 
       raw_waveform_map[ck] = raw_waveforms;


### PR DESCRIPTION
Second round of purging of TimeClass for times other than trigger times.
All other times should be `double`s representing nanoseconds since the Trigger. 