### PR TITLE
Some hotfixes in reconstruction tools; option to not use Minuit for position fit in PointPosFinder

### DIFF
--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -185,7 +185,6 @@ bool DigitBuilder::BuildPMTRecoDigit() {
 			  	//ahit.Print();
 					//if(v_message<verbosity) ahit.Print(); // << VERY verbose
 					// get calibrated PMT time (Use the MC time for now)
-					//calT = ahit.GetTime()*1.0;
 					calT = ahit.GetTime()*1.0; // remove 950 ns offs
 					calQ = ahit.GetCharge();
 					digitType = RecoDigit::PMT8inch;
@@ -223,7 +222,7 @@ bool DigitBuilder::BuildLAPPDRecoDigit() {
 			//Tube ID is different from that in ANNIEReco
 			LAPPDId = det.GetDetectorId();
 			//if(LAPPDId != 266 && LAPPDId != 271 && LAPPDId != 236 && LAPPDId != 231 && LAPPDId != 206) continue;
-			//if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue;
+			if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue;
                         if(chankey.GetSubDetectorType()==subdetector::LAPPD){ // redundant
 				std::vector<LAPPDHit>& hits = apair.second;
 				for(LAPPDHit& ahit : hits){

--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -222,7 +222,7 @@ bool DigitBuilder::BuildLAPPDRecoDigit() {
 			//Tube ID is different from that in ANNIEReco
 			LAPPDId = det.GetDetectorId();
 			//if(LAPPDId != 266 && LAPPDId != 271 && LAPPDId != 236 && LAPPDId != 231 && LAPPDId != 206) continue;
-			if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue;
+			//if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue;
                         if(chankey.GetSubDetectorType()==subdetector::LAPPD){ // redundant
 				std::vector<LAPPDHit>& hits = apair.second;
 				for(LAPPDHit& ahit : hits){

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -238,7 +238,6 @@ bool EventSelector::EventSelectionByMCTruthInfo() {
   	  || (trueVtxZ > fidcutz) ){
   return false;
   }	
-  /* 
   // mrd cut
   double muonStopX, muonStopY, muonStopZ;
   muonStopX = fMuonStopVertex->GetPosition().X();
@@ -256,7 +255,7 @@ bool EventSelector::EventSelectionByMCTruthInfo() {
   	|| muonStopX<-1.0*mrdWidthX || muonStopX>mrdWidthX
   	|| muonStopY<-1.0*mrdHeightY || muonStopY>mrdHeightY) {
     return false;	
-  }*/
+  }
   return true;
 }
 

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -238,7 +238,9 @@ bool EventSelector::EventSelectionByMCTruthInfo() {
   	  || (trueVtxZ > fidcutz) ){
   return false;
   }	
+  
   // mrd cut
+  /*
   double muonStopX, muonStopY, muonStopZ;
   muonStopX = fMuonStopVertex->GetPosition().X();
   muonStopY = fMuonStopVertex->GetPosition().Y();
@@ -256,6 +258,7 @@ bool EventSelector::EventSelectionByMCTruthInfo() {
   	|| muonStopY<-1.0*mrdHeightY || muonStopY>mrdHeightY) {
     return false;	
   }
+  */
   return true;
 }
 

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -71,7 +71,8 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
   if (muonRecoDebug_fill){
     fRecoTree->Branch("seedVtxX",&fSeedVtxX); 
     fRecoTree->Branch("seedVtxY",&fSeedVtxY); 
-    fRecoTree->Branch("seedVtxZ",&fSeedVtxZ); 
+    fRecoTree->Branch("seedVtxZ",&fSeedVtxZ);
+    fRecoTree->Branch("seedVtxFOM",&fSeedVtxFOM); 
     fRecoTree->Branch("seedVtxTime",&fSeedVtxTime,"seedVtxTime/D");
     
     fRecoTree->Branch("pointPosX",&fPointPosX,"pointPosX/D");
@@ -85,7 +86,7 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
     fRecoTree->Branch("pointDirY",&fPointDirY,"pointDirY/D");
     fRecoTree->Branch("pointDirZ",&fPointDirZ,"pointDirZ/D");
     fRecoTree->Branch("pointDirTime",&fPointDirTime,"pointDirTime/D");
-    fRecoTree->Branch("pointDirStatus",&fPointDirStatus,"pointDirStatus/D");
+    fRecoTree->Branch("pointDirStatus",&fPointDirStatus,"pointDirStatus/I");
     fRecoTree->Branch("pointDirFOM",&fPointDirFOM,"pointDirFOM/D");
     
     fRecoTree->Branch("pointVtxPosX",&fPointVtxPosX,"pointVtxPosX/D");
@@ -96,7 +97,7 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
     fRecoTree->Branch("pointVtxDirY",&fPointVtxDirY,"pointVtxDirY/D");
     fRecoTree->Branch("pointVtxDirZ",&fPointVtxDirZ,"pointVtxDirZ/D");
     fRecoTree->Branch("pointVtxFOM",&fPointVtxFOM,"pointVtxFOM/D");
-    fRecoTree->Branch("pointVtxStatus",&fPointVtxStatus,"pointVtxStatus/D");
+    fRecoTree->Branch("pointVtxStatus",&fPointVtxStatus,"pointVtxStatus/I");
   } 
 
   // Difference in MC Truth and Muon Reconstruction Analysis
@@ -233,7 +234,7 @@ bool PhaseIITreeMaker::Execute(){
   if (muonRecoDebug_fill){
     // Read Seed candidates   
     std::vector<RecoVertex>* seedvtxlist = 0;
-    auto get_seedvtxlist = m_data->Stores.at("RecoEvent")->Get("vSeedVtxList",seedvtxlist);  ///> Get List of seeds from "RecoEvent" 
+    auto get_seedvtxlist = m_data->Stores.at("RecoEvent")->Get("vSeedVtxList",seedvtxlist);  ///> Get List of seeds from "RecoEvent"
     if(get_seedvtxlist){
       for( auto& seed : *seedvtxlist ){
         fSeedVtxX.push_back(seed.GetPosition().X());
@@ -244,7 +245,16 @@ bool PhaseIITreeMaker::Execute(){
     } else {  
   	Log("PhaseIITreeMaker  Tool: No Seed List found.  Continuing to build tree ",v_message,verbosity); 
     }
-
+    std::vector<double>* seedfomlist = 0;
+    auto get_seedfomlist = m_data->Stores.at("RecoEvent")->Get("vSeedFOMList",seedfomlist);  ///> Get List of seed FOMs from "RecoEvent" 
+    if(get_seedfomlist){
+      for( auto& seedFOM : *seedfomlist ){
+        fSeedVtxFOM.push_back(seedFOM);
+      }
+    } else {  
+  	Log("PhaseIITreeMaker  Tool: No Seed FOM List found.  Continuing to build tree ",v_message,verbosity); 
+    }
+    
     // Read PointPosition-fitted Vertex   
     RecoVertex* pointposvtx = 0;
     auto get_pointposdata = m_data->Stores.at("RecoEvent")->Get("PointPosition",pointposvtx);
@@ -345,6 +355,7 @@ void PhaseIITreeMaker::ResetVariables() {
     fSeedVtxX.clear();
     fSeedVtxY.clear();
     fSeedVtxZ.clear();
+    fSeedVtxFOM.clear();
     fSeedVtxTime = 0;
     fPointPosX = 0;
     fPointPosY = 0;

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
@@ -73,6 +73,7 @@ class PhaseIITreeMaker: public Tool {
   std::vector<double> fSeedVtxX;
   std::vector<double> fSeedVtxY;
   std::vector<double> fSeedVtxZ;
+  std::vector<double> fSeedVtxFOM;
   double fSeedVtxTime;
   
   // Reco vertex

--- a/UserTools/VtxPointPositionFinder/README.md
+++ b/UserTools/VtxPointPositionFinder/README.md
@@ -14,6 +14,17 @@ Describe any data formats VtxPointPositionFinder creates, destroys, changes, or 
 Describe any configuration variables for VtxPointPositionFinder.
 
 ```
-param1 value1
-param2 value2
+UseTrueVertexAsSeed bool
+If true, any information from the seed list is not used.  The True MC Vertex will instead be used
+as the input to the Minuit-based Point Position fitting algorithm.
+
+UseMinuitForPos bool
+If true, Minuit is used to vary both the position and time to find the highest point position
+FOM.  Initial fit parameters will be the vertex seed the highest FOM, or the True MC Vertex.
+
+If false, the seed with the highest FOM (whose vertex time was fit using Minuit) will be returned
+ as the point position vertex.
+
+If both of the above are false, the Point Position vertex is set equal to the true MC Vertex.
+
 ```

--- a/UserTools/VtxPointPositionFinder/VtxPointPositionFinder.cpp
+++ b/UserTools/VtxPointPositionFinder/VtxPointPositionFinder.cpp
@@ -89,8 +89,9 @@ bool VtxPointPositionFinder::Execute(){
       fPointPosition  = (RecoVertex*)(this->FitPointPosition(fTrueVertex));
     } else {
       Log("VtxPointPositionFinder Tool: You've chosen to use MC truth information but not use Minuit for position fit... returning True MC vertex as Point Position",v_message,verbosity);
-      fPointPosition = fTrueVertex;
-    // Push fitted vertex to RecoEvent store
+    RecoVertex* newVertex = new RecoVertex();
+    newVertex->CloneVertex(fTrueVertex);
+    fPointPosition = (RecoVertex*)(newVertex);
     this->PushPointPosition(fPointPosition, true);
     }
   

--- a/UserTools/VtxPointPositionFinder/VtxPointPositionFinder.h
+++ b/UserTools/VtxPointPositionFinder/VtxPointPositionFinder.h
@@ -50,12 +50,20 @@ class VtxPointPositionFinder: public Tool {
  		
  	/// \brief Push fitted point position to store
  	void PushPointPosition(RecoVertex* vtx, bool savetodisk);
+
+ 	/// \brief Push vtx seed FOMs to store
+ 	void PushVertexSeedFOMList(bool savetodisk);
  	
  	bool fUseTrueVertexAsSeed;
+ 	bool fUseMinuit; //If True, give the best GridSeed to the Minuit Optimizer
+
  	RecoVertex* fTrueVertex = 0;
  	std::vector<RecoDigit>* fDigitList = 0;
- 		
- 	/// \brief Simple position
+
+	// Create an object to store the Grid Seed FOMs 
+        std::vector<double>* vSeedFOMList;
+ 	
+        /// \brief Simple position
  	RecoVertex* fSimplePosition = 0;
  	
  	/// \brief Point position

--- a/UserTools/VtxSeedGenerator/README.md
+++ b/UserTools/VtxSeedGenerator/README.md
@@ -18,14 +18,15 @@ Describe any configuration variables for VtxSeedGenerator.
 	m_variables.Get("NumberOfSeeds", fNumSeeds);
 	m_variables.Get("verbosity", verbosity);
 	m_variables.Get("UseSeedGrid", UseSeedGrid);
+
 SeedType (int)
 NumberOfSeeds (int)
 verbosity (int)
 UseSeedGrid (bool)
 
 SeedType specifies whether to use PMTs, LAPPDs, or all. 
-SeedType 0: Use only LAPPDs for seed
-SeedType 1: User only LAPPDs for seed
+SeedType 0: Use only LAPPDs for calculating median seed time
+SeedType 1: User only LAPPDs for calculating median seed time
 SeedType 2: Use both the LAPPDs and the PMTs
  
 NumberOfSeeds specifies how many points to generate in the grid, or how

--- a/UserTools/VtxSeedGenerator/README.md
+++ b/UserTools/VtxSeedGenerator/README.md
@@ -25,7 +25,7 @@ verbosity (int)
 UseSeedGrid (bool)
 
 SeedType specifies whether to use PMTs, LAPPDs, or all. 
-SeedType 0: Use only LAPPDs for calculating median seed time
+SeedType 0: Use only PMTs for calculating median seed time
 SeedType 1: User only LAPPDs for calculating median seed time
 SeedType 2: Use both the LAPPDs and the PMTs
  

--- a/UserTools/VtxSeedGenerator/VtxSeedGenerator.cpp
+++ b/UserTools/VtxSeedGenerator/VtxSeedGenerator.cpp
@@ -151,7 +151,7 @@ bool VtxSeedGenerator::GenerateSeedGrid(int NSeeds) {
   //Assuming roughly equal distance, we can calculate the number of
   //layers needed to have close to even spacing, and # points on each disk
   double approx_points = pow((NSeeds*tankradius/tanklength),(2.0/3.0));
-  int numlayers = (int) pow(pow(tankradius,2)/approx_points,(1.0/2.0));
+  int numlayers = (int) (tanklength/pow(pow(tankradius,2)/approx_points,(1.0/2.0)));
   int points_ondisk = (int) approx_points;
 
   //Now, fill a vector of doubles with the xy plane points 

--- a/configfiles/PhaseIIReco/VtxPointPositionFinderConfig
+++ b/configfiles/PhaseIIReco/VtxPointPositionFinderConfig
@@ -2,7 +2,4 @@
 
 verbosity 3
 UseTrueVertexAsSeed 0
-
-
-
-
+UseMinuitForPos 1


### PR DESCRIPTION
This pull request will make several changes to reconstruction-specific tools:

   - Hotfixes to the VtxSeedGenerator and PhaseIITreeMaker tools
   - The VtxPointPosition finder tool now has the option for not using Minuit to fit both position and time.  Instead, the seed position, and it's fit simple position time, with the highest figure of merit can be claimed as the point position vertex.  
   - Only accepting digits from the 5 LAPPDs proposed for Phase II is now the default for the DigitBuilder tool.
   - When using the EventSelector tool with the MCTruthCut flag set, rejecting events that do not stop in the MRD is now the default.

Also, a small note that "f_NoPointPos" is a poor name for this feature; the PointPositionFinder tool is still necessary in the reconstruction chain, but the feature reduces the dependency on Minuit.