### PR TITLE
bugfix in LoadWCSimLAPPD

### DIFF
--- a/UserTools/Factory/Factory.cpp
+++ b/UserTools/Factory/Factory.cpp
@@ -61,5 +61,6 @@ if (tool=="VtxExtendedVertexFinder") ret=new VtxExtendedVertexFinder;
 if (tool=="VtxPointDirectionFinder") ret=new VtxPointDirectionFinder;
 if (tool=="VtxPointVertexFinder") ret=new VtxPointVertexFinder;
 if (tool=="LoadCCData") ret=new LoadCCData;
+if (tool=="HitResiduals") ret=new HitResiduals;
 return ret;
 }

--- a/UserTools/HitResiduals/HitResiduals.cpp
+++ b/UserTools/HitResiduals/HitResiduals.cpp
@@ -1,0 +1,169 @@
+/* vim:set noexpandtab tabstop=4 wrap */
+#include "HitResiduals.h"
+
+#include "TApplication.h"
+#include "TSystem.h"
+#include "TCanvas.h"
+#include "TROOT.h"
+#include "TH1.h"
+#include "TLegend.h"
+
+#include <thread>         // std::this_thread::sleep_for
+#include <chrono>         // std::chrono::seconds
+
+HitResiduals::HitResiduals():Tool(){}
+
+const double SPEED_OF_LIGHT=29.9792458; // cm/ns - match time and position units of PMT
+const double REF_INDEX_WATER=1.42535;   // maximum Rindex gives maximum travel time
+
+bool HitResiduals::Initialise(std::string configfile, DataModel &data){
+	
+	/////////////////// Usefull header ///////////////////////
+	if(configfile!="")	m_variables.Initialise(configfile); //loading config file
+	//m_variables.Print();
+	
+	m_data= &data; //assigning transient data pointer
+	/////////////////////////////////////////////////////////////////
+	
+	Double_t canvwidth = 700;
+	Double_t canvheight = 600;
+	// create the ROOT application to show histograms
+	int myargc=0;
+	char *myargv[] = {(const char*)"somestring"};
+	hitResidualApp = new TApplication("HitResidualApp",&myargc,myargv);
+	htimeresidpmt = new TH1D("htimeresidpmt","PMT Digit Time residual",300,-10,25);
+	htimeresidlappd = new TH1D("htimeresidlappd","LAPPD Digit Time residual",300,-10,25);
+	hitResidCanv = new TCanvas("hitResidCanv","hitResidCanv",canvwidth,canvheight);
+	
+	return true;
+}
+
+
+bool HitResiduals::Execute(){
+	
+	int annieeventexists = m_data->Stores.count("ANNIEEvent");
+	if(!annieeventexists){ cerr<<"no ANNIEEvent store!"<<endl; return false;};
+	get_ok = m_data->Stores["ANNIEEvent"]->Get("EventTime",EventTime);
+	if(get_ok==0){ cerr<<"No EventTime in ANNIEEVENT!"<<endl; return false; }
+	get_ok = m_data->Stores["ANNIEEvent"]->Get("MCParticles",MCParticles);
+	if(get_ok==0){ cerr<<"No MCParticles in ANNIEEVENT!"<<endl; return false; }
+	get_ok = m_data->Stores["ANNIEEvent"]->Get("MCHits",MCHits);
+	if(get_ok==0){ cerr<<"No MCHits in ANNIEEVENT!"<<endl; return false; }
+	get_ok = m_data->Stores["ANNIEEvent"]->Get("MCLAPPDHits",MCLAPPDHits);
+	if(get_ok==0){ cerr<<"No MCLAPPDHits in ANNIEEVENT!"<<endl; return false; }
+	get_ok = m_data->Stores["ANNIEEvent"]->Header->Get("AnnieGeometry",anniegeom);
+	if(get_ok==0){ cerr<<"No AnnieGeometry in ANNIEEVENT!"<<endl; return false; }
+	
+	// FIRST GET THE TRIGGER TIME. IF WE HAVE A PROMPT TRIGGER, THIS SHOULD BE 0
+	double triggertime = static_cast<double>(EventTime->GetNs());
+	//if(triggertime!=0) cout<<"Non-zero trigger time: "<<EventTime->GetNs()<<endl;
+	
+	// NEXT GET THE PRIMARY MUON TIME
+	bool mufound=false;
+	MCParticle primarymuon;
+	double muontime;
+	Position muonvertex;
+	if(MCParticles){
+		for(int particlei=0; particlei<MCParticles->size(); particlei++){
+			MCParticle aparticle = MCParticles->at(particlei);
+			//if(v_debug<verbosity) aparticle.Print();     // print if we're being *really* verbose
+			if(aparticle.GetParentPdg()!=0) continue;      // not a primary particle
+			if(aparticle.GetPdgCode()!=13) continue;       // not a muon
+			primarymuon = aparticle;                       // note the particle
+			mufound=true;                                  // note that we found it
+			break;                                         // won't have more than one primary muon
+		}
+		if(mufound){
+			muontime = primarymuon.GetStartTime();
+			muonvertex = primarymuon.GetStartVertex();
+		} else {
+			cerr<<"No Primary Muon"<<endl;
+			return false;
+		}
+	} else {
+		cerr<<"No MCParticles"<<endl;
+		return false;
+	}
+	if(muontime!=0) cout<<"Non-zero muon time: "<<muontime<<endl;
+	
+	// NOW LOOP OVER HITS AND CALCULATE RESIDUALS
+	if(MCHits){
+		cout<<"Num MCHits : "<<MCHits->size()<<endl;
+		// iterate over the map of sensors with a measurement
+		for(std::pair<ChannelKey,std::vector<Hit>>&& apair : *MCHits){
+			ChannelKey chankey = apair.first;
+			Detector thistube = anniegeom->GetDetector(chankey);
+			Position tubeposition = thistube.GetDetectorPosition();
+			double distance = sqrt(pow((tubeposition.X()-muonvertex.X()),2.)+
+								   pow((tubeposition.Y()-muonvertex.Y()),2.)+
+								   pow((tubeposition.Z()-muonvertex.Z()),2.));
+			if(chankey.GetSubDetectorType()==subdetector::ADC){  // ADC, LAPPD, TDC
+				std::vector<Hit>& hits = apair.second;
+				for(Hit& ahit : hits){
+					//if(v_message<verbosity) ahit.Print(); // << VERY verbose
+					double hittime = ahit.GetTime();
+					double expectedarrivaltime = muontime + distance*REF_INDEX_WATER/SPEED_OF_LIGHT;
+					double timeresidual = hittime-expectedarrivaltime;
+					htimeresidpmt->Fill(timeresidual);
+					cout<<"Hittime "<<hittime<<", expected arrival time "<<expectedarrivaltime
+						<<", residual "<<timeresidual<<endl;
+				}
+			}
+		} // end loop over MCHits
+	} else {
+		cout<<"No MCHits"<<endl;
+	}
+	if(MCLAPPDHits){
+		cout<<"Num MCLAPPDHits : "<<MCLAPPDHits->size()<<endl;
+		// iterate over the map of sensors with a measurement
+		for(std::pair<ChannelKey,std::vector<LAPPDHit>>&& apair : *MCLAPPDHits){
+			ChannelKey chankey = apair.first;
+			Detector thistube = anniegeom->GetDetector(chankey);
+			Position tubeposition = thistube.GetDetectorPosition();
+			double distance = sqrt(pow((tubeposition.X()-muonvertex.X()),2.)+
+								   pow((tubeposition.Y()-muonvertex.Y()),2.)+
+								   pow((tubeposition.Z()-muonvertex.Z()),2.));
+			if(chankey.GetSubDetectorType()==subdetector::LAPPD){  // ADC, LAPPD, TDC
+				std::vector<LAPPDHit>& hits = apair.second;
+				for(LAPPDHit& ahit : hits){
+					//if(v_message<verbosity) ahit.Print(); // << VERY verbose
+					double hittime = ahit.GetTime();
+					double expectedarrivaltime = muontime + distance*REF_INDEX_WATER/SPEED_OF_LIGHT;
+					double timeresidual = hittime-expectedarrivaltime;
+					htimeresidlappd->Fill(timeresidual);
+					cout<<"LAPPDHittime "<<hittime<<", expected arrival time "<<expectedarrivaltime
+						<<", residual "<<timeresidual<<endl;
+				}
+			}
+		} // end loop over MCLAPPDHits
+	} else {
+		cout<<"No MCLAPPDHits"<<endl;
+	}
+	
+	return true;
+}
+
+
+bool HitResiduals::Finalise(){
+	
+	gSystem->ProcessEvents();
+	hitResidCanv->cd();
+	htimeresidpmt->SetLineColor(kBlue);
+	htimeresidlappd->SetLineColor(kRed);
+	htimeresidpmt->Draw();
+	htimeresidlappd->Draw("same");
+	hitResidCanv->BuildLegend();
+	hitResidCanv->SaveAs("HitTimeResiduals.png");
+	while(gROOT->FindObject("htimeresidpmt")!=nullptr){
+		gSystem->ProcessEvents();
+		std::this_thread::sleep_for(std::chrono::seconds(1));
+	}
+	
+	// cleanup track drawing TApplication
+	if(htimeresidpmt) delete htimeresidpmt;
+	if(htimeresidlappd) delete htimeresidlappd;
+	if(hitResidCanv) delete hitResidCanv;
+	delete hitResidualApp;
+	
+	return true;
+}

