### PR TITLE
add an option to LoadWCSim to use unsmeared time of first photon

### DIFF
--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -311,14 +311,18 @@ bool LoadWCSim::Execute(){
 			} else {
 				// instead take the true time of the first photon
 				std::vector<int> photonids = digihit->GetPhotonIds();   // indices of the digit's photons
-				int first_photon_index = photonids.front();
-				WCSimRootCherenkovHitTime* thehittimeobject =
-					 (WCSimRootCherenkovHitTime*)firsttrig->GetCherenkovHitTimes()->At(first_photon_index);
-				if(thehittimeobject==nullptr){
-					cerr<<"LoadWCSim Tool: ERROR! Retrieval of first photon from digit returned nullptr!"<<endl;
-					continue;
+				double earliestphotontruetime=999999999999;
+				for(int& aphotonindex : photonids){
+					WCSimRootCherenkovHitTime* thehittimeobject =
+						 (WCSimRootCherenkovHitTime*)firsttrig->GetCherenkovHitTimes()->At(aphotonindex);
+					if(thehittimeobject==nullptr){
+						cerr<<"LoadWCSim Tool: ERROR! Retrieval of photon from digit returned nullptr!"<<endl;
+						continue;
+					}
+					double aphotontime = static_cast<double>(thehittimeobject->GetTruetime());
+					if(aphotontime<earliestphotontruetime){ earliestphotontruetime = aphotontime; }
 				}
-				digittime = static_cast<double>(thehittimeobject->GetTruetime());
+				digittime = earliestphotontruetime;
 			}
 			if(verbose>2){ cout<<"digittime is "<<digittime<<" [ns] from Trigger"<<endl; }
 			float digiq = digihit->GetQ();

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -20,6 +20,7 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	m_variables.Get("verbose",verbose);
 	m_variables.Get("InputFile",MCFile);
 	m_variables.Get("HistoricTriggeroffset",HistoricTriggeroffset);
+	m_variables.Get("UseDigitSmearedTime",use_smeared_digit_time);
 	m_variables.Get("WCSimVersion",FILE_VERSION);
 	// put in the CStore for downstream tools
 	m_data->CStore.Set("WCSimVersion",FILE_VERSION);
@@ -293,17 +294,32 @@ bool LoadWCSim::Execute(){
 		if(verbose>2) cout<<"MCParticles has "<<MCParticles->size()<<" entries"<<endl;
 		
 		// n.b. ChannelKey is currently typedef'd as an int: it's just a unique PMT id for MRD+Tank+FACC
+		WCSimRootTrigger* firsttrig=WCSimEntry->wcsimrootevent->GetTrigger(0);  // photons are all in first trig
 		int numtankdigits = atrigt ? atrigt->GetCherenkovDigiHits()->GetEntries() : 0;
 		if(verbose>1) cout<<"looping over "<<numtankdigits<<" tank digits"<<endl;
 		for(int digiti=0; digiti<numtankdigits; digiti++){
 			if(verbose>2) cout<<"getting digit "<<digiti<<endl;
 			WCSimRootCherenkovDigiHit* digihit =
 				(WCSimRootCherenkovDigiHit*)atrigt->GetCherenkovDigiHits()->At(digiti);
-			//WCSimRootChernkovDigiHit has methods GetTubeId(), GetT(), GetQ()
+			//WCSimRootChernkovDigiHit has methods GetTubeId(), GetT(), GetQ(), GetPhotonIds()
 			if(verbose>2) cout<<"next digihit at "<<digihit<<endl;
 			int tubeid = digihit->GetTubeId()-1;  // WCSim Digi TubeIds start from 1!
 			if(verbose>2) cout<<"tubeid="<<tubeid<<endl;
-			double digittime(static_cast<double>(digihit->GetT()-HistoricTriggeroffset)); // relative to trigger
+			double digittime;
+			if(use_smeared_digit_time){
+				digittime = static_cast<double>(digihit->GetT()-HistoricTriggeroffset); // relative to trigger
+			} else {
+				// instead take the true time of the first photon
+				std::vector<int> photonids = digihit->GetPhotonIds();   // indices of the digit's photons
+				int first_photon_index = photonids.front();
+				WCSimRootCherenkovHitTime* thehittimeobject =
+					 (WCSimRootCherenkovHitTime*)firsttrig->GetCherenkovHitTimes()->At(first_photon_index);
+				if(thehittimeobject==nullptr){
+					cerr<<"LoadWCSim Tool: ERROR! Retrieval of first photon from digit returned nullptr!"<<endl;
+					continue;
+				}
+				digittime = static_cast<double>(thehittimeobject->GetTruetime());
+			}
 			if(verbose>2){ cout<<"digittime is "<<digittime<<" [ns] from Trigger"<<endl; }
 			float digiq = digihit->GetQ();
 			if(verbose>2) cout<<"digit Q is "<<digiq<<endl;

--- a/UserTools/LoadWCSim/LoadWCSim.h
+++ b/UserTools/LoadWCSim/LoadWCSim.h
@@ -31,6 +31,7 @@ private:
 
 	int verbose=1;
 	int HistoricTriggeroffset;
+	int use_smeared_digit_time;   // digit_time = (T): first photon smeared time, (F): first photon true time
 	// WCSim variables
 	TFile* file;
 	TTree* wcsimtree;


### PR DESCRIPTION
There was some contention over the way WCSim performs digitization and allocates times to digits. This has primarily been "fixed" in WCSim with the option to convert each individual photon into a digit and bypass the digitization step, but an intermediate backport would be to use the true time of the first photon in each digit as the digit time. This would negate the 'time walk' effect to a degree since this uses pre-smear photon times. Smearing may be introduced later to model PMT time resolution, but it is not performed by the LoadWCSim tool in this update. When using this option in the LoadWCSim tool, the number and charges of digits would remain as per with digitization, in contrast to when bypassing digitization in WCSim.

