### PR TITLE
Option to use PMT parametric model in Reconstruction

### DIFF
--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -23,11 +23,14 @@ bool DigitBuilder::Initialise(std::string configfile, DataModel &data){
   //m_variables.Print();
 
   m_data= &data; //assigning transient data pointer
-  /////////////////////////////////////////////////////////////////
-  fPhotodetectorConfiguration = "All";
   
+  ///////////////////// Defaults for Config ///////////////
+  fPhotodetectorConfiguration = "All";
+  fParametricModel = 0;
+
   /// Get the Tool configuration variables
 	m_variables.Get("verbosity",verbosity);
+	m_variables.Get("ParametricModel", fParametricModel);
 	m_variables.Get("PhotoDetectorConfiguration", fPhotodetectorConfiguration);
 	
 	/// Construct the other objects we'll be setting at event level,
@@ -167,21 +170,45 @@ bool DigitBuilder::BuildPMTRecoDigit() {
 			pos_reco.SetZ(pos_sim.Z()-168.1);
 	
 			if(chankey.GetSubDetectorType()==subdetector::ADC){
-				std::vector<Hit>& hits = apair.second;	
-			  for(Hit& ahit : hits){
-			  	//ahit.Print();
-					//if(v_message<verbosity) ahit.Print(); // << VERY verbose
-					// get calibrated PMT time (Use the MC time for now)
-					calT = ahit.GetTime()*1.0; // remove 950 ns offs
-					calQ = ahit.GetCharge();
-					digitType = RecoDigit::PMT8inch;
-					RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType, PMTId);
-				  //recoDigit.Print();
+				std::vector<Hit>& hits = apair.second;
+        if(fParametricModel){
+          //We'll get all hit info and then define a time/charge for each digit
+          std::vector<double> hitTimes;
+          std::vector<double> hitCharges;
+          for(Hit& ahit : hits){
+					  hitTimes.push_back(ahit.GetTime()*1.0); 
+            hitCharges.push_back(ahit.GetCharge());
+          }
+          // Do median and sum
+          std::sort(hitTimes.begin(), hitTimes.end());
+          size_t timesize = hitTimes.size();
+          if (timesize % 2 == 0){
+            calT = (hitTimes[timesize/2 - 1] + hitTimes[timesize/2])/2;
+          } else {
+            calT = hitTimes[timesize/2];
+          }
+          calQ = 0.;
+          for(std::vector<double>::iterator it = hitCharges.begin(); it != hitCharges.end(); ++it){
+            calQ += *it;
+          }
+				  digitType = RecoDigit::PMT8inch;
+				  RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType, PMTId);
 				  fDigitList->push_back(recoDigit); 
-        }
-			}
+        } else {
+			    for(Hit& ahit : hits){
+				  	//if(v_message<verbosity) ahit.Print(); // << VERY verbose
+				  	// get calibrated PMT time (Use the MC time for now)
+				  	calT = ahit.GetTime()*1.0; 
+            calQ = ahit.GetCharge();
+				  	digitType = RecoDigit::PMT8inch;
+				  	RecoDigit recoDigit(region, pos_reco, calT, calQ, digitType, PMTId);
+				    //recoDigit.Print();
+				    fDigitList->push_back(recoDigit); 
+          }
+			  }
+      }
 		} // end loop over MCHits
-	} else {
+  } else {
 		cout<<"No MCHits"<<endl;
 		return false;
 	}