--- a/UserTools/HitResiduals/HitResiduals.h
+++ b/UserTools/HitResiduals/HitResiduals.h
@@ -1,0 +1,35 @@
+/* vim:set noexpandtab tabstop=4 wrap */
+#ifndef HitResiduals_H
+#define HitResiduals_H
+
+#include <string>
+#include <iostream>
+
+#include "Tool.h"
+
+class HitResiduals: public Tool {
+	
+	public:
+	HitResiduals();
+	bool Initialise(std::string configfile,DataModel &data);
+	bool Execute();
+	bool Finalise();
+	
+	private:
+	TimeClass* EventTime=nullptr;
+	std::vector<MCParticle>* MCParticles=nullptr;
+	std::map<ChannelKey,std::vector<Hit>>* MCHits=nullptr;
+	std::map<ChannelKey,std::vector<LAPPDHit>>* MCLAPPDHits=nullptr;
+	Geometry* anniegeom=nullptr;
+	
+	TApplication* hitResidualApp = nullptr;
+	TCanvas* hitResidCanv=nullptr;
+	TH1D* htimeresidpmt = nullptr;
+	TH1D* htimeresidlappd = nullptr;
+	
+	int get_ok;
+	
+};
+
+
+#endif

--- a/UserTools/HitResiduals/README.md
+++ b/UserTools/HitResiduals/README.md
@@ -1,0 +1,19 @@
+# HitResiduals
+
+HitResiduals
+
+## Data
+
+Describe any data formats HitResiduals creates, destroys, changes, or analyzes. E.G.
+
+**RawLAPPDData** `map<Geometry, vector<Waveform<double>>>`
+* Takes this data from the `ANNIEEvent` store and finds the number of peaks
+
+## Configuration
+
+Describe any configuration variables for HitResiduals.
+
+```
+param1 value1
+param2 value2
+```

