### PR TITLE
Information for Energy Reconstruction and DigitBuilder hotfix

### DIFF
--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -110,6 +110,8 @@ bool DigitBuilder::Execute(){
   this->PushRecoDigits(true); 
   this->PushTrueVertex(true);
   this->PushTrueStopVertex(true);
+  this->PushTrueWaterTrackLength(WaterTrackLength);
+  this->PushTrueMRDTrackLength(MRDTrackLength);
 
   return true;
 }
@@ -320,9 +322,13 @@ void DigitBuilder::FindTrueVertexFromMC() {
   double muonstarttime = primarymuon.GetStartTime();
   Position muonstoppos = primarymuon.GetStopVertex();    // only true if the muon is primary
   double muonstoptime = primarymuon.GetStopTime();
-  
   Direction muondirection = primarymuon.GetStartDirection();
+  
   double muonenergy = primarymuon.GetStartEnergy();
+  m_data->Stores.at("RecoEvent")->Set("TrueMuonEnergy", muonenergy);
+
+  MRDTrackLength = primarymuon.GetTrackLengthInMrd();
+  WaterTrackLength = primarymuon.GetTrackLengthInTank();
   // set true vertex
   // change unit
   muonstartpos.UnitToCentimeter(); // convert unit from meter to centimeter
@@ -344,6 +350,7 @@ void DigitBuilder::FindTrueVertexFromMC() {
 	logmessage = "  muonStop = ("+to_string(muonstoppos.X()) + ", " + to_string(muonstoppos.Y()) + ", " + to_string(muonstoppos.Z()) + ") "+ "\n";
 	Log(logmessage,v_debug,verbosity);
 }
+
 
 void DigitBuilder::FindPionKaonCountFromMC() {
   
@@ -422,6 +429,16 @@ void DigitBuilder::PushTrueStopVertex(bool savetodisk) {
 void DigitBuilder::PushRecoDigits(bool savetodisk) {
 	Log("DigitBuilder Tool: Push reconstructed digits to the RecoEvent store",v_message,verbosity);
 	m_data->Stores.at("RecoEvent")->Set("RecoDigit", fDigitList, savetodisk);  ///> Add digits to RecoEvent
+}
+
+void DigitBuilder::PushTrueWaterTrackLength(double WaterT) {
+	Log("DigitBuilder Tool: Push true track length in tank to the RecoEvent store",v_message,verbosity);
+	m_data->Stores.at("RecoEvent")->Set("TrueTrackLengthInWater", WaterT);  ///> Add digits to RecoEvent
+}
+
+void DigitBuilder::PushTrueMRDTrackLength(double MRDT) {
+	Log("DigitBuilder Tool: Push true track length in MRD to the RecoEvent store",v_message,verbosity);
+	m_data->Stores.at("RecoEvent")->Set("TrueTrackLengthInMRD", MRDT);  ///> Add digits to RecoEvent
 }
 
 void DigitBuilder::Reset() {

--- a/UserTools/DigitBuilder/DigitBuilder.cpp
+++ b/UserTools/DigitBuilder/DigitBuilder.cpp
@@ -185,8 +185,13 @@ bool DigitBuilder::BuildPMTRecoDigit() {
           std::vector<double> hitTimes;
           std::vector<double> hitCharges;
           for(Hit& ahit : hits){
-          	if(calT>-10 && calT<40) {
-					    hitTimes.push_back(ahit.GetTime()*1.0); 
+            if(verbosity>3){
+              std::cout << "This HIT'S TIME AND CHARGE: " << ahit.GetTime() <<
+                  "," << ahit.GetCharge() << std::endl;
+            }
+            double hitTime = ahit.GetTime()*1.0;
+          	if(hitTime>-10 && hitTime<40) {
+			  hitTimes.push_back(ahit.GetTime()*1.0); 
               hitCharges.push_back(ahit.GetCharge());
             }
           }
@@ -202,6 +207,10 @@ bool DigitBuilder::BuildPMTRecoDigit() {
           calQ = 0.;
           for(std::vector<double>::iterator it = hitCharges.begin(); it != hitCharges.end(); ++it){
             calQ += *it;
+          }
+          if(verbosity>3){
+            std::cout << "PARAMETRIC MODEL TIME AND CHARGE FOR THIS PMT: " << calT <<
+                "," << calQ << std::endl;
           }
           if(calQ>10) {
 				    digitType = RecoDigit::PMT8inch;
@@ -327,8 +336,11 @@ void DigitBuilder::FindTrueVertexFromMC() {
   double muonenergy = primarymuon.GetStartEnergy();
   m_data->Stores.at("RecoEvent")->Set("TrueMuonEnergy", muonenergy);
 
-  MRDTrackLength = primarymuon.GetTrackLengthInMrd();
+  // MCParticleProperties tool fills in MRD track in m, but
+  // Water track in cm...
+  MRDTrackLength = primarymuon.GetTrackLengthInMrd()*100.;
   WaterTrackLength = primarymuon.GetTrackLengthInTank();
+
   // set true vertex
   // change unit
   muonstartpos.UnitToCentimeter(); // convert unit from meter to centimeter

--- a/UserTools/DigitBuilder/DigitBuilder.h
+++ b/UserTools/DigitBuilder/DigitBuilder.h
@@ -77,9 +77,13 @@ class DigitBuilder: public Tool {
 
  	/// \brief Push reco digits to ANNIEEvent
   ///
-  /// It adds the vector of PMT and LAPPD digits to ANNIEEvent
+  /// It adds the vector of PMT and LAPPD digits to RecoEvent
  	void PushRecoDigits(bool savetodisk);
- 	
+
+  /// \brief Push muon track lengths to RecoEvent Store
+  void PushTrueWaterTrackLength(double WaterT);
+  void PushTrueMRDTrackLength(double MRDT);
+
  	/// \brief Reset digits
  	///
  	/// Clear digit list
@@ -125,6 +129,8 @@ class DigitBuilder: public Tool {
 	RecoVertex* fMuonStartVertex = nullptr; 	 ///< true muon start vertex
 	RecoVertex* fMuonStopVertex = nullptr; 	 ///< true muon stop vertex
 	std::vector<MCParticle>* fMCParticles=nullptr;  ///< truth tracks
+  double WaterTrackLength = -999.;
+  double MRDTrackLength = -999.;
 
 	// retrieved from CStore, for mapping WCSim LAPPD IDs to unique detectorkey
 	// Note: WCSim doesn't have "striplines", so while the LoadWCSim tool generates

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -188,6 +188,9 @@ bool EventSelector::PromptTriggerCheck() {
 }
 
 bool EventSelector::NHitCountCheck(int NHitCut) {
+  if(verbosity>3){
+    std::cout << "SIZE OF DIGIT LIST FOR EVENT IS: " << fDigitList->size() << std::endl;
+  }
   if(fDigitList->size()<NHitCut) {
 		Log("EventSelector Tool: Event has less than 4 digits",v_message,verbosity);
 		return false;

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -394,7 +394,7 @@ void PhaseIITreeMaker::ResetVariables() {
   fTrueDirY = -9999;
   fTrueDirZ = -9999;
   fTrueAngle = -9999;
-  fTruePhi = -;
+  fTruePhi = -9999;
  
   if (muonRecoDebug_fill){ 
     fSeedVtxX.clear();

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -24,10 +24,11 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
   fOutput_tfile = new TFile(output_filename.c_str(), "recreate");
   fRecoTree = new TTree("phaseII", "ANNIE Phase II Reconstruction Tree");
   //Metadata for Events
-  fRecoTree->Branch("McEntryNumber",&fMCEventNum,"McEntryNumber/I");
+  fRecoTree->Branch("mcEntryNumber",&fMCEventNum,"mcEntryNumber/I");
   fRecoTree->Branch("triggerNumber",&fMCTriggerNum,"triggerNumber/I");
   fRecoTree->Branch("eventNumber",&fEventNumber,"eventNumber/I");
-
+  fRecoTree->Branch("runNumber",&fRunNumber,"runNumber/I");
+  fRecoTree->Branch("subrunNumber",&fSubrunNumber,"subrunNumber/I");
 
   //Event Staus Flag Information
   fRecoTree->Branch("eventStatusApplied",&fEventStatusApplied,"eventStatusApplied/I");
@@ -35,7 +36,7 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
   
   //Hit information (PMT and LAPPD)
   //Always output in Phase II Reco Tree
-  fRecoTree->Branch("nhits",&fNhits,"fNhits/I");
+  fRecoTree->Branch("nhits",&fNhits,"nhits/I");
   fRecoTree->Branch("filter",&fIsFiltered);
   fRecoTree->Branch("digitX",&fDigitX);
   fRecoTree->Branch("digitY",&fDigitY);
@@ -54,7 +55,7 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
   fRecoTree->Branch("recoDirX",&fRecoDirX,"recoDirX/D");
   fRecoTree->Branch("recoDirY",&fRecoDirY,"recoDirY/D");
   fRecoTree->Branch("recoDirZ",&fRecoDirZ,"recoDirZ/D");
-  fRecoTree->Branch("recoTheta",&fRecoTheta,"recoTheta/D");
+  fRecoTree->Branch("recoAngle",&fRecoAngle,"recoAngle/D");
   fRecoTree->Branch("recoPhi",&fRecoPhi,"recoPhi/D");
   fRecoTree->Branch("recoVtxFOM",&fRecoVtxFOM,"recoVtxFOM/D");
   fRecoTree->Branch("recoStatus",&fRecoStatus,"recoStatus/I");
@@ -69,7 +70,7 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
     fRecoTree->Branch("trueDirX",&fTrueDirX,"trueDirX/D");
     fRecoTree->Branch("trueDirY",&fTrueDirY,"trueDirY/D");
     fRecoTree->Branch("trueDirZ",&fTrueDirZ,"trueDirZ/D");
-    fRecoTree->Branch("trueTheta",&fTrueTheta,"trueTheta/D");
+    fRecoTree->Branch("trueAngle",&fTrueAngle,"trueAngle/D");
     fRecoTree->Branch("truePhi",&fTruePhi,"truePhi/D");
     fRecoTree->Branch("trueMuonEnergy",&fTrueMuonEnergy, "trueMuonEnergy/D");
     fRecoTree->Branch("trueTrackLengthInWater",&fTrueTrackLengthInWater,"trueTrackLengthInWater/D");
@@ -139,7 +140,7 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
 }
 
 bool PhaseIITreeMaker::Execute(){
-	Log("===========================================================================================",v_debug,verbosity);
+  Log("===========================================================================================",v_debug,verbosity);
   Log("PhaseIITreeMaker Tool: Executing",v_debug,verbosity);
 
   // Reset variables
@@ -172,6 +173,9 @@ bool PhaseIITreeMaker::Execute(){
   
   // ANNIE Event number
   m_data->Stores.at("ANNIEEvent")->Get("EventNumber",fEventNumber);
+
+  m_data->Stores.at("ANNIEEvent")->Get("RunNumber",fRunNumber);
+  m_data->Stores.at("ANNIEEvent")->Get("SubrunNumber",fSubrunNumber);
   
   std::string logmessage = "  Retriving information for MCEntry "+to_string(fMCEventNum)+
   	", MCTrigger "+ to_string(fMCTriggerNum) + ", EventNumber " + to_string(fEventNumber);
@@ -218,7 +222,7 @@ bool PhaseIITreeMaker::Execute(){
     fRecoDirX = recovtx->GetDirection().X();
     fRecoDirY = recovtx->GetDirection().Y();
     fRecoDirZ = recovtx->GetDirection().Z();
-    fRecoTheta = TMath::ACos(fRecoDirZ);
+    fRecoAngle = TMath::ACos(fRecoDirZ);
     if (fRecoDirX>0.0){
       fRecoPhi = atan(fRecoDirY/fRecoDirX);
     }
@@ -346,7 +350,7 @@ bool PhaseIITreeMaker::Execute(){
       fDeltaVtxR = sqrt(pow(fDeltaVtxX,2) + pow(fDeltaVtxY,2) + pow(fDeltaVtxZ,2)); 
       fDeltaParallel = fDeltaVtxX*fRecoDirX + fDeltaVtxY*fRecoDirY + fDeltaVtxZ*fRecoDirZ;
       fDeltaPerpendicular = sqrt(pow(fDeltaVtxR,2) - pow(fDeltaParallel,2));
-      fDeltaAzimuth = (fRecoTheta - fTrueTheta)/(TMath::Pi()/180.0);
+      fDeltaAzimuth = (fRecoAngle - fTrueAngle)/(TMath::Pi()/180.0);
       fDeltaZenith = (fRecoPhi - fTruePhi)/(TMath::Pi()/180.0); 
       double cosphi = fTrueDirX*fRecoDirX+fTrueDirY*fRecoDirY+fTrueDirZ*fRecoDirZ;
       double phi = TMath::ACos(cosphi); // radians
@@ -372,64 +376,66 @@ bool PhaseIITreeMaker::Finalise(){
 
 void PhaseIITreeMaker::ResetVariables() {
   // tree variables
-  fMCEventNum = -1;
-  fMCTriggerNum = -1;
-  fEventNumber = -1;
-  fNhits = -1;
+  fMCEventNum = -9999;
+  fMCTriggerNum = -9999;
+  fEventNumber = -9999;
+  fNhits = -9999;
+  fRunNumber = -9999;
+  fSubrunNumber = -9999;
   
-  fTrueVtxX = -1;
-  fTrueVtxY = -1;
-  fTrueVtxZ = -1;
-  fTrueVtxTime = -1;
-  fTrueMuonEnergy = -1;
-  fTrueTrackLengthInWater = -1;
-  fTrueTrackLengthInMRD = -1;
-  fTrueDirX = -1;
-  fTrueDirY = -1;
-  fTrueDirZ = -1;
-  fTrueTheta = -1;
-  fTruePhi = 0;
+  fTrueVtxX = -9999;
+  fTrueVtxY = -9999;
+  fTrueVtxZ = -9999;
+  fTrueVtxTime = -9999;
+  fTrueMuonEnergy = -9999;
+  fTrueTrackLengthInWater = -9999;
+  fTrueTrackLengthInMRD = -9999;
+  fTrueDirX = -9999;
+  fTrueDirY = -9999;
+  fTrueDirZ = -9999;
+  fTrueAngle = -9999;
+  fTruePhi = -;
  
   if (muonRecoDebug_fill){ 
     fSeedVtxX.clear();
     fSeedVtxY.clear();
     fSeedVtxZ.clear();
     fSeedVtxFOM.clear();
-    fSeedVtxTime = -1;
-    fPointPosX = -1;
-    fPointPosY = -1;
-    fPointPosZ = -1;
-    fPointPosTime = -1;
-    fPointPosFOM = -1;
-    fPointPosStatus = -1;
-    fPointDirX = -1;
-    fPointDirY = -1;
-    fPointDirZ = -1;
-    fPointDirTime = -1;
-    fPointDirFOM = -1;
-    fPointDirStatus = -1;
-    fPointVtxPosX = -1;
-    fPointVtxPosY = -1;
-    fPointVtxPosZ = -1;
-    fPointVtxDirX = -1;
-    fPointVtxDirY = -1;
-    fPointVtxDirZ = -1;
-    fPointVtxTime = -1;
-    fPointVtxStatus = -1;
-    fPointVtxFOM = -1;
+    fSeedVtxTime = -9999;
+    fPointPosX = -9999;
+    fPointPosY = -9999;
+    fPointPosZ = -9999;
+    fPointPosTime = -9999;
+    fPointPosFOM = -9999;
+    fPointPosStatus = -9999;
+    fPointDirX = -9999;
+    fPointDirY = -9999;
+    fPointDirZ = -9999;
+    fPointDirTime = -9999;
+    fPointDirFOM = -9999;
+    fPointDirStatus = -9999;
+    fPointVtxPosX = -9999;
+    fPointVtxPosY = -9999;
+    fPointVtxPosZ = -9999;
+    fPointVtxDirX = -9999;
+    fPointVtxDirY = -9999;
+    fPointVtxDirZ = -9999;
+    fPointVtxTime = -9999;
+    fPointVtxStatus = -9999;
+    fPointVtxFOM = -9999;
   }
 
-  fRecoVtxX = -1;
-  fRecoVtxY = -1;
-  fRecoVtxZ = -1;
-  fRecoStatus = -1;
-  fRecoVtxTime = -1;
-  fRecoVtxFOM = -1;
-  fRecoDirX = -1;
-  fRecoDirY = -1;
-  fRecoDirZ = -1;
-  fRecoTheta = -1;
-  fRecoPhi = -1;
+  fRecoVtxX = -9999;
+  fRecoVtxY = -9999;
+  fRecoVtxZ = -9999;
+  fRecoStatus = -9999;
+  fRecoVtxTime = -9999;
+  fRecoVtxFOM = -9999;
+  fRecoDirX = -9999;
+  fRecoDirY = -9999;
+  fRecoDirZ = -9999;
+  fRecoAngle = -9999;
+  fRecoPhi = -9999;
   fIsFiltered.clear();
   fDigitX.clear();
   fDigitY.clear();
@@ -440,25 +446,25 @@ void PhaseIITreeMaker::ResetVariables() {
   fDigitDetID.clear();	
   
   if (muonTruthRecoDiff_fill){ 
-    fDeltaVtxX = -1;
-    fDeltaVtxY = -1;
-    fDeltaVtxZ = -1;
-    fDeltaVtxR = -1;
-    fDeltaVtxT = -1;
-    fDeltaParallel = -1;
-    fDeltaPerpendicular = -1;
-    fDeltaAzimuth = -1;
-    fDeltaZenith = -1;
-    fDeltaAngle = -1;
+    fDeltaVtxX = -9999;
+    fDeltaVtxY = -9999;
+    fDeltaVtxZ = -9999;
+    fDeltaVtxR = -9999;
+    fDeltaVtxT = -9999;
+    fDeltaParallel = -9999;
+    fDeltaPerpendicular = -9999;
+    fDeltaAzimuth = -9999;
+    fDeltaZenith = -9999;
+    fDeltaAngle = -9999;
   }
 
   if (pionKaonCount_fill){
-    fPi0Count = -1;
-    fPiPlusCount = -1;
-    fPiMinusCount = -1;
-    fK0Count = -1;
-    fKPlusCount = -1;
-    fKMinusCount = -1;
+    fPi0Count = -9999;
+    fPiPlusCount = -9999;
+    fPiMinusCount = -9999;
+    fK0Count = -9999;
+    fKPlusCount = -9999;
+    fKMinusCount = -9999;
   }
 }
 
@@ -475,7 +481,8 @@ bool PhaseIITreeMaker::FillMCTruthInfo() {
     fTrueDirX = truevtx->GetDirection().X();
     fTrueDirY = truevtx->GetDirection().Y();
     fTrueDirZ = truevtx->GetDirection().Z();
-    fTrueTheta = TMath::ACos(fTrueDirZ);
+    double TrueAngRad = TMath::ACos(fTrueDirZ);
+    fTrueAngle = TrueAngRad/(TMath::Pi()/180.0); // radians->degrees
     if (fTrueDirX>0.0){
       fTruePhi = atan(fTrueDirY/fTrueDirX);
     }

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
@@ -54,7 +54,9 @@ class PhaseIITreeMaker: public Tool {
   
   /// \brief ANNIE event number
   uint32_t fEventNumber;
-
+	
+  uint32_t fRunNumber;
+  uint32_t fSubrunNumber;
   // \brief Event Status flag masks
   int fEventStatusApplied;
   int fEventStatusFlagged;
@@ -78,7 +80,7 @@ class PhaseIITreeMaker: public Tool {
   double fTrueDirX;
   double fTrueDirY;
   double fTrueDirZ;
-  double fTrueTheta;
+  double fTrueAngle;
   double fTruePhi;
   double fTrueMuonEnergy;
   double fTrueTrackLengthInWater; 
@@ -126,7 +128,7 @@ class PhaseIITreeMaker: public Tool {
   double fRecoDirY;
   double fRecoDirZ;
   double fRecoVtxFOM;
-  double fRecoTheta;
+  double fRecoAngle;
   double fRecoPhi;
   int fRecoStatus;
   

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
@@ -24,6 +24,11 @@ class PhaseIITreeMaker: public Tool {
   bool Execute();
   bool Finalise();
 
+  /// \brief Load MCTruth information into ROOT file variables
+  //
+  /// Function loads the Muon MC Truth variables with the information
+  /// Saved in the RecoEvent store.
+  bool FillMCTruthInfo();
 
  private:
  	/// \brief Reset all variables. 
@@ -75,7 +80,9 @@ class PhaseIITreeMaker: public Tool {
   double fTrueDirZ;
   double fTrueTheta;
   double fTruePhi;
-  double fTrueEnergy; 
+  double fTrueMuonEnergy;
+  double fTrueTrackLengthInWater; 
+  double fTrueTrackLengthInMRD; 
 
   // Seed vertex
   std::vector<double> fSeedVtxX;

--- a/configfiles/VertexReco/PhaseIIExtGrid/DigitBuilderConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/DigitBuilderConfig
@@ -1,0 +1,8 @@
+# DigitBuilder config file
+
+verbosity 1
+ParametricModel 1
+# There are three configurations: "PMT_only", "LAPPD_only", "All"
+PhotoDetectorConfiguration PMT_only
+#Get Pion/Kaon counts from MC Truth
+GetPionKaonInfo 1

--- a/configfiles/VertexReco/PhaseIIExtGrid/EventSelectorConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/EventSelectorConfig
@@ -1,0 +1,9 @@
+# EventSelector config file
+
+verbosity 4
+MCFVCut 1
+MCMRDCut 1
+MCPiKCut 1
+MRDRecoCut 0
+NHitCut 1
+PromptTrigOnly 1

--- a/configfiles/VertexReco/PhaseIIExtGrid/FindMrdTracksConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/FindMrdTracksConfig
@@ -1,0 +1,8 @@
+#FindMrdTracks Config File
+# all variables retrieved with m_variables.Get() must be defined here!
+
+OutputDirectory .
+verbose 1
+MinDigitsForTrack 4
+MaxMrdSubEventDuration 30  # [ns]
+WriteTracksToFile 1

--- a/configfiles/VertexReco/PhaseIIExtGrid/LoadWCSimConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/LoadWCSimConfig
@@ -1,0 +1,10 @@
+#LoadWCSim Config File
+# all variables retrieved with m_variables.Get() must be defined here!
+
+verbose 2
+HistoricTriggeroffset 0
+InputFile #INPUT_FILE_PMT#
+WCSimVersion 3               ## should reflect the WCSim version of the files being loaded
+LappdNumStrips 60        ## num channels to construct from each LAPPD
+LappdStripLength 100     ## relative x position of each LAPPD strip, for dual-sided readout [mm]
+LappdStripSeparation 10  ## stripline separation, for calculating relative y position of each LAPPD strip [mm]

--- a/configfiles/VertexReco/PhaseIIExtGrid/LoadWCSimLAPPDConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/LoadWCSimLAPPDConfig
@@ -1,0 +1,10 @@
+#LoadWCSimLAPPD Config File
+# all variables retrieved with m_variables.Get() must be defined here!
+
+verbose 3
+InputFile #INPUT_FILE_LAPPD# 
+WCSimVersion 3               ## should reflect the WCSim version of the files being loaded
+# octagonal inner structure radius in m (from drawings 106.64")
+InnerStructureRadius 1.3545
+HistoricTriggeroffset 0
+DrawDebugGraphs 0 # whether to draw TPolyMarker3D's of hits

--- a/configfiles/VertexReco/PhaseIIExtGrid/MCParticlePropertiesConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/MCParticlePropertiesConfig
@@ -1,0 +1,1 @@
+verbosity 4

--- a/configfiles/VertexReco/PhaseIIExtGrid/PhaseIITreeMakerConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/PhaseIITreeMakerConfig
@@ -1,0 +1,11 @@
+verbose 3
+
+fillCleanEventsOnly 1
+muonRecoDebug_fill 0
+muonMCTruth_fill 1
+muonTruthRecoDiff_fill 1
+pionKaonCount_fill 1
+
+OutputFile #OUTPUT_FILE_TREE#
+NumEventsWritten 2000
+

--- a/configfiles/VertexReco/PhaseIIExtGrid/README.md
+++ b/configfiles/VertexReco/PhaseIIExtGrid/README.md
@@ -1,0 +1,25 @@
+# Configure files
+
+***********************
+#Description
+**********************
+
+Configure files are simple text files for passing variables to the Tools.
+
+Text files are read by the Store class (src/Store) and automatically asigned to an internal map for the relavent Tool to use.
+
+
+************************
+#Useage
+************************
+
+Any line starting with a "#" will be ignored by the Store, as will blank lines.
+
+Variables should be stored one per line as follows:
+
+
+Name Value #Comments 
+
+
+Note: Only one value is permitted per name and they are stored in a string stream and templated cast back to the type given.
+

--- a/configfiles/VertexReco/PhaseIIExtGrid/ToolChainConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/ToolChainConfig
@@ -1,0 +1,23 @@
+#ToolChain dynamic setup file
+
+##### Runtime Paramiters #####
+verbose 0 ## Verbosity level of ToolChain
+error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
+attempt_recover 1 ## 1= will attempt to finalise if an execute fails
+
+###### Logging #####
+log_mode Interactive # Interactive=cout , Remote= remote logging system "serservice_name Remote_Logging" , Local = local file log;
+log_local_path ./log
+log_service LogStore
+
+###### Service discovery ##### Ignore these settings for local analysis
+service_publish_sec -1
+service_kick_sec -1
+
+##### Tools To Add #####
+Tools_File #INPUT_CONFIG_DIR#/ToolsConfig  ## list of tools to run and their config files
+
+##### Run Type #####
+Inline -1 ## number of Execute steps in program, -1 infinite loop that is ended by user
+Interactive 0 ## set to 1 if you want to run the code interactively
+

--- a/configfiles/VertexReco/PhaseIIExtGrid/ToolsConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/ToolsConfig
@@ -1,0 +1,10 @@
+LoadWCSim LoadWCSim #INPUT_CONFIG_DIR#/LoadWCSimConfig
+LoadWCSimLAPPD LoadWCSimLAPPD #INPUT_CONFIG_DIR#/LoadWCSimLAPPDConfig
+MCParticleProperties MCParticleProperties #INPUT_CONFIG_DIR#/MCParticlePropertiesConfig
+#FindMrdTracks FindMrdTracks #INPUT_CONFIG_DIR#/FindMrdTracksConfig
+DigitBuilder DigitBuilder #INPUT_CONFIG_DIR#//DigitBuilderConfig
+EventSelector EventSelector #INPUT_CONFIG_DIR#/EventSelectorConfig
+VtxSeedGenerator VtxSeedGenerator #INPUT_CONFIG_DIR#/VtxSeedGeneratorConfig
+VtxExtendedVertexFinder VtxExtendedVertexFinder #INPUT_CONFIG_DIR#/VtxExtendedVertexFinderConfig
+PhaseIITreeMaker PhaseIITreeMaker #INPUT_CONFIG_DIR#/PhaseIITreeMakerConfig
+#SaveRecoEvent SaveRecoEvent #INPUT_CONFIG_DIR#/SaveRecoEventConfig

--- a/configfiles/VertexReco/PhaseIIExtGrid/VtxExtendedVertexFinderConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/VtxExtendedVertexFinderConfig
@@ -1,0 +1,5 @@
+# VtxPointPositionFinder config file
+
+verbosity 3
+UseTrueVertexAsSeed 0
+FitAllOnSeedGrid 1

--- a/configfiles/VertexReco/PhaseIIExtGrid/VtxSeedGeneratorConfig
+++ b/configfiles/VertexReco/PhaseIIExtGrid/VtxSeedGeneratorConfig
@@ -1,0 +1,6 @@
+# VtxSeedGenerator config file
+
+verbosity 3
+NumberOfSeeds 100
+UseSeedGrid 1
+SeedType 2

--- a/configfiles/VertexReco/PhaseIIReco/MCParticlePropertiesConfig
+++ b/configfiles/VertexReco/PhaseIIReco/MCParticlePropertiesConfig
@@ -1,0 +1,1 @@
+verbosity 4

--- a/configfiles/VertexReco/PhaseIIReco/ToolsConfig
+++ b/configfiles/VertexReco/PhaseIIReco/ToolsConfig
@@ -1,5 +1,6 @@
 LoadWCSim LoadWCSim ./configfiles/VertexReco/PhaseIIReco/LoadWCSimConfig
 LoadWCSimLAPPD LoadWCSimLAPPD ./configfiles/VertexReco/PhaseIIReco/LoadWCSimLAPPDConfig
+MCParticleProperties MCParticleProperties ./configfiles/VertexReco/PhaseIIReco/MCParticlePropertiesConfig
 #FindMrdTracks FindMrdTracks ./configfiles/FindMrdTracks/FindMrdTracksConfig
 DigitBuilder DigitBuilder ./configfiles/VertexReco/PhaseIIReco/DigitBuilderConfig
 HitCleaner HitCleaner ./configfiles/VertexReco/PhaseIIReco/HitCleanerConfig

--- a/configfiles/VertexReco/PhaseIIRecoTruth/MCParticlePropertiesConfig
+++ b/configfiles/VertexReco/PhaseIIRecoTruth/MCParticlePropertiesConfig
@@ -1,0 +1,1 @@
+verbosity 4

--- a/configfiles/VertexReco/PhaseIIRecoTruth/ToolsConfig
+++ b/configfiles/VertexReco/PhaseIIRecoTruth/ToolsConfig
@@ -1,5 +1,6 @@
 LoadWCSim LoadWCSim ./configfiles/VertexReco/PhaseIIRecoTruth/LoadWCSimConfig
 LoadWCSimLAPPD LoadWCSimLAPPD ./configfiles/VertexReco/PhaseIIRecoTruth/LoadWCSimLAPPDConfig
+MCParticleProperties MCParticleProperties ./configfiles/VertexReco/PhaseIIReco/MCParticlePropertiesConfig
 #FindMrdTracks FindMrdTracks ./configfiles/FindMrdTracks/FindMrdTracksConfig
 DigitBuilder DigitBuilder ./configfiles/VertexReco/PhaseIIRecoTruth/DigitBuilderConfig
 EventSelector EventSelector ./configfiles/VertexReco/PhaseIIRecoTruth/EventSelectorConfig

--- a/configfiles/VertexReco/PhaseIISanityCheck/MCParticlePropertiesConfig
+++ b/configfiles/VertexReco/PhaseIISanityCheck/MCParticlePropertiesConfig
@@ -1,0 +1,1 @@
+verbosity 4

--- a/configfiles/VertexReco/PhaseIISanityCheck/ToolsConfig
+++ b/configfiles/VertexReco/PhaseIISanityCheck/ToolsConfig
@@ -1,5 +1,6 @@
 LoadWCSim LoadWCSim ./configfiles/VertexReco/PhaseIISanityCheck/LoadWCSimConfig
 LoadWCSimLAPPD LoadWCSimLAPPD ./configfiles/VertexReco/PhaseIISanityCheck/LoadWCSimLAPPDConfig
+MCParticleProperties MCParticleProperties ./configfiles/VertexReco/PhaseIIReco/MCParticlePropertiesConfig
 #FindMrdTracks FindMrdTracks ./configfiles/FindMrdTracks/FindMrdTracksConfig
 EventSelector EventSelector ./configfiles/VertexReco/PhaseIISanityCheck/EventSelectorConfig
 DigitBuilder DigitBuilder ./configfiles/VertexReco/PhaseIISanityCheck/DigitBuilderConfig


### PR DESCRIPTION
Notes regarding major changes:
  - Hotfix in the DigitBuilder tool in hit selection for Parametric model
  - Addition of MCParticleProperties to the standard VertexReco toolchains to store True MRD/Tank track info
  - Addition of some info needed for energy reconstruction training into PhaseIITreeMaker
  - Variables that have no info. loaded in PhaseIITreeMaker now initialized to -9999 rather than 0
  