### PR TITLE
Hotfix to PhaseIITreeMaker tool - now checks if RecoDigits are available in store

### DIFF
--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -170,7 +170,11 @@ bool PhaseIITreeMaker::Execute(){
   
   // Read digits
   std::vector<RecoDigit>* digitList = nullptr;
-	m_data->Stores.at("RecoEvent")->Get("RecoDigit",digitList);  ///> Get digits from "RecoEvent" 
+	auto get_digits = m_data->Stores.at("RecoEvent")->Get("RecoDigit",digitList);  ///> Get digits from "RecoEvent" 
+  if(!get_digits) {
+    Log("PhaseITreeMaker tool: no digit list in store!", v_error, verbosity);
+    return false;	
+  }
   fNhits = digitList->size();
   for( auto& digit : *digitList ){
     fDigitX.push_back(digit.GetPosition().X());

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -170,7 +170,7 @@ bool PhaseIITreeMaker::Execute(){
   
   // Read digits
   std::vector<RecoDigit>* digitList = nullptr;
-	auto get_digits = m_data->Stores.at("RecoEvent")->Get("RecoDigit",digitList);  ///> Get digits from "RecoEvent" 
+  auto get_digits = m_data->Stores.at("RecoEvent")->Get("RecoDigit",digitList);  ///> Get digits from "RecoEvent" 
   if(!get_digits) {
     Log("PhaseITreeMaker tool: no digit list in store!", v_error, verbosity);
     return false;	


### PR DESCRIPTION
Previously, if no RecoDigitList was in the RecoEvent store, PhaseIITreeMaker would crash ToolAnalysis.