--- a/UserTools/Unity.cpp
+++ b/UserTools/Unity.cpp
@@ -69,4 +69,5 @@
 #include "LoadCCData/PMTData.cpp"
 //#include "LoadCCData/RunInformation.cpp"
 //#include "LoadCCData/TrigData.cpp"
+#include "HitResiduals/HitResiduals.cpp"
 

--- a/configfiles/LoadWCSim/HitResidualsConfig
+++ b/configfiles/LoadWCSim/HitResidualsConfig
@@ -1,0 +1,4 @@
+#HitResiduals Config File
+# all variables retrieved with m_variables.Get() must be defined here!
+
+verbose 1

--- a/configfiles/LoadWCSim/LoadWCSimConfig
+++ b/configfiles/LoadWCSim/LoadWCSimConfig
@@ -2,5 +2,7 @@
 # all variables retrieved with m_variables.Get() must be defined here!
 
 verbose 1
-InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_24-09-17_BNB_Water_10k_22-05-17/wcsim_0.0.0.root
-HistoricTriggeroffset 950
+#InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_24-09-17_BNB_Water_10k_22-05-17/wcsim_0.0.0.root
+#InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_03-05-17_rhatcher/wcsim_0.1000.root   ## first of the DOE proposal files
+InputFile /pnfs/annie/persistent/users/moflaher/wcsim/multipmt/tankonly/wcsim_3-12-18_ANNIEp2v6_BNB_Water_10k_22-05-17/wcsim_0.0.0.root
+HistoricTriggeroffset 0

