### PR TITLE
New Prompt Trigger selection feature in EventBuilder tool

### DIFF
--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -59,19 +59,6 @@ bool DigitBuilder::Execute(){
   		return false;
 	};
 	
-	/// First, see if this is a delayed trigger in the event
-	auto get_mctrigger = m_data->Stores.at("ANNIEEvent")->Get("MCTriggernum",fMCTriggernum);
-	if(!get_mctrigger){ 
-		Log("DigitBuilder Tool: Error retrieving MCTriggernum from ANNIEEvent!",v_error,verbosity); 
-		return false; 
-	}
-	
-	/// if so, truth analysis is probably not interested in this trigger. Primary muon will not be in the listed tracks.
-	if(fMCTriggernum>0){ 
-		Log("DigitBuilder Tool: Skipping delayed trigger",v_debug,verbosity); 
-		return true;
-	}
-	
 	/// check if EventCutStatus exists
   auto get_evtcutstatus = m_data->Stores.at("RecoEvent")->Get("EventCutStatus",fEventCutStatus);
 	if(!get_evtcutstatus){

--- a/UserTools/DigitBuilder/DigitBuilder.h
+++ b/UserTools/DigitBuilder/DigitBuilder.h
@@ -73,7 +73,6 @@ class DigitBuilder: public Tool {
 	uint32_t fSubrunNumber;    ///< MC has no 'subrun', always 0
 	uint32_t fEventNumber;     ///< flattens the 'event -> trigger' MC hierarchy
 	uint64_t fMCEventNum;      ///< event number in MC file
-	uint16_t fMCTriggernum;    ///< trigger number in MC file
 	std::vector<int> fLAPPDId; ///< selected LAPPDs
 	std::string fPhotodetectorConfiguration; ///< "PMTs_Only", "LAPPDs_Only", "All_Detectors"
 	

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -16,6 +16,7 @@ bool EventSelector::Initialise(std::string configfile, DataModel &data){
   m_variables.Get("verbosity",verbosity);
   m_variables.Get("MRDRecoCut", fMRDRecoCut);
   m_variables.Get("MCTruthCut", fMCTruthCut);
+  m_variables.Get("PromptTrigOnly", fPromptTrigOnly);
 
   /// Construct the other objects we'll be setting at event level,
   fMuonStartVertex = new RecoVertex();
@@ -52,13 +53,13 @@ bool EventSelector::Execute(){
   m_data->Stores.at("ANNIEEvent")->Get("MCEventNum",fMCEventNum);  
   
   // MC trigger number
-  m_data->Stores.at("ANNIEEvent")->Get("MCTriggernum",fMCTriggerNum); 
+  m_data->Stores.at("ANNIEEvent")->Get("MCTriggernum",fMCTriggernum); 
   
   // ANNIE Event number
   m_data->Stores.at("ANNIEEvent")->Get("EventNumber",fEventNumber);
   
   std::string logmessage = "EventSelector Tool: Processing MCEntry "+to_string(fMCEventNum)+
-  	", MCTrigger "+to_string(fMCTriggerNum) + ", Event "+to_string(fEventNumber);
+  	", MCTrigger "+to_string(fMCTriggernum) + ", Event "+to_string(fEventNumber);
 	Log(logmessage,v_message,verbosity);
   
   auto get_geometry= m_data->Stores.at("ANNIEEvent")->Header->Get("AnnieGeometry",fGeometry);
@@ -80,6 +81,10 @@ bool EventSelector::Execute(){
   if(fMCTruthCut){
     bool passMCTruth= this->EventSelectionByMCTruthInfo();
     if(!passMCTruth) fEventCutStatus = false; 
+  }
+  if(fPromptTrigOnly){
+    bool isPromptTrigger= this->PromptTriggerCheck();
+    if(!isPromptTrigger) fEventCutStatus = false; 
   }
   
   //FIXME: This isn't working according to Jingbo
@@ -167,6 +172,22 @@ void EventSelector::PushTrueVertex(bool savetodisk) {
   Log("EventSelector Tool: Push true vertex to the RecoEvent store",v_message,verbosity);
   m_data->Stores.at("RecoEvent")->Set("TrueVertex", fMuonStartVertex, savetodisk); 
 }
+
+bool EventSelector::PromptTriggerCheck() {
+  /// First, see if this is a delayed trigger in the event
+  auto get_mctrigger = m_data->Stores.at("ANNIEEvent")->Get("MCTriggernum",fMCTriggernum);
+  if(!get_mctrigger){ 
+    Log("DigitBuilder Tool: Error retrieving MCTriggernum from ANNIEEvent!",v_error,verbosity); 
+    return false; 
+  }	
+  /// if so, truth analysis is probably not interested in this trigger. Primary muon will not be in the listed tracks.
+  if(fMCTriggernum>0){ 
+    Log("DigitBuilder Tool: This event is not a prompt trigger",v_debug,verbosity); 
+    return false;
+  }
+  return true;
+}
+	
 
 // This function isn't working now, because the MRDTracks store must have been changed. 
 // We have to contact Marcus and ask how we can retieve the MRD track information. 

--- a/UserTools/EventSelector/EventSelector.h
+++ b/UserTools/EventSelector/EventSelector.h
@@ -39,6 +39,13 @@ class EventSelector: public Tool {
  	/// length. If the longest track is stoped inside the MRD, the event is 
  	/// selected
  	bool EventSelectionByMRDReco();
+
+ 	/// \brief Event selection by trigger number
+ 	///
+ 	/// The selection is based on the trigger number for the event
+ 	/// in the store "ANNIEEvent".  Events are selected if they have
+ 	/// an MCTriggernum == 0 (i.e. they are a prompt trigger) 
+ 	bool PromptTriggerCheck();
  	
  	/// \brief Event selection by fidicual volume
  	///
@@ -65,7 +72,7 @@ class EventSelector: public Tool {
   uint64_t fMCEventNum;
   
   /// \brief trigger number
-  uint16_t fMCTriggerNum;
+  uint16_t fMCTriggernum;
   
   /// \brief ANNIE event number
   uint32_t fEventNumber;
@@ -81,6 +88,7 @@ class EventSelector: public Tool {
 	std::string fInputfile;
 	bool fMRDRecoCut = false;
 	bool fMCTruthCut = false;
+        bool fPromptTrigOnly = true;
 	bool fEventCutStatus;
 
 	/// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.

--- a/UserTools/EventSelector/README.md
+++ b/UserTools/EventSelector/README.md
@@ -9,6 +9,8 @@ various event selection criteria.  Current event selection flags that can be
 utilized include:
   - MRDRecoCut Flags muon events that reconstruct within a defined radius and height
   - MCTruthCut: Flags MC muon events generated within a defined radius and height 
+  - PromptTrigOnly: Flags muon events that do not have an MCTriggernum of 0
+                    (any store event with MCTriggernum>0 is a delayed trigger)
 
 For each event, all cuts defined with the config file are checked.  If the event
 passes all cuts, EventCutStatus is set to true and saved to the RecoEvent store.
@@ -28,4 +30,5 @@ master EventCutStatus bit checked by all following tools
 verbosity bool
 MRDRecoCut (1 or 0)
 MCTruthCut (1 or 0)
+PromptTrigOnly (1 or 0)
 ```

--- a/configfiles/PhaseIIReco/EventSelectorConfig
+++ b/configfiles/PhaseIIReco/EventSelectorConfig
@@ -3,3 +3,4 @@
 verbosity 3
 MCTruthCut 1
 MRDRecoCut 0
+PromptTrigOnly 1

--- a/configfiles/PhaseIIRecoTruth/EventSelectorConfig
+++ b/configfiles/PhaseIIRecoTruth/EventSelectorConfig
@@ -3,3 +3,4 @@
 verbosity 3
 MCTruthCut 1
 MRDRecoCut 0
+PromptTrigOnly 1


### PR DESCRIPTION
This PR adds a new feature to the EventSelector tool for reconstructing prompt triggers only.  Using this event selection criteria is configurable through the PromptTrigOnly bool now settable in EventSelectorConfig files.

This selection criteria was originally hard-coded into the DigitBuilder tool, and has been removed.