### PR TITLE
prevent autoloading warnings 

### DIFF
--- a/Setup.sh
+++ b/Setup.sh
@@ -7,7 +7,7 @@ ToolDAQapp=`pwd`
 source ${ToolDAQapp}/ToolDAQ/root/bin/thisroot.sh
 
 export LD_LIBRARY_PATH=${ToolDAQapp}/lib:${ToolDAQapp}/ToolDAQ/zeromq-4.0.7/lib:${ToolDAQapp}/ToolDAQ/boost_1_66_0/install/lib:${ToolDAQapp}/ToolDAQ/root/lib:${ToolDAQapp}/ToolDAQ/WCSimLib/:${ToolDAQapp}/ToolDAQ/MrdTrackLib/src:$LD_LIBRARY_PATH
-export ROOT_INCLUDE_PATH=${TOOLANALYSIS_ROOT}/ToolDAQ/WCSimLib/include/:${TOOLANALYSIS_ROOT}/ToolDAQ/MrdTrackLib/include:$ROOT_INCLUDE_PATH
+export ROOT_INCLUDE_PATH=${ToolDAQapp}/ToolDAQ/WCSimLib/include/:${ToolDAQapp}/ToolDAQ/MrdTrackLib/include:$ROOT_INCLUDE_PATH
 
 for folder in `ls -d ${ToolDAQapp}/UserTools/*/ `
 do

--- a/Setup.sh
+++ b/Setup.sh
@@ -7,6 +7,7 @@ ToolDAQapp=`pwd`
 source ${ToolDAQapp}/ToolDAQ/root/bin/thisroot.sh
 
 export LD_LIBRARY_PATH=${ToolDAQapp}/lib:${ToolDAQapp}/ToolDAQ/zeromq-4.0.7/lib:${ToolDAQapp}/ToolDAQ/boost_1_66_0/install/lib:${ToolDAQapp}/ToolDAQ/root/lib:${ToolDAQapp}/ToolDAQ/WCSimLib/:${ToolDAQapp}/ToolDAQ/MrdTrackLib/src:$LD_LIBRARY_PATH
+export ROOT_INCLUDE_PATH=${TOOLANALYSIS_ROOT}/ToolDAQ/WCSimLib/include/:${TOOLANALYSIS_ROOT}/ToolDAQ/MrdTrackLib/include:$ROOT_INCLUDE_PATH
 
 for folder in `ls -d ${ToolDAQapp}/UserTools/*/ `
 do

--- a/SetupFNAL.sh
+++ b/SetupFNAL.sh
@@ -9,7 +9,7 @@ TOOLANALYSIS_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source /cvmfs/annie.opensciencegrid.org/setup_annie.sh --local
 
 export LD_LIBRARY_PATH=${TOOLANALYSIS_ROOT}/lib:${TOOLANALYSIS_ROOT}/ToolDAQ/ToolDAQFramework/lib/:${TOOLANALYSIS_ROOT}/ToolDAQ/zeromq-4.0.7/lib:${TOOLANALYSIS_ROOT}/ToolDAQ/WCSimLib:${TOOLANALYSIS_ROOT}/ToolDAQ/MrdTrackLib/src:$LD_LIBRARY_PATH
-export ROOT_INCLUDE_PATH=${TOOLANALYSIS_ROOT}/ToolDAQ/WCSimLib/include/:$ROOT_INCLUDE_PATH
+export ROOT_INCLUDE_PATH=${TOOLANALYSIS_ROOT}/ToolDAQ/WCSimLib/include/:${TOOLANALYSIS_ROOT}/ToolDAQ/MrdTrackLib/include:$ROOT_INCLUDE_PATH
 
 for folder in `ls -d ${TOOLANALYSIS_ROOT}/UserTools/*/ `
 do

--- a/SetupFNAL.sh
+++ b/SetupFNAL.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# Saves the directory where this script is located to the TOOLANALYSIS_ROOT
+# Saves the directory where this script is located to the ToolDAQapp
 # variable. This method isn't foolproof. See
 # https://stackoverflow.com/a/246128/4081973 if you need something more robust
 # for edge cases (e.g., you're calling the script using symlinks).
-TOOLANALYSIS_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ToolDAQapp="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source /cvmfs/annie.opensciencegrid.org/setup_annie.sh --local
 
-export LD_LIBRARY_PATH=${TOOLANALYSIS_ROOT}/lib:${TOOLANALYSIS_ROOT}/ToolDAQ/ToolDAQFramework/lib/:${TOOLANALYSIS_ROOT}/ToolDAQ/zeromq-4.0.7/lib:${TOOLANALYSIS_ROOT}/ToolDAQ/WCSimLib:${TOOLANALYSIS_ROOT}/ToolDAQ/MrdTrackLib/src:$LD_LIBRARY_PATH
-export ROOT_INCLUDE_PATH=${TOOLANALYSIS_ROOT}/ToolDAQ/WCSimLib/include/:${TOOLANALYSIS_ROOT}/ToolDAQ/MrdTrackLib/include:$ROOT_INCLUDE_PATH
+export LD_LIBRARY_PATH=${ToolDAQapp}/lib:${ToolDAQapp}/ToolDAQ/ToolDAQFramework/lib/:${ToolDAQapp}/ToolDAQ/zeromq-4.0.7/lib:${ToolDAQapp}/ToolDAQ/WCSimLib:${ToolDAQapp}/ToolDAQ/MrdTrackLib/src:$LD_LIBRARY_PATH
+export ROOT_INCLUDE_PATH=${ToolDAQapp}/ToolDAQ/WCSimLib/include/:${ToolDAQapp}/ToolDAQ/MrdTrackLib/include:$ROOT_INCLUDE_PATH
 
-for folder in `ls -d ${TOOLANALYSIS_ROOT}/UserTools/*/ `
+for folder in `ls -d ${ToolDAQapp}/UserTools/*/ `
 do
     export PYTHONPATH=$folder:${PYTHONPATH}
 done


### PR DESCRIPTION
by passing path to headers for ROOT custom classes to ROOT_INCLUDE_PATH in Setup.sh and SetupFNAL.sh.
These 'errors' should only be warnings safe to ignore unless you want to write those custom classes to ROOT files (which is unlikely anyway), but they've confused several people and clutter the output.