### PR TITLE
Added flags that check Reconstruction information in EventSelector

### DIFF
--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -16,11 +16,13 @@ bool EventSelector::Initialise(std::string configfile, DataModel &data){
   m_variables.Get("verbosity",verbosity);
   m_variables.Get("MRDRecoCut", fMRDRecoCut);
   m_variables.Get("MCFVCut", fMCFVCut);
+  m_variables.Get("MCPMTVolCut", fMCPMTVolCut);
   m_variables.Get("MCMRDCut", fMCMRDCut);
   m_variables.Get("MCPiKCut", fMCPiKCut);
   m_variables.Get("NHitCut", fNHitCut);
   m_variables.Get("PromptTrigOnly", fPromptTrigOnly);
   m_variables.Get("RecoFVCut", fRecoFVCut);
+  m_variables.Get("RecoPMTVolCut", fRecoPMTVolCut);
   m_variables.Get("SaveStatusToStore", fSaveStatusToStore);
 
   /// Construct the other objects we'll be needing at event level,
@@ -72,23 +74,32 @@ bool EventSelector::Execute(){
   	return false;
   }
 
+  // BEGIN CUTS USING TRUTH INFORMATION //
   if (fMCPiKCut){
     fEventApplied |= EventSelector::kFlagMCPiK; 
     bool passNoPiK = this->EventSelectionNoPiK();
     if(!passNoPiK) fEventFlagged |= EventSelector::kFlagMCPiK;
   }  
-  if(fMCFVCut){
+
+  if(fMCFVCut || fMCPMTVolCut){
     // get truth vertex information 
     auto get_truevtx = m_data->Stores.at("RecoEvent")->Get("TrueVertex", fMuonStartVertex);
 	if(!get_truevtx){ 
 	  Log("EventSelector Tool: Error retrieving TrueVertex from RecoEvent!",v_error,verbosity); 
 	  return false; 
 	}
-    fEventApplied |= EventSelector::kFlagMCFV; 
-    bool passMCFVCut= this->EventSelectionByFV(true);
-    if(!passMCFVCut) fEventFlagged |= EventSelector::kFlagMCFV;
-; 
+    if (fMCFVCut){
+      fEventApplied |= EventSelector::kFlagMCFV; 
+      bool passMCFVCut= this->EventSelectionByFV(true);
+      if(!passMCFVCut) fEventFlagged |= EventSelector::kFlagMCFV;
+    }
+    if (fMCPMTVolCut){
+      fEventApplied |= EventSelector::kFlagMCPMTVol; 
+      bool passMCPMTCut= this->EventSelectionByPMTVol(true);
+      if(!passMCPMTCut) fEventFlagged |= EventSelector::kFlagMCPMTVol;
+    }
   }
+
   if(fMCMRDCut){
     auto get_truestopvtx = m_data->Stores.at("RecoEvent")->Get("TrueStopVertex", fMuonStopVertex);
     if(!get_truestopvtx){ 
@@ -113,16 +124,24 @@ bool EventSelector::Execute(){
     if(!HasEnoughHits) fEventFlagged |= EventSelector::kFlagNHit;
   }
 
-  if(fRecoFVCut){
+  // BEGIN CUTS USING RECONSTRUCTED INFORMATION //
+  if(fRecoFVCut || fRecoPMTVolCut){
 	// Retrive Reconstructed vertex from RecoEvent 
 	auto get_ok = m_data->Stores.at("RecoEvent")->Get("ExtendedVertex",fRecoVertex);  ///> Get reconstructed vertex 
     if(not get_ok){
   	  Log("EventSelector Tool: Error retrieving Extended vertex from RecoEvent!",v_error,verbosity); 
   	  return false;
     }
-    fEventApplied |= EventSelector::kFlagRecoFV; 
-    bool passRecoFVCut= this->EventSelectionByFV(false);
-    if(!passRecoFVCut) fEventFlagged |= EventSelector::kFlagRecoFV;
+    if(fRecoFVCut){
+      fEventApplied |= EventSelector::kFlagRecoFV; 
+      bool passRecoFVCut= this->EventSelectionByFV(false);
+      if(!passRecoFVCut) fEventFlagged |= EventSelector::kFlagRecoFV;
+    }
+    if(fRecoPMTVolCut){
+      fEventApplied |= EventSelector::kFlagRecoPMTVol; 
+      bool passRecoPMTVolCut= this->EventSelectionByPMTVol(false);
+      if(!passRecoPMTVolCut) fEventFlagged |= EventSelector::kFlagRecoPMTVol;
+    }
   }
 
   //FIXME: This isn't working according to Jingbo
@@ -275,6 +294,35 @@ bool EventSelector::EventSelectionByFV(bool isMC) {
   	  || (TMath::Abs(checkedVtxY) > fidcuty) 
   	  || (checkedVtxZ > fidcutz) ){
   Log("EventSelector Tool: This event did not reconstruct inside the FV",v_message,verbosity); 
+  return false;
+  }	
+ 
+  return true;
+}
+
+bool EventSelector::EventSelectionByPMTVol(bool isMC) {
+  if(isMC && !fMuonStartVertex) return false;
+  if(!isMC && !fRecoVertex) return false;
+  RecoVertex* checkedVertex;
+  if(isMC){
+      Log("EventSelector Tool: Checking PMT volume cut for true muon vertex",v_debug,verbosity); 
+      checkedVertex=fMuonStartVertex;
+  } else {
+      Log("EventSelector Tool: Checking PMT volume cut for reconstructed muon vertex",v_debug,verbosity); 
+    checkedVertex=fRecoVertex;
+  }
+  double checkedVtxX, checkedVtxY, checkedVtxZ;
+  Position vtxPos = checkedVertex->GetPosition();
+  Direction vtxDir = checkedVertex->GetDirection();
+  checkedVtxX = vtxPos.X();
+  checkedVtxY = vtxPos.Y();
+  checkedVtxZ = vtxPos.Z();
+  //Currently hard-coded; estimated with a tape measure on the ANNIE frame :)
+  double fidcutradius = 87.;
+  double fidcuty = 85.;
+  if( (TMath::Sqrt(TMath::Power(checkedVtxX, 2) + TMath::Power(checkedVtxZ,2)) > fidcutradius) 
+  	  || (TMath::Abs(checkedVtxY) > fidcuty)){
+  Log("EventSelector Tool: This event did not reconstruct inside the PMT volume",v_message,verbosity); 
   return false;
   }	
  

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -293,7 +293,7 @@ bool EventSelector::EventSelectionByFV(bool isMC) {
   if( (TMath::Sqrt(TMath::Power(checkedVtxX, 2) + TMath::Power(checkedVtxZ,2)) > fidcutradius) 
   	  || (TMath::Abs(checkedVtxY) > fidcuty) 
   	  || (checkedVtxZ > fidcutz) ){
-  Log("EventSelector Tool: This event did not reconstruct inside the FV",v_message,verbosity); 
+  Log("EventSelector Tool: This event is not contained inside the FV",v_message,verbosity); 
   return false;
   }	
  
@@ -318,11 +318,11 @@ bool EventSelector::EventSelectionByPMTVol(bool isMC) {
   checkedVtxY = vtxPos.Y();
   checkedVtxZ = vtxPos.Z();
   //Currently hard-coded; estimated with a tape measure on the ANNIE frame :)
-  double fidcutradius = 87.;
-  double fidcuty = 85.;
+  double fidcutradius = 100.;
+  double fidcuty = 145;
   if( (TMath::Sqrt(TMath::Power(checkedVtxX, 2) + TMath::Power(checkedVtxZ,2)) > fidcutradius) 
   	  || (TMath::Abs(checkedVtxY) > fidcuty)){
-  Log("EventSelector Tool: This event did not reconstruct inside the PMT volume",v_message,verbosity); 
+  Log("EventSelector Tool: This event is not contained within the PMT volume",v_message,verbosity); 
   return false;
   }	
  

--- a/UserTools/EventSelector/EventSelector.h
+++ b/UserTools/EventSelector/EventSelector.h
@@ -30,12 +30,14 @@ class EventSelector: public Tool {
   typedef enum EventFlags {
    kFlagNone         = 0x00, //0
    kFlagMCFV         = 0x01, //1
-   kFlagMCMRD        = 0x02, //2
-   kFlagMCPiK        = 0x04, //4
-   kFlagRecoMRD      = 0x08, //8
-   kFlagPromptTrig   = 0x10, //16
-   kFlagNHit         = 0x20, //32
-   kFlagRecoFV       = 0x30, //64
+   kFlagMCPMTVol     = 0x02, //2
+   kFlagMCMRD        = 0x04, //4
+   kFlagMCPiK        = 0x08, //8
+   kFlagRecoMRD      = 0x10, //16
+   kFlagPromptTrig   = 0x20, //32
+   kFlagNHit         = 0x40, //64
+   kFlagRecoFV       = 0x80, //128
+   kFlagRecoPMTVol   = 0x100, //256
   } EventFlags_t;
 
  private:
@@ -70,6 +72,13 @@ class EventSelector: public Tool {
     /// If False, the reconstructed vertex is used. 
  	bool EventSelectionByFV(bool isMC);
 
+ 	/// \brief Event selection by PMT Volume 
+ 	///
+ 	/// The selection is based on the muon interaction point. 
+ 	/// If isMC is true, checks the Event using muon truth info. 
+    /// If False, the reconstructed vertex is used. 
+ 	bool EventSelectionByPMTVol(bool isMC);
+
  	/// \brief Event selection by Muon MRD stop position
   /////
  	/// The selection is based on the true vertex stop position from MC. 
@@ -97,35 +106,37 @@ class EventSelector: public Tool {
   // \brief Event Status bitwords
   int fEventApplied; //Integer indicates what event cleaning flags were checked for the event
   int fEventFlagged; //Integer indicates what evt. cleaning flags the event was flagged with
-
-	Geometry fGeometry;    ///< ANNIE Geometry
-	RecoVertex* fMuonStartVertex = nullptr; 	 ///< true muon start vertex
-	RecoVertex* fMuonStopVertex = nullptr; 	 ///< true muon stop vertex
-	std::vector<RecoDigit>* fDigitList;				///< Reconstructed Hits including both LAPPD hits and PMT hits
-	RecoVertex* fRecoVertex = nullptr; 	 ///< Reconstructed Vertex 
-
-	//verbosity initialization
-	int verbosity=1;
-
-	std::string fInputfile;
-	bool fMRDRecoCut = false;
-	bool fMCFVCut = false;
-	bool fRecoFVCut = false;
-	bool fMCMRDCut = false;
-	bool fMCPiKCut = false;
+  
+  Geometry fGeometry;    ///< ANNIE Geometry
+  RecoVertex* fMuonStartVertex = nullptr; 	 ///< true muon start vertex
+  RecoVertex* fMuonStopVertex = nullptr; 	 ///< true muon stop vertex
+  std::vector<RecoDigit>* fDigitList;				///< Reconstructed Hits including both LAPPD hits and PMT hits
+  RecoVertex* fRecoVertex = nullptr; 	 ///< Reconstructed Vertex 
+  
+  //verbosity initialization
+  int verbosity=1;
+  
+  std::string fInputfile;
+  bool fMRDRecoCut = false;
+  bool fMCFVCut = false;
+  bool fMCPMTVolCut = false;
+  bool fMCMRDCut = false;
+  bool fMCPiKCut = false;
   bool fNHitCut = true;
+  bool fRecoPMTVolCut = false;
+  bool fRecoFVCut = false;
   bool fPromptTrigOnly = true;
-	bool fEventCutStatus;
-
-
-    bool fSaveStatusToStore = true;
-	/// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.
-	int v_error=0;
-	int v_warning=1;
-	int v_message=2;
-	int v_debug=3;
-	std::string logmessage;
-
+  bool fEventCutStatus;
+  
+  
+  bool fSaveStatusToStore = true;
+  /// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.
+  int v_error=0;
+  int v_warning=1;
+  int v_message=2;
+  int v_debug=3;
+  std::string logmessage;
+  
 };
 
 

--- a/UserTools/EventSelector/README.md
+++ b/UserTools/EventSelector/README.md
@@ -10,27 +10,38 @@ utilized include:
   - MCPiKCut: Flags events that had a primary muon or pion produced
   - MRDRecoCut Flags muon events that do not stop in the MRD according to reco.
   - MCFVCut: Flags MC muon events that are not generated in the defined Fiducial volume 
+  - MCPMTVolCut: Flags MC muon events that are not generated inside the PMT volume 
   - MCMRDCut: Flags MC muon events with muons that do not stop in the MRD
   - PromptTrigOnly: Flags muon events that do not have an MCTriggernum of 0
                     (any store event with MCTriggernum>0 is a delayed trigger)
   - NHit: Flags events that do not have at least some number of hits (default is 4)
+  - Identical cuts, but with the reconstructed information, are prefaced with "Reco"
 
 After running the event selector tool, two bitmasks are added to the RecoEvent
 store: "EventFlagApplied" and "EventFlagged".  The prior indicates which event
 selection criteria were checked on the event, while the latter indicates which
 event selection the event actually failed.  The bitmask as of now is given by:
 
-   kFlagNone  = 0x00, //0
-   kFlagMCFV    = 0x01, //1
-   kFlagMCMRD    = 0x02, //2
-   kFlagMCPiK   = 0x04, //4
-   kFlagRecoMRD    = 0x08, //8
-   kFlagPromptTrig     = 0x10, //16
-   kFlagNHit     = 0x20, //32
+   kFlagNone         = 0x00, //0
+   kFlagMCFV         = 0x01, //1
+   kFlagMCPMTVol     = 0x02, //2
+   kFlagMCMRD        = 0x04, //4
+   kFlagMCPiK        = 0x08, //8
+   kFlagRecoMRD      = 0x10, //16
+   kFlagPromptTrig   = 0x20, //32
+   kFlagNHit         = 0x40, //64
+   kFlagRecoFV       = 0x80, //128
+   kFlagRecoPMTVol   = 0x100, //256
 
-For each event, all cuts defined with the config file are checked.  If the event
-passes all cuts, EventCutStatus is set to true and saved to the RecoEvent store.
-If any cut fails, EventCutStatus is set to false.
+For each event, all cuts defined with the config file are checked.  
+
+The fSaveStatusToStore bool determines if the "EventCutStatus" bool in the store
+is updated after running event selection.  If the event
+passes all cuts and fSaveStatusToStore==true, EventCutStatus is set to true in 
+the RecoEvent store.  If any cut fails, EventCutStatus is set to false.
+
+The EventCutStatus tool is used by downstream tools to determine whether to run
+the tool or not.  
 
 
 ## Configuration
@@ -39,11 +50,16 @@ Configurables tell EventSelector which cuts to run/check when defining the
 master EventCutStatus bit checked by all following tools
 
 ```
-verbosity bool
-
-MRDRecoCut (1 or 0)
-MCTruthCut (1 or 0)
-MCPiKCut (1 or 0)
-GetPionKaonInfo (1 or 0)
-PromptTrigOnly (1 or 0)
+All bools (1 or 0)
+verbosity
+MRDRecoCut
+MCFVCut
+MCPMTVolCut
+MCMRDCut
+MCPiKCut
+NHitCut
+PromptTrigOnly
+RecoFVCut
+RecoPMTVolCut
+SaveStatusToStore
 ```


### PR DESCRIPTION
This PR adds flags for checking reconstruction information using the EventSelector tool.  When the tool is run, either the MC Truth information or reconstruction information can now be used to flag events.