@@ -209,7 +236,8 @@ bool DigitBuilder::BuildLAPPDRecoDigit() {
 			//Tube ID is different from that in ANNIEReco
 			LAPPDId = det.GetDetectorId();
 			//if(LAPPDId != 266 && LAPPDId != 271 && LAPPDId != 236 && LAPPDId != 231 && LAPPDId != 206) continue;
-			//if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue;
+			//if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue; 
+      if(LAPPDId != 11 && LAPPDId != 13 && LAPPDId != 14 && LAPPDId != 15 && LAPPDId != 17) continue;
                         if(chankey.GetSubDetectorType()==subdetector::LAPPD){ // redundant
 				std::vector<LAPPDHit>& hits = apair.second;
 				for(LAPPDHit& ahit : hits){

--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -237,7 +237,7 @@ bool DigitBuilder::BuildLAPPDRecoDigit() {
 			LAPPDId = det.GetDetectorId();
 			//if(LAPPDId != 266 && LAPPDId != 271 && LAPPDId != 236 && LAPPDId != 231 && LAPPDId != 206) continue;
 			//if(LAPPDId != 90 && LAPPDId != 83 && LAPPDId != 56 && LAPPDId != 59 && LAPPDId != 22) continue; 
-      if(LAPPDId != 11 && LAPPDId != 13 && LAPPDId != 14 && LAPPDId != 15 && LAPPDId != 17) continue;
+      //if(LAPPDId != 11 && LAPPDId != 13 && LAPPDId != 14 && LAPPDId != 15 && LAPPDId != 17) continue;
                         if(chankey.GetSubDetectorType()==subdetector::LAPPD){ // redundant
 				std::vector<LAPPDHit>& hits = apair.second;
 				for(LAPPDHit& ahit : hits){

--- a/UserTools/DigitBuilder/DigitBuilder.h
+++ b/UserTools/DigitBuilder/DigitBuilder.h
@@ -75,7 +75,8 @@ class DigitBuilder: public Tool {
 	uint64_t fMCEventNum;      ///< event number in MC file
 	std::vector<int> fLAPPDId; ///< selected LAPPDs
 	std::string fPhotodetectorConfiguration; ///< "PMTs_Only", "LAPPDs_Only", "All_Detectors"
-	
+	bool fParametricModel;     ///< configures if PMTs hits for each event are accumulated into one hit per PMT
+
 	Geometry fGeometry;    ///< ANNIE Geometry
 	std::map<ChannelKey,std::vector<Hit>>* fMCHits=nullptr;             ///< PMT hits
 	std::map<ChannelKey,std::vector<LAPPDHit>>* fMCLAPPDHits=nullptr;   ///< LAPPD hits

--- a/configfiles/PhaseIIReco/DigitBuilderConfig
+++ b/configfiles/PhaseIIReco/DigitBuilderConfig
@@ -1,8 +1,6 @@
 # DigitBuilder config file
 
 verbosity 3
-OutputFile ./DigitBuilder.root
-MCTruthCut 1
-MRDRecoCut 0
+ParametricModel 1
 # There are three configurations: "PMT_only", "LAPPD_only", "All"
 PhotoDetectorConfiguration All

--- a/configfiles/PhaseIIRecoTruth/DigitBuilderConfig
+++ b/configfiles/PhaseIIRecoTruth/DigitBuilderConfig
@@ -1,7 +1,7 @@
 # DigitBuilder config file
 
-verbosity 3
+verbosity 1
 ParametricModel 1
 # There are three configurations: "PMT_only", "LAPPD_only", "All"
-PhotoDetectorConfiguration All 
+PhotoDetectorConfiguration All
 #LAPPDId 266 271 236 231 206

--- a/configfiles/PhaseIIRecoTruth/DigitBuilderConfig
+++ b/configfiles/PhaseIIRecoTruth/DigitBuilderConfig
@@ -1,7 +1,7 @@
 # DigitBuilder config file
 
 verbosity 3
-OutputFile ./DigitBuilder.root
+ParametricModel 1
 # There are three configurations: "PMT_only", "LAPPD_only", "All"
-PhotoDetectorConfiguration PMT_only 
+PhotoDetectorConfiguration All 
 #LAPPDId 266 271 236 231 206


### PR DESCRIPTION
The following pull request adds the option to use a parametric PMT hit model.  This option should only be used with WCSim files that do not implement any PMT digiziation.

For each trigger in a WCSim event, each PMT is assigned a single hit time and charge in the following way:
  - The hit time is assigned as the median of all hits on the PMT in the trigger window
  - The hit harge is the sum of all single hit charges in the trigger window

This model is turned off by default.