### PR TITLE
Hotfix for reconstruction symlinks

### DIFF
--- a/PhaseIIReco
+++ b/PhaseIIReco
@@ -1,1 +1,1 @@
-configfiles/PhaseIIReco/ToolChainConfig
+configfiles/VertexReco/PhaseIIReco/ToolChainConfig

--- a/PhaseIISanityCheck
+++ b/PhaseIISanityCheck
@@ -1,1 +1,1 @@
-configfiles/PhaseIISanityCheck/ToolChainConfig
+configfiles/VertexReco/PhaseIISanityCheck/ToolChainConfig


### PR DESCRIPTION
Symlinks pointing to default PhaseII reconstruction and reconstruction checking tool needed to point to new ToolChainConfig locations.