### PR TITLE
New Event Selection flag: Check if interaction vertex reconstructs in FV

### DIFF
--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -20,10 +20,12 @@ bool EventSelector::Initialise(std::string configfile, DataModel &data){
   m_variables.Get("MCPiKCut", fMCPiKCut);
   m_variables.Get("NHitCut", fNHitCut);
   m_variables.Get("PromptTrigOnly", fPromptTrigOnly);
+  m_variables.Get("RecoFVCut", fRecoFVCut);
+  m_variables.Get("SaveStatusToStore", fSaveStatusToStore);
 
   /// Construct the other objects we'll be needing at event level,
   
-  // Make the RecoDigit Store if it doesn't exist
+  // Make the RecoEvent Store if it doesn't exist
   int recoeventexists = m_data->Stores.count("RecoEvent");
   if(recoeventexists==0) m_data->Stores["RecoEvent"] = new BoostStore(false,2);
   //TODO: Have an event selection mask filled based on what cuts are run
@@ -43,13 +45,6 @@ bool EventSelector::Execute(){
   	return false;
   };
 
-  // see if "RecoEvent" exists
-  auto get_recoevent = m_data->Stores.count("RecoEvent");
-  if(!get_recoevent){
-  	Log("EventSelector Tool: No RecoEvent store!",v_error,verbosity); 
-  	return false;
-  };
-  
   // MC entry number
   m_data->Stores.at("ANNIEEvent")->Get("MCEventNum",fMCEventNum);  
   
@@ -69,17 +64,6 @@ bool EventSelector::Execute(){
     return false; 
   }
 
-  // get truth vertex information 
-  auto get_truevtx = m_data->Stores.at("RecoEvent")->Get("TrueVertex", fMuonStartVertex);
-	if(!get_truevtx){ 
-	  Log("EventSelector Tool: Error retrieving TrueVertex from RecoEvent!",v_error,verbosity); 
-	  return false; 
-	}
-  auto get_truestopvtx = m_data->Stores.at("RecoEvent")->Get("TrueStopVertex", fMuonStopVertex);
-	if(!get_truestopvtx){ 
-	  Log("EventSelector Tool: Error retrieving TrueStopVertex from RecoEvent!",v_error,verbosity); 
-	  return false; 
-	}
 
 	// Retrive digits from RecoEvent
 	auto get_ok = m_data->Stores.at("RecoEvent")->Get("RecoDigit",fDigitList);  ///> Get digits from "RecoEvent" 
@@ -94,12 +78,23 @@ bool EventSelector::Execute(){
     if(!passNoPiK) fEventFlagged |= EventSelector::kFlagMCPiK;
   }  
   if(fMCFVCut){
+    // get truth vertex information 
+    auto get_truevtx = m_data->Stores.at("RecoEvent")->Get("TrueVertex", fMuonStartVertex);
+	if(!get_truevtx){ 
+	  Log("EventSelector Tool: Error retrieving TrueVertex from RecoEvent!",v_error,verbosity); 
+	  return false; 
+	}
     fEventApplied |= EventSelector::kFlagMCFV; 
-    bool passMCFVCut= this->EventSelectionByMCTruthFV();
+    bool passMCFVCut= this->EventSelectionByFV(true);
     if(!passMCFVCut) fEventFlagged |= EventSelector::kFlagMCFV;
 ; 
   }
   if(fMCMRDCut){
+    auto get_truestopvtx = m_data->Stores.at("RecoEvent")->Get("TrueStopVertex", fMuonStopVertex);
+    if(!get_truestopvtx){ 
+      Log("EventSelector Tool: Error retrieving TrueStopVertex from RecoEvent!",v_error,verbosity); 
+      return false; 
+    }
     fEventApplied |= EventSelector::kFlagMCMRD; 
     bool passMCMRDCut= this->EventSelectionByMCTruthMRD();
     if(!passMCMRDCut) fEventFlagged |= EventSelector::kFlagMCMRD;
@@ -118,6 +113,18 @@ bool EventSelector::Execute(){
     if(!HasEnoughHits) fEventFlagged |= EventSelector::kFlagNHit;
   }
 
+  if(fRecoFVCut){
+	// Retrive Reconstructed vertex from RecoEvent 
+	auto get_ok = m_data->Stores.at("RecoEvent")->Get("ExtendedVertex",fRecoVertex);  ///> Get reconstructed vertex 
+    if(not get_ok){
+  	  Log("EventSelector Tool: Error retrieving Extended vertex from RecoEvent!",v_error,verbosity); 
+  	  return false;
+    }
+    fEventApplied |= EventSelector::kFlagRecoFV; 
+    bool passRecoFVCut= this->EventSelectionByFV(false);
+    if(!passRecoFVCut) fEventFlagged |= EventSelector::kFlagRecoFV;
+  }
+
   //FIXME: This isn't working according to Jingbo
   if(fMRDRecoCut){
     fEventApplied |= EventSelector::kFlagRecoMRD; 
@@ -132,7 +139,7 @@ bool EventSelector::Execute(){
   if(fEventCutStatus){  
     Log("EventSelector Tool: Event is clean according to current event selection.",v_message,verbosity);
   }
-  m_data->Stores.at("RecoEvent")->Set("EventCutStatus", fEventCutStatus);
+  if(fSaveStatusToStore) m_data->Stores.at("RecoEvent")->Set("EventCutStatus", fEventCutStatus);
   m_data->Stores.at("RecoEvent")->Set("EventFlagApplied", fEventApplied);
   m_data->Stores.at("RecoEvent")->Set("EventFlagged", fEventFlagged);
   return true;
@@ -241,24 +248,33 @@ bool EventSelector::EventSelectionByMRDReco() {
 }
 
 
-bool EventSelector::EventSelectionByMCTruthFV() {
-  if(!fMuonStartVertex) return false;
-  double trueVtxX, trueVtxY, trueVtxZ;
-  Position vtxPos = fMuonStartVertex->GetPosition();
-  Direction vtxDir = fMuonStartVertex->GetDirection();
-  trueVtxX = vtxPos.X();
-  trueVtxY = vtxPos.Y();
-  trueVtxZ = vtxPos.Z();
-  std::cout<<"trueVtxX, Y, Z = "<<trueVtxX<<", "<<trueVtxY<<", "<<trueVtxZ<<std::endl;
-  double tankradius = ANNIEGeometry::Instance()->GetCylRadius();	
+bool EventSelector::EventSelectionByFV(bool isMC) {
+  if(isMC && !fMuonStartVertex) return false;
+  if(!isMC && !fRecoVertex) return false;
+  RecoVertex* checkedVertex;
+  if(isMC){
+      Log("EventSelector Tool: Checking FV cut for true muon vertex",v_debug,verbosity); 
+      checkedVertex=fMuonStartVertex;
+  } else {
+      Log("EventSelector Tool: Checking FV cut for reconstructed muon vertex",v_debug,verbosity); 
+    checkedVertex=fRecoVertex;
+  }
+  double checkedVtxX, checkedVtxY, checkedVtxZ;
+  Position vtxPos = checkedVertex->GetPosition();
+  Direction vtxDir = checkedVertex->GetDirection();
+  checkedVtxX = vtxPos.X();
+  checkedVtxY = vtxPos.Y();
+  checkedVtxZ = vtxPos.Z();
+  std::cout<<"checkedVtxX, Y, Z = "<<checkedVtxX<<", "<<checkedVtxY<<", "<<checkedVtxZ<<std::endl;
+  double tankradius = ANNIEGeometry::Instance()->GetCylRadius();
   double fidcutradius = 0.8 * tankradius;
   double fidcuty = 50.;
   double fidcutz = 0.;
-  if(trueVtxZ > fidcutz) return false;
-  if( (TMath::Sqrt(TMath::Power(trueVtxX, 2) + TMath::Power(trueVtxZ,2)) > fidcutradius) 
-  	  || (TMath::Abs(trueVtxY) > fidcuty) 
-  	  || (trueVtxZ > fidcutz) ){
-  Log("EventSelector Tool: This MC Event's muon was not generated in the FV",v_message,verbosity); 
+  if(checkedVtxZ > fidcutz) return false;
+  if( (TMath::Sqrt(TMath::Power(checkedVtxX, 2) + TMath::Power(checkedVtxZ,2)) > fidcutradius) 
+  	  || (TMath::Abs(checkedVtxY) > fidcuty) 
+  	  || (checkedVtxZ > fidcutz) ){
+  Log("EventSelector Tool: This event did not reconstruct inside the FV",v_message,verbosity); 
   return false;
   }	
  

--- a/UserTools/EventSelector/EventSelector.h
+++ b/UserTools/EventSelector/EventSelector.h
@@ -28,13 +28,14 @@ class EventSelector: public Tool {
   bool Finalise();
 
   typedef enum EventFlags {
-   kFlagNone  = 0x00, //0
-   kFlagMCFV    = 0x01, //1
-   kFlagMCMRD    = 0x02, //2
-   kFlagMCPiK   = 0x04, //4
-   kFlagRecoMRD    = 0x08, //8
-   kFlagPromptTrig     = 0x10, //16
-   kFlagNHit     = 0x20, //32
+   kFlagNone         = 0x00, //0
+   kFlagMCFV         = 0x01, //1
+   kFlagMCMRD        = 0x02, //2
+   kFlagMCPiK        = 0x04, //4
+   kFlagRecoMRD      = 0x08, //8
+   kFlagPromptTrig   = 0x10, //16
+   kFlagNHit         = 0x20, //32
+   kFlagRecoFV       = 0x30, //64
   } EventFlags_t;
 
  private:
@@ -64,11 +65,10 @@ class EventSelector: public Tool {
 
  	/// \brief Event selection by fidicual volume
  	///
- 	/// The selection is based on the true vertex position from MC. 
- 	/// If the true vertex is inside the fidicual volume, the event 
- 	/// is selected. 
- 	/// The 
- 	bool EventSelectionByMCTruthFV();
+ 	/// The selection is based on the muon interaction point. 
+ 	/// If isMC is true, checks the Event using muon truth info. 
+    /// If False, the reconstructed vertex is used. 
+ 	bool EventSelectionByFV(bool isMC);
 
  	/// \brief Event selection by Muon MRD stop position
   /////
@@ -102,6 +102,7 @@ class EventSelector: public Tool {
 	RecoVertex* fMuonStartVertex = nullptr; 	 ///< true muon start vertex
 	RecoVertex* fMuonStopVertex = nullptr; 	 ///< true muon stop vertex
 	std::vector<RecoDigit>* fDigitList;				///< Reconstructed Hits including both LAPPD hits and PMT hits
+	RecoVertex* fRecoVertex = nullptr; 	 ///< Reconstructed Vertex 
 
 	//verbosity initialization
 	int verbosity=1;
@@ -109,12 +110,15 @@ class EventSelector: public Tool {
 	std::string fInputfile;
 	bool fMRDRecoCut = false;
 	bool fMCFVCut = false;
+	bool fRecoFVCut = false;
 	bool fMCMRDCut = false;
 	bool fMCPiKCut = false;
   bool fNHitCut = true;
   bool fPromptTrigOnly = true;
 	bool fEventCutStatus;
 
+
+    bool fSaveStatusToStore = true;
 	/// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.
 	int v_error=0;
 	int v_warning=1;

--- a/UserTools/VtxExtendedVertexFinder/VtxExtendedVertexFinder.cpp
+++ b/UserTools/VtxExtendedVertexFinder/VtxExtendedVertexFinder.cpp
@@ -13,6 +13,7 @@ bool VtxExtendedVertexFinder::Initialise(std::string configfile, DataModel &data
   /////////////////////////////////////////////////////////////////
 
   fUseTrueVertexAsSeed = false;
+  fSeedGridFits = false;
   /// Get the Tool configuration variables
   m_variables.Get("UseTrueVertexAsSeed",fUseTrueVertexAsSeed);
   m_variables.Get("FitAllOnSeedGrid",fSeedGridFits);


### PR DESCRIPTION
Added an event selection flag that checks if the reconstructed vertex is in the ficudial volume.

Previously, a bit only existed for checking if the MC Truth position is in the fiducial volume.  Now, the check can be performed with either the truth information or the reconstructed information.

Also a hotfix in the Extended Vertex Finder tool; needed to initialize a boolean to false that was previously left undefined.