--- a/configfiles/LoadWCSim/LoadWCSimLAPPDConfig
+++ b/configfiles/LoadWCSim/LoadWCSimLAPPDConfig
@@ -1,8 +1,12 @@
 #LoadWCSimLAPPD Config File
 # all variables retrieved with m_variables.Get() must be defined here!
 
-verbose 3
-InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_24-09-17_BNB_Water_10k_22-05-17/wcsim_lappd_0.0.0.root
+verbose 1
+#InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_24-09-17_BNB_Water_10k_22-05-17/wcsim_lappd_0.0.0.root
+#InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_03-05-17_rhatcher/wcsim_lappd_0.1000.root  ## first of the DOE proposal files
+InputFile /pnfs/annie/persistent/users/moflaher/wcsim/multipmt/tankonly/wcsim_3-12-18_ANNIEp2v6_BNB_Water_10k_22-05-17/wcsim_lappd_0.0.0.root
+FileVersion 3            ## should reflect the WCSim version of the files being loaded
+
 # octagonal inner structure radius in m (from drawings 106.64")
 InnerStructureRadius 1.3545
 DrawDebugGraphs 0 # whether to draw TPolyMarker3D's of hits

--- a/configfiles/LoadWCSim/ToolChainConfig
+++ b/configfiles/LoadWCSim/ToolChainConfig
@@ -18,6 +18,6 @@ service_kick_sec -1
 Tools_File configfiles/LoadWCSim/ToolsConfig
 
 ##### Run Type #####
-Inline -1 ## number of Execute steps in program, -1 infinite loop that is ended by user 
+Inline 50 ## number of Execute steps in program, -1 infinite loop that is ended by user 
 Interactive 0 ## set to 1 if you want to run the code interactively
 

--- a/configfiles/LoadWCSim/ToolsConfig
+++ b/configfiles/LoadWCSim/ToolsConfig
@@ -1,4 +1,5 @@
 myLoadWCSim LoadWCSim ./configfiles/LoadWCSim/LoadWCSimConfig
 myLoadWCSimLAPPD LoadWCSimLAPPD ./configfiles/LoadWCSim/LoadWCSimLAPPDConfig
-myPrintANNIEEvent PrintANNIEEvent ./configfiles/LoadWCSim/PrintANNIEEventConfig
+#myPrintANNIEEvent PrintANNIEEvent ./configfiles/LoadWCSim/PrintANNIEEventConfig
+myHitTimeResiduals HitResiduals ./configfiles/LoadWCSim/HitResidualsConfig
 


### PR DESCRIPTION
LAPPD hits from prompt triggers were not being cleared when adding hits to delayed triggers, and delayed trigger LAPPD hit times were relative to the prompt trigger time, not the delayed trigger time.

This PR also includes the addition of a demonstration HitResiduals tool showing how to calculate hit time residuals for light from a primary muon.