### PR TITLE
MCParticles loaded into store with time relative to trigger

### DIFF
--- a/DataModel/MinuitOptimizer.cpp
+++ b/DataModel/MinuitOptimizer.cpp
@@ -392,7 +392,8 @@ void MinuitOptimizer::TimePropertiesLnL(double vtxTime, double vtxParam, double&
   double delta = 0.0;       // time residual of each hit
   double sigma = 0.0;       // time resolution of each hit
   double A = 0.0;           // normalisation of first Gaussian
-
+  int type;                 // Digit type (LAPPD or PMT)
+  
   double Preal = 0.0;       // probability of real hit
   double P = 0.0;           // probability of hit
 
@@ -410,8 +411,8 @@ void MinuitOptimizer::TimePropertiesLnL(double vtxTime, double vtxParam, double&
   // add noise to model
   // ==================
   double nFilterDigits = this->fVtxGeo->GetNFilterDigits(); 
-  double Pnoise = fTimeFitNoiseRate/nFilterDigits;//FIXME
-  Pnoise = 1e-8;//FIXME
+  double Pnoise; 
+  //Pnoise = fTimeFitNoiseRate/nFilterDigits;//FIXME
   
   //bool istruehits = (Interface::Instance())->IsTrueHits();
   bool istruehits = 0; // for test only. JW
@@ -423,7 +424,15 @@ void MinuitOptimizer::TimePropertiesLnL(double vtxTime, double vtxParam, double&
     	int detType = this->fVtxGeo->GetDigitType(idigit); 
       delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
       sigma = this->fVtxGeo->GetDeltaSigma(idigit);
-      sigma = 1.2*sigma; 
+      type = this->fVtxGeo->GetDigitType(idigit);
+      if (type == RecoDigit::PMT8inch){  //PMT8Inch
+        sigma = 1.5*sigma;
+        Pnoise = 1e-8; //FIXME; Need implementation of noise model 
+      } 
+      if (type == RecoDigit::lappd_v0){  //lappd
+        sigma = 1.2*sigma;
+        Pnoise = 1e-8;  //FIXME; Need implementation of noise model 
+      }
       A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
       Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
       P = (1.0-Pnoise)*Preal + Pnoise; 

--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -186,7 +186,7 @@ bool DigitBuilder::BuildPMTRecoDigit() {
 					//if(v_message<verbosity) ahit.Print(); // << VERY verbose
 					// get calibrated PMT time (Use the MC time for now)
 					//calT = ahit.GetTime()*1.0;
-					calT = ahit.GetTime()*1.0 - 950.0; // remove 950 ns offs
+					calT = ahit.GetTime()*1.0; // remove 950 ns offs
 					calQ = ahit.GetCharge();
 					digitType = RecoDigit::PMT8inch;
 					RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType, PMTId);

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -243,7 +243,6 @@ bool LoadWCSim::Execute(){
 		EventTimeNs = atrigt->GetHeader()->GetDate();
 		EventTime->SetNs(EventTimeNs);
 		if(verbose>2) cout<<"EventTime is "<<EventTimeNs<<"ns"<<endl;
-		
 		if(verbose>1) cout<<"getting "<<atrigt->GetNtrack()<<" tracks"<<endl;
 		for(int tracki=0; tracki<atrigt->GetNtrack(); tracki++){
 			if(verbose>2) cout<<"getting track "<<tracki<<endl;
@@ -272,12 +271,12 @@ bool LoadWCSim::Execute(){
 			tracktype startstoptype = tracktype::UNDEFINED;
 			
 			//nextrack->GetFlag()!=-1 ????? do we need to skip/override anything for these?
-			
+		        //MC particle times now stored relative to the trigger time	
 			MCParticle thisparticle(
 				nextrack->GetIpnu(), nextrack->GetE(), nextrack->GetEndE(),
 				Position(nextrack->GetStart(0) / 100., nextrack->GetStart(1) / 100., nextrack->GetStart(2) / 100.),
 				Position(nextrack->GetStop(0) / 100., nextrack->GetStop(1) / 100., nextrack->GetStop(2) / 100.),
-				(static_cast<double>(nextrack->GetTime())), (static_cast<double>(nextrack->GetStopTime())),
+				(static_cast<double>(nextrack->GetTime()-EventTimeNs)), (static_cast<double>(nextrack->GetStopTime()-EventTimeNs)),
 				Direction(nextrack->GetDir(0), nextrack->GetDir(1), nextrack->GetDir(2)),
 				(sqrt(pow(nextrack->GetStop(0)-nextrack->GetStart(0),2.)+
 					 pow(nextrack->GetStop(1)-nextrack->GetStart(1),2.)+


### PR DESCRIPTION
There are several small changes made in this pull request:
  - MCParticles would now be loaded to the store relative to the trigger time.  This would put the particles in the same time frame as the LAPPDs and the PMTs.
  - A hard-coded historic trigger offset in the DigitBuilder tool has been removed.  The trigger offset is already handled in the LoadWCSim tool.
  - The MinuitOptimizer now applies a different weight to the LAPPD and PMT sigmas in the time likelihood function.  This change is made to have ToolAnalysis more closely resemble the DoE proposal's likelihood function.

Regarding the change to LoadWCSim, I have confirmed with Marcus that this change is all right.  @marc1uk, can you have one last look and confirm I have applied the time shift appropriately?