### PR TITLE
Volume enclosed by PMTs added as geometry property

### DIFF
--- a/DataModel/Geometry.cpp
+++ b/DataModel/Geometry.cpp
@@ -1,7 +1,7 @@
 /* vim:set noexpandtab tabstop=4 wrap */
 #include "Geometry.h"
 
-Geometry::Geometry(double ver, Position tankc, double tankr, double tankhh, double mrdw, double mrdh, double mrdd, double mrds, int ntankpmts, int nmrdpmts, int nvetopmts, int nlappds, geostatus statin, std::vector<std::map<unsigned long,Detector>* >dets){
+Geometry::Geometry(double ver, Position tankc, double tankr, double tankhh, double pmtr, double pmthh, double mrdw, double mrdh, double mrdd, double mrds, int ntankpmts, int nmrdpmts, int nvetopmts, int nlappds, geostatus statin, std::vector<std::map<unsigned long,Detector>* >dets){
 	NextFreeChannelKey=0;
 	NextFreeDetectorKey=0;
 	Version=ver;
@@ -9,6 +9,8 @@ Geometry::Geometry(double ver, Position tankc, double tankr, double tankhh, doub
 	tank_centre=tankc;
 	tank_radius=tankr;
 	tank_halfheight=tankhh;
+	pmt_radius=pmtr;
+	pmt_halfheight=pmthh;
 	mrd_width=mrdw;
 	mrd_height=mrdh;
 	mrd_depth=mrdd;

--- a/DataModel/Geometry.cpp
+++ b/DataModel/Geometry.cpp
@@ -1,7 +1,7 @@
 /* vim:set noexpandtab tabstop=4 wrap */
 #include "Geometry.h"
 
-Geometry::Geometry(double ver, Position tankc, double tankr, double tankhh, double pmtr, double pmthh, double mrdw, double mrdh, double mrdd, double mrds, int ntankpmts, int nmrdpmts, int nvetopmts, int nlappds, geostatus statin, std::vector<std::map<unsigned long,Detector>* >dets){
+Geometry::Geometry(double ver, Position tankc, double tankr, double tankhh, double pmtencr, double pmtenchh, double mrdw, double mrdh, double mrdd, double mrds, int ntankpmts, int nmrdpmts, int nvetopmts, int nlappds, geostatus statin, std::vector<std::map<unsigned long,Detector>* >dets){
 	NextFreeChannelKey=0;
 	NextFreeDetectorKey=0;
 	Version=ver;
@@ -9,8 +9,8 @@ Geometry::Geometry(double ver, Position tankc, double tankr, double tankhh, doub
 	tank_centre=tankc;
 	tank_radius=tankr;
 	tank_halfheight=tankhh;
-	pmt_radius=pmtr;
-	pmt_halfheight=pmthh;
+	pmt_enclosed_radius=pmtencr;
+	pmt_enclosed_halfheight=pmtenchh;
 	mrd_width=mrdw;
 	mrd_height=mrdh;
 	mrd_depth=mrdd;

--- a/DataModel/Geometry.h
+++ b/DataModel/Geometry.h
@@ -17,12 +17,12 @@ class Geometry : public SerialisableObject{
 	
 	public:
 	// Do we care to have the overloaded empty constructor?
-	Geometry() : NextFreeChannelKey(0), NextFreeDetectorKey(0), Version(0.), tank_centre(Position(0,0,0)), tank_radius(0.), tank_halfheight(0.), mrd_width(0.), mrd_height(0.), mrd_depth(0.), mrd_start(0.), numtankpmts(0), nummrdpmts(0), numvetopmts(0), numlappds(0), Status(geostatus::FULLY_OPERATIONAL), Detectors(std::vector<std::map<unsigned long,Detector>* >{}) {
+	Geometry() : NextFreeChannelKey(0), NextFreeDetectorKey(0), Version(0.), tank_centre(Position(0,0,0)), tank_radius(0.), tank_halfheight(0.), pmt_radius(0.), pmt_halfheight(0.), mrd_width(0.), mrd_height(0.), mrd_depth(0.), mrd_start(0.), numtankpmts(0), nummrdpmts(0), numvetopmts(0), numlappds(0), Status(geostatus::FULLY_OPERATIONAL), Detectors(std::vector<std::map<unsigned long,Detector>* >{}) {
 		serialise=true;
 		RealDetectors.reserve(10);
 	}
 	
-	Geometry(double ver, Position tankc, double tankr, double tankhh, double mrdw, double mrdh, double mrdd, double mrds, int ntankpmts, int nmrdpmts, int nvetopmts, int nlappds, geostatus statin, std::vector<std::map<unsigned long,Detector>* >dets=std::vector<std::map<unsigned long,Detector>* >{});
+	Geometry(double ver, Position tankc, double tankr, double tankhh, double pmtr, double pmthh, double mrdw, double mrdh, double mrdd, double mrds, int ntankpmts, int nmrdpmts, int nvetopmts, int nlappds, geostatus statin, std::vector<std::map<unsigned long,Detector>* >dets=std::vector<std::map<unsigned long,Detector>* >{});
 	
 	inline std::vector<std::map<unsigned long,Detector>* >* GetDetectors(){return &Detectors;}
 	inline double GetVersion(){return Version;}
@@ -30,6 +30,8 @@ class Geometry : public SerialisableObject{
 	inline Position GetTankCentre(){return tank_centre;}
 	inline double GetTankRadius(){return tank_radius;}
 	inline double GetTankHalfheight(){return tank_halfheight;}
+	inline double GetPMTRadius(){return pmt_radius;}
+	inline double GetPMTHalfheight(){return pmt_halfheight;}
 	inline double GetFiducialCutRadius(){return fiducialradius;}
 	inline double GetFiducialCutY(){return fiducialcuty;}
 	inline double GetFiducialCutZ(){return fiducialcutz;}
@@ -44,6 +46,8 @@ class Geometry : public SerialisableObject{
 	inline void SetTankCentre(Position tank_centrein){tank_centre = tank_centrein;}
 	inline void SetTankRadius(double tank_radiusIn){tank_radius = tank_radiusIn;}
 	inline void SetTankHalfheight(double tank_halfheightIn){tank_halfheight = tank_halfheightIn;}
+	inline void SetPMTRadius(double pmt_radiusIn){pmt_radius = pmt_radiusIn;}
+	inline void SetPMTHalfheight(double pmt_halfheightIn){pmt_halfheight = pmt_halfheightIn;}
 	inline void SetFiducialCutRadius(double fidcutradiusin){fiducialradius = fidcutradiusin;}
 	inline void SetFiducialCutZ(double fidcutzin){fiducialcutz = fidcutzin;}
 	inline void SetFiducialCutY(double fidcutyin){fiducialcuty = fidcutyin;}
@@ -219,6 +223,8 @@ class Geometry : public SerialisableObject{
 		cout<<"tank_centre : "; tank_centre.Print();
 		cout<<"tank_radius : "<<tank_radius<<endl;
 		cout<<"tank_halfheight : "<<tank_halfheight<<endl;
+		cout<<"pmt_radius : "<<pmt_radius<<endl;
+		cout<<"pmt_halfheight : "<<pmt_halfheight<<endl;
 		cout<<"tank fiducial radius: "<<fiducialradius<<endl;
 		cout<<"tank fiducial z cut: "<<fiducialcutz<<endl;
 		cout<<"tank fiducial y cut: "<<fiducialcuty<<endl;
@@ -256,6 +262,8 @@ class Geometry : public SerialisableObject{
 	Position tank_centre;
 	double tank_radius;
 	double tank_halfheight;
+	double pmt_radius;
+	double pmt_halfheight;
 	double mrd_width;
 	double mrd_height;
 	double mrd_depth;

--- a/DataModel/Geometry.h
+++ b/DataModel/Geometry.h
@@ -17,12 +17,12 @@ class Geometry : public SerialisableObject{
 	
 	public:
 	// Do we care to have the overloaded empty constructor?
-	Geometry() : NextFreeChannelKey(0), NextFreeDetectorKey(0), Version(0.), tank_centre(Position(0,0,0)), tank_radius(0.), tank_halfheight(0.), pmt_radius(0.), pmt_halfheight(0.), mrd_width(0.), mrd_height(0.), mrd_depth(0.), mrd_start(0.), numtankpmts(0), nummrdpmts(0), numvetopmts(0), numlappds(0), Status(geostatus::FULLY_OPERATIONAL), Detectors(std::vector<std::map<unsigned long,Detector>* >{}) {
+	Geometry() : NextFreeChannelKey(0), NextFreeDetectorKey(0), Version(0.), tank_centre(Position(0,0,0)), tank_radius(0.), tank_halfheight(0.), pmt_enclosed_radius(0.), pmt_enclosed_halfheight(0.), mrd_width(0.), mrd_height(0.), mrd_depth(0.), mrd_start(0.), numtankpmts(0), nummrdpmts(0), numvetopmts(0), numlappds(0), Status(geostatus::FULLY_OPERATIONAL), Detectors(std::vector<std::map<unsigned long,Detector>* >{}) {
 		serialise=true;
 		RealDetectors.reserve(10);
 	}
 	
-	Geometry(double ver, Position tankc, double tankr, double tankhh, double pmtr, double pmthh, double mrdw, double mrdh, double mrdd, double mrds, int ntankpmts, int nmrdpmts, int nvetopmts, int nlappds, geostatus statin, std::vector<std::map<unsigned long,Detector>* >dets=std::vector<std::map<unsigned long,Detector>* >{});
+	Geometry(double ver, Position tankc, double tankr, double tankhh, double pmtencr, double pmtenchh, double mrdw, double mrdh, double mrdd, double mrds, int ntankpmts, int nmrdpmts, int nvetopmts, int nlappds, geostatus statin, std::vector<std::map<unsigned long,Detector>* >dets=std::vector<std::map<unsigned long,Detector>* >{});
 	
 	inline std::vector<std::map<unsigned long,Detector>* >* GetDetectors(){return &Detectors;}
 	inline double GetVersion(){return Version;}
@@ -30,8 +30,8 @@ class Geometry : public SerialisableObject{
 	inline Position GetTankCentre(){return tank_centre;}
 	inline double GetTankRadius(){return tank_radius;}
 	inline double GetTankHalfheight(){return tank_halfheight;}
-	inline double GetPMTRadius(){return pmt_radius;}
-	inline double GetPMTHalfheight(){return pmt_halfheight;}
+	inline double GetPMTEnclosedRadius(){return pmt_enclosed_radius;}
+	inline double GetPMTEnclosedHalfheight(){return pmt_enclosed_halfheight;}
 	inline double GetFiducialCutRadius(){return fiducialradius;}
 	inline double GetFiducialCutY(){return fiducialcuty;}
 	inline double GetFiducialCutZ(){return fiducialcutz;}
@@ -46,8 +46,8 @@ class Geometry : public SerialisableObject{
 	inline void SetTankCentre(Position tank_centrein){tank_centre = tank_centrein;}
 	inline void SetTankRadius(double tank_radiusIn){tank_radius = tank_radiusIn;}
 	inline void SetTankHalfheight(double tank_halfheightIn){tank_halfheight = tank_halfheightIn;}
-	inline void SetPMTRadius(double pmt_radiusIn){pmt_radius = pmt_radiusIn;}
-	inline void SetPMTHalfheight(double pmt_halfheightIn){pmt_halfheight = pmt_halfheightIn;}
+	inline void SetPMTEnclosedRadius(double pmt_enclosed_radiusIn){pmt_enclosed_radius = pmt_enclosed_radiusIn;}
+	inline void SetPMTEnclosedHalfheight(double pmt_enclosed_halfheightIn){pmt_enclosed_halfheight = pmt_enclosed_halfheightIn;}
 	inline void SetFiducialCutRadius(double fidcutradiusin){fiducialradius = fidcutradiusin;}
 	inline void SetFiducialCutZ(double fidcutzin){fiducialcutz = fidcutzin;}
 	inline void SetFiducialCutY(double fidcutyin){fiducialcuty = fidcutyin;}
@@ -223,8 +223,8 @@ class Geometry : public SerialisableObject{
 		cout<<"tank_centre : "; tank_centre.Print();
 		cout<<"tank_radius : "<<tank_radius<<endl;
 		cout<<"tank_halfheight : "<<tank_halfheight<<endl;
-		cout<<"pmt_radius : "<<pmt_radius<<endl;
-		cout<<"pmt_halfheight : "<<pmt_halfheight<<endl;
+		cout<<"pmt_enclosed_radius : "<<pmt_enclosed_radius<<endl;
+		cout<<"pmt_enclosed_halfheight : "<<pmt_enclosed_halfheight<<endl;
 		cout<<"tank fiducial radius: "<<fiducialradius<<endl;
 		cout<<"tank fiducial z cut: "<<fiducialcutz<<endl;
 		cout<<"tank fiducial y cut: "<<fiducialcuty<<endl;
@@ -262,8 +262,8 @@ class Geometry : public SerialisableObject{
 	Position tank_centre;
 	double tank_radius;
 	double tank_halfheight;
-	double pmt_radius;
-	double pmt_halfheight;
+	double pmt_enclosed_radius;
+	double pmt_enclosed_halfheight;
 	double mrd_width;
 	double mrd_height;
 	double mrd_depth;
@@ -284,6 +284,8 @@ class Geometry : public SerialisableObject{
 			ar & tank_centre;
 			ar & tank_radius;
 			ar & tank_halfheight;
+			ar & pmt_enclosed_radius;
+			ar & pmt_enclosed_halfheight;
 			ar & mrd_width;
 			ar & mrd_height;
 			ar & mrd_depth;

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -320,8 +320,8 @@ bool EventSelector::EventSelectionByPMTVol(bool isMC) {
   checkedVtxX = vtxPos.X();
   checkedVtxY = vtxPos.Y();
   checkedVtxZ = vtxPos.Z();
-  double fidcutradius = fGeometry.GetPMTRadius()*100.;
-  double fidcuty = fGeometry.GetPMTHalfheight()*100.;
+  double fidcutradius = fGeometry.GetPMTEnclosedRadius()*100.;
+  double fidcuty = fGeometry.GetPMTEnclosedHalfheight()*100.;
   if( (TMath::Sqrt(TMath::Power(checkedVtxX, 2) + TMath::Power(checkedVtxZ,2)) > fidcutradius) 
   	  || (TMath::Abs(checkedVtxY) > fidcuty)){
   Log("EventSelector Tool: This event is not contained within the PMT volume",v_message,verbosity); 

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -320,9 +320,8 @@ bool EventSelector::EventSelectionByPMTVol(bool isMC) {
   checkedVtxX = vtxPos.X();
   checkedVtxY = vtxPos.Y();
   checkedVtxZ = vtxPos.Z();
-  //Currently hard-coded; estimated with a tape measure on the ANNIE frame :)
-  double fidcutradius = 100.;
-  double fidcuty = 145;
+  double fidcutradius = fGeometry.GetPMTRadius()*100.;
+  double fidcuty = fGeometry.GetPMTHalfheight()*100.;
   if( (TMath::Sqrt(TMath::Power(checkedVtxX, 2) + TMath::Power(checkedVtxZ,2)) > fidcutradius) 
   	  || (TMath::Abs(checkedVtxY) > fidcuty)){
   Log("EventSelector Tool: This event is not contained within the PMT volume",v_message,verbosity); 

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -566,8 +566,8 @@ void LoadWCSim::ConstructToolChainGeometry(){
 	double tank_radius = (wcsimrootgeom->GetWCCylRadius()) / 100.;
 	double tank_halfheight = (wcsimrootgeom->GetWCCylLength()) / 100.;
 	//Currently hard-coded; estimated with a tape measure on the ANNIE frame :)
-	double pmt_radius = 1.0;
-	double pmt_halfheight = 1.45;
+	double pmt_enclosed_radius = 1.0;
+	double pmt_enclosed_halfheight = 1.45;
 	// geometry variables not yet in wcsimrootgeom are in MRDSpecs.hh
 	double mrd_width  =  (MRDSpecs::MRD_width)  / 100.;
 	double mrd_height =  (MRDSpecs::MRD_height) / 100.;
@@ -582,8 +582,8 @@ void LoadWCSim::ConstructToolChainGeometry(){
 									   tank_centre,
 									   tank_radius,
 									   tank_halfheight,
-									   pmt_radius,
-									   pmt_halfheight,
+									   pmt_enclosed_radius,
+									   pmt_enclosed_halfheight,
 									   mrd_width,
 									   mrd_height,
 									   mrd_depth,

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -565,6 +565,9 @@ void LoadWCSim::ConstructToolChainGeometry(){
 	Position tank_centre(tank_xcentre, tank_ycentre, tank_zcentre);
 	double tank_radius = (wcsimrootgeom->GetWCCylRadius()) / 100.;
 	double tank_halfheight = (wcsimrootgeom->GetWCCylLength()) / 100.;
+	//Currently hard-coded; estimated with a tape measure on the ANNIE frame :)
+	double pmt_radius = 1.0;
+	double pmt_halfheight = 1.45;
 	// geometry variables not yet in wcsimrootgeom are in MRDSpecs.hh
 	double mrd_width  =  (MRDSpecs::MRD_width)  / 100.;
 	double mrd_height =  (MRDSpecs::MRD_height) / 100.;
@@ -579,6 +582,8 @@ void LoadWCSim::ConstructToolChainGeometry(){
 									   tank_centre,
 									   tank_radius,
 									   tank_halfheight,
+									   pmt_radius,
+									   pmt_halfheight,
 									   mrd_width,
 									   mrd_height,
 									   mrd_depth,


### PR DESCRIPTION
The geometry class now has get/set methods for the volume enclosed by the PMTs in ANNIE.

LoadWCSim has been modified to load the current estimate for the PMT-enclosed radius and half-height.  Volume was estimated using a tape measure on the frame.  