### PR TITLE
Pion/Kaon counter for Event Selection in Monte Carlo

### DIFF
--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -16,7 +16,9 @@ bool EventSelector::Initialise(std::string configfile, DataModel &data){
   m_variables.Get("verbosity",verbosity);
   m_variables.Get("MRDRecoCut", fMRDRecoCut);
   m_variables.Get("MCTruthCut", fMCTruthCut);
+  m_variables.Get("MCPiKCut", fMCPiKCut);
   m_variables.Get("PromptTrigOnly", fPromptTrigOnly);
+  m_variables.Get("GetPionKaonInfo", fGetPiKInfo);
 
   /// Construct the other objects we'll be setting at event level,
   fMuonStartVertex = new RecoVertex();
@@ -77,6 +79,14 @@ bool EventSelector::Execute(){
 	
   /// Find true neutrino vertex which is defined by the start point of the Primary muon
   this->FindTrueVertexFromMC();
+  if (fMCPiKCut){
+    this->FindPionKaonCountFromMC();
+    bool passNoPiK = this->EventSelectionNoPiK();
+    if(!passNoPiK) fEventCutStatus = false;
+  } else if (fGetPiKInfo){
+    this->FindPionKaonCountFromMC();
+  }
+  
   
   if(fMCTruthCut){
     bool passMCTruth= this->EventSelectionByMCTruthInfo();
@@ -109,6 +119,89 @@ bool EventSelector::Finalise(){
   delete fMuonStopVertex;
   if(verbosity>0) cout<<"EventSelector exitting"<<endl;
   return true;
+}
+
+bool EventSelector::EventSelectionNoPiK() {
+  
+  // Get the pion and kaon counts from the store.  If any count is greater
+  // than zero, the fEventCutStatus is set to "false" for a failed event.
+  //Fill in pion counts for this event
+  int pi0count, pipcount, pi0mcount, K0count, Kpcount, Kmcount;
+  m_data->Stores.at("RecoEvent")->Get("MCPi0Count", pi0count);
+  m_data->Stores.at("RecoEvent")->Get("MCPiPlusCount", pipcount);
+  m_data->Stores.at("RecoEvent")->Get("MCPiMinusCount", pi0mcount);
+  m_data->Stores.at("RecoEvent")->Get("MCK0Count", K0count);
+  m_data->Stores.at("RecoEvent")->Get("MCKPlusCount", Kpcount);
+  m_data->Stores.at("RecoEvent")->Get("MCKMinusCount", Kmcount);
+  int sum = pi0count + pipcount + pi0mcount + K0count + Kpcount + Kmcount;
+  if (sum > 0){
+    Log("EventSelector: A primary pion or kaon was found. Total count: " +to_string(sum),v_message,verbosity);
+    return false;
+  } else{
+    return true;
+  }
+}
+
+void EventSelector::FindPionKaonCountFromMC() {
+  
+  // loop over the MCParticles to find the highest enery primary muon
+  // MCParticles is a std::vector<MCParticle>
+  bool pionfound=false;
+  bool kaonfound=false;
+  int pi0count = 0;
+  int pipcount = 0;
+  int pimcount = 0;
+  int K0count = 0;
+  int Kpcount = 0;
+  int Kmcount = 0;
+  if(fMCParticles){
+    Log("EventSelector::  Tool: Num MCParticles = "+to_string(fMCParticles->size()),v_message,verbosity);
+    for(int particlei=0; particlei<fMCParticles->size(); particlei++){
+      MCParticle aparticle = fMCParticles->at(particlei);
+      //if(v_debug<verbosity) aparticle.Print();       // print if we're being *really* verbose
+      if(aparticle.GetParentPdg()!=0) continue;      // not a primary particle
+      if(aparticle.GetPdgCode()==111){               // is a primary pi0
+        pionfound = true;
+        pi0count++;
+      }
+      if(aparticle.GetPdgCode()==211){               // is a primary pi+
+        pionfound = true;
+        pipcount++;
+      }
+      if(aparticle.GetPdgCode()==-211){               // is a primary pi-
+        pionfound = true;
+        pimcount++;
+      }
+      if(aparticle.GetParentPdg()!=0) continue;      // not a primary particle
+      if(aparticle.GetPdgCode()==311){               // is a primary K0
+        kaonfound = true;
+        K0count++;
+      }
+      if(aparticle.GetPdgCode()==321){               // is a primary K+
+        kaonfound = true;
+        Kpcount++;
+      }
+      if(aparticle.GetPdgCode()==-321){               // is a primary K-
+        kaonfound = true;
+        Kmcount++;
+      }
+    }
+  } else {
+    Log("EventSelector::  Tool: No MCParticles in the event!",v_error,verbosity);
+  }
+  if(not pionfound){
+    Log("EventSelector::  Tool: No primary pions in this event",v_warning,verbosity);
+  }
+  if(not kaonfound){
+    Log("EventSelector::  Tool: No kaons in this event",v_warning,verbosity);
+  }
+  //Fill in pion counts for this event
+  m_data->Stores.at("RecoEvent")->Set("MCPi0Count", pi0count);
+  m_data->Stores.at("RecoEvent")->Set("MCPiPlusCount", pipcount);
+  m_data->Stores.at("RecoEvent")->Set("MCPiMinusCount", pimcount);
+  m_data->Stores.at("RecoEvent")->Set("MCK0Count", K0count);
+  m_data->Stores.at("RecoEvent")->Set("MCKPlusCount", Kpcount);
+  m_data->Stores.at("RecoEvent")->Set("MCKMinusCount", Kmcount);
 }
 
 RecoVertex* EventSelector::FindTrueVertexFromMC() {

--- a/UserTools/EventSelector/EventSelector.h
+++ b/UserTools/EventSelector/EventSelector.h
@@ -54,14 +54,29 @@ class EventSelector: public Tool {
  	/// is selected. 
  	/// The 
  	bool EventSelectionByMCTruthInfo();
- 	
+
+ 	/// \brief Event selection by Pion Kaon count
+  /////
+ 	/// This event selection criteria requires that no pions or 
+ 	/// kaons are parent particles in the event.  This will help
+  /// Select the CC0Pi events when testing reconstruction.
+ 	bool EventSelectionNoPiK();
+
  	/// \brief Find true neutrino vertex
  	///
  	/// Loop over all MC particles and find the particle with highest energy. 
  	/// This particle is the primary muon. The muon start position, time and 
  	/// the muon direction are used to initise the true neutrino vertex 
  	RecoVertex* FindTrueVertexFromMC();
+
+ 	/// \brief Find PionKaon Count 
+ 	///
+ 	/// Loop over all MC particles and find any particles with PDG codes
+  /// Consistent with Pions or Kaons of any charges. Racks up a count
+  /// of the number of each type of particle
  	
+  void FindPionKaonCountFromMC();
+
  	/// \brief Save true neutrino vertex
  	///
  	/// Push true neutrino vertex to "RecoVertex"
@@ -88,7 +103,9 @@ class EventSelector: public Tool {
 	std::string fInputfile;
 	bool fMRDRecoCut = false;
 	bool fMCTruthCut = false;
-        bool fPromptTrigOnly = true;
+	bool fMCPiKCut = false;
+  bool fGetPiKInfo = false;
+  bool fPromptTrigOnly = true;
 	bool fEventCutStatus;
 
 	/// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.

--- a/UserTools/EventSelector/README.md
+++ b/UserTools/EventSelector/README.md
@@ -7,10 +7,15 @@ EventSelector
 The event selector tool flags events in the input data file as passing or failing
 various event selection criteria.  Current event selection flags that can be
 utilized include:
+  - MCPiKCut: Flags events that had a primary muon or pion produced
   - MRDRecoCut Flags muon events that reconstruct within a defined radius and height
   - MCTruthCut: Flags MC muon events generated within a defined radius and height 
   - PromptTrigOnly: Flags muon events that do not have an MCTriggernum of 0
                     (any store event with MCTriggernum>0 is a delayed trigger)
+
+Additionally, the bool "GetPionKaonInfo" allows the user to simply load the pion/kaon
+count without actually flagging any events.  As things evolve, this could be moved
+to a separate, standalone tool if desired.
 
 For each event, all cuts defined with the config file are checked.  If the event
 passes all cuts, EventCutStatus is set to true and saved to the RecoEvent store.
@@ -28,7 +33,10 @@ master EventCutStatus bit checked by all following tools
 
 ```
 verbosity bool
+
 MRDRecoCut (1 or 0)
 MCTruthCut (1 or 0)
+MCPiKCut (1 or 0)
+GetPionKaonInfo (1 or 0)
 PromptTrigOnly (1 or 0)
 ```

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -16,6 +16,7 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
   m_variables.Get("muonMCTruth_fill", muonMCTruth_fill);
   m_variables.Get("muonRecoDebug_fill", muonRecoDebug_fill);
   m_variables.Get("muonTruthRecoDiff_fill", muonTruthRecoDiff_fill);
+  m_variables.Get("pionKaonCount_fill", pionKaonCount_fill);
 
   std::string output_filename;
   m_variables.Get("OutputFile", output_filename);
@@ -114,7 +115,17 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
     fRecoTree->Branch("DeltaZenith",&fDeltaZenith,"DeltaZenith/D");
     fRecoTree->Branch("DeltaAngle",&fDeltaAngle,"DeltaAngle/D");
   } 
-	
+
+  // Pion and kaon counts as found in MC Truth based on PDG codes
+  if (pionKaonCount_fill){
+    fRecoTree->Branch("Pi0Count",&fPi0Count,"Pi0Count/I");
+    fRecoTree->Branch("PiPlusCount",&fPiPlusCount,"PiPlusCount/I");
+    fRecoTree->Branch("PiMinusCount",&fPiMinusCount,"PiMinusCount/I");
+    fRecoTree->Branch("K0Count",&fK0Count,"K0Count/I");
+    fRecoTree->Branch("KPlusCount",&fKPlusCount,"KPlusCount/I");
+    fRecoTree->Branch("KMinusCount",&fKMinusCount,"KMinusCount/I");
+  }
+
   return true;
 }
 
@@ -301,6 +312,26 @@ bool PhaseIITreeMaker::Execute(){
     }
   }
 
+  if (pionKaonCount_fill){
+    int pi0count, pipcount, pimcount, K0count, Kpcount, Kmcount;
+    auto get_pi0 = m_data->Stores.at("RecoEvent")->Get("MCPi0Count",pi0count);
+    auto get_pim = m_data->Stores.at("RecoEvent")->Get("MCPiMinusCount",pimcount);
+    auto get_pip = m_data->Stores.at("RecoEvent")->Get("MCPiPlusCount",pipcount);
+    auto get_k0 = m_data->Stores.at("RecoEvent")->Get("MCK0Count",K0count);
+    auto get_km = m_data->Stores.at("RecoEvent")->Get("MCKMinusCount",Kmcount);
+    auto get_kp = m_data->Stores.at("RecoEvent")->Get("MCKPlusCount",Kpcount);
+    if(get_pi0 && get_pim && get_pip && get_k0 && get_km && get_kp) {
+      // set values in tree to thouse grabbed from the RecoEvent Store
+      fPi0Count = pi0count;
+      fPiPlusCount = pipcount;
+      fPiMinusCount = pimcount;
+      fK0Count = K0count;
+      fKPlusCount = Kpcount;
+      fKMinusCount = Kmcount;
+    } else {
+      Log("PhaseIITreeMaker Tool: Missing MC Pion/Kaon count information. Continuing to build remaining tree",v_message,verbosity);
+    }
+  } 
 
   if (muonTruthRecoDiff_fill){
     //Let's fill in stuff from the RecoSummary
@@ -378,7 +409,8 @@ void PhaseIITreeMaker::ResetVariables() {
     fPointVtxTime = 0;
     fPointVtxStatus = 0;
     fPointVtxFOM = 0;
-  } 
+  }
+
   fRecoVtxX = 0;
   fRecoVtxY = 0;
   fRecoVtxZ = 0;
@@ -410,6 +442,15 @@ void PhaseIITreeMaker::ResetVariables() {
     fDeltaAzimuth = 0;
     fDeltaZenith = 0;
     fDeltaAngle = 0;
+  }
+
+  if (pionKaonCount_fill){
+    fPi0Count = -1;
+    fPiPlusCount = -1;
+    fPiMinusCount = -1;
+    fK0Count = -1;
+    fKPlusCount = -1;
+    fKMinusCount = -1;
   }
 }
 

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
@@ -115,6 +115,7 @@ class PhaseIITreeMaker: public Tool {
   double fRecoPhi;
   int fRecoStatus;
   
+  // Difference between MC and Truth
   double fDeltaVtxX; 
   double fDeltaVtxY;
   double fDeltaVtxZ;
@@ -126,7 +127,14 @@ class PhaseIITreeMaker: public Tool {
   double fDeltaZenith;  
   double fDeltaAngle;
   
-  	
+  // Pion and kaon counts for event
+  int fPi0Count;
+  int fPiPlusCount;
+  int fPiMinusCount;
+  int fK0Count;
+  int fKPlusCount;
+  int fKMinusCount;
+
   /// \brief Integer that determines the level of logging to perform
   int verbosity = 0;
   int v_error=0;
@@ -140,6 +148,7 @@ class PhaseIITreeMaker: public Tool {
   int muonMCTruth_fill = 0; //Output the MC truth information
   int muonRecoDebug_fill = 0; //Outputs results of Reconstruction at each step (best fits, FOMs, etc.)
   int muonTruthRecoDiff_fill = 0; //Output difference in truth and reconstructed values
+  int pionKaonCount_fill = 0;  //Output the number of pions and kaons based on truth info
 };
 
 

--- a/UserTools/PhaseIITreeMaker/README.md
+++ b/UserTools/PhaseIITreeMaker/README.md
@@ -31,6 +31,8 @@ reconstruction chain are saved to the tree.  Values include seeds from SeedVtxFi
 fits from PointPosFinder, and FOMs for likelihood fits at each reconstruction step.
 Will output to tree if 1.
 
+pionKaonCount_fill (1 or 0)
+Input determines if MC Truth pion and kaon counts are output to Phase II tree.
 param1 value1
 param2 value2
 ```

--- a/configfiles/PhaseIIReco/EventSelectorConfig
+++ b/configfiles/PhaseIIReco/EventSelectorConfig
@@ -3,4 +3,6 @@
 verbosity 3
 MCTruthCut 1
 MRDRecoCut 0
+MCPiKCut 0
+GetPionKaonInfo 1
 PromptTrigOnly 1

--- a/configfiles/PhaseIIReco/PhaseIITreeMakerConfig
+++ b/configfiles/PhaseIIReco/PhaseIITreeMakerConfig
@@ -3,6 +3,7 @@ verbose 3
 muonRecoDebug_fill 1
 muonMCTruth_fill 1
 muonTruthRecoDiff_fill 1
+pionKaonCount_fill 1
 
 OutputFile /Jingbo/RecoGridSeed_5LAPPD_0.1.7.root
 NumEventsWritten 1000

--- a/configfiles/PhaseIIRecoTruth/EventSelectorConfig
+++ b/configfiles/PhaseIIRecoTruth/EventSelectorConfig
@@ -1,6 +1,8 @@
 # EventSelector config file
 
 verbosity 3
-MCTruthCut 1
+MCTruthCut 0
+MCPiKCut 0
+GetPionKaonInfo 1
 MRDRecoCut 0
 PromptTrigOnly 1

--- a/configfiles/PhaseIIRecoTruth/LoadWCSimConfig
+++ b/configfiles/PhaseIIRecoTruth/LoadWCSimConfig
@@ -2,4 +2,4 @@
 # all variables retrieved with m_variables.Get() must be defined here!
 
 verbose 1
-InputFile /AnnieShare/p2r_data/wcsim_0.2.9.root
+InputFile /AnnieShare/p2r_data/p2v6/wcsim_0.1.9.root

--- a/configfiles/PhaseIIRecoTruth/LoadWCSimLAPPDConfig
+++ b/configfiles/PhaseIIRecoTruth/LoadWCSimLAPPDConfig
@@ -2,8 +2,8 @@
 # all variables retrieved with m_variables.Get() must be defined here!
 
 verbose 3
-InputFile /AnnieShare/p2r_data/wcsim_lappd_0.2.9.root
+InputFile /AnnieShare/p2r_data/p2v6/wcsim_lappd_0.1.9.root
 # octagonal inner structure radius in m (from drawings 106.64")
 InnerStructureRadius 1.3545
-HistoricTriggeroffset 950
+HistoricTriggeroffset 0
 DrawDebugGraphs 0 # whether to draw TPolyMarker3D's of hits

--- a/configfiles/PhaseIIRecoTruth/PhaseIITreeMakerConfig
+++ b/configfiles/PhaseIIRecoTruth/PhaseIITreeMakerConfig
@@ -3,7 +3,8 @@ verbose 3
 muonRecoDebug_fill 1
 muonMCTruth_fill 1
 muonTruthRecoDiff_fill 1
+pionKaonCount_fill 1
 
-OutputFile /ToolAnalysis/Recotest_truth_5LAPPD_0.2.9.root
+OutputFile /ToolAnalysis/pionKaonCountTest.root
 NumEventsWritten 2000
 


### PR DESCRIPTION
This pull request would primarily add features to the EventSelector and PhaseIITreeMaker tools used in reconstruction.

Changes to the event selector include a method for counting pions and kaons using MCParticle information and another method for adjusting the EventSelectionsStatus flag based on the pion/kaon count.  Requiring that there are parent pions or kaons would result in reconstruction only being performed on CC0pi0K events in Monte Carlo.  The pion/kaon counts are stored in the "RecoEvent" store.

The ability to count pions/kaons and still reconstruct all events is also implemented.  This could be useful for knowing how many true tracks are expected in the tank.  

Changes to the PhaseIITreeMaker allow for the pion and kaon count in each event to be saved to the PhaseII ntuple.