### PR TITLE
Separation of LnL and FoM calculations from MinuitOptimizer

### DIFF
--- a/DataModel/FoMCalculator.cpp
+++ b/DataModel/FoMCalculator.cpp
@@ -1,0 +1,630 @@
+#include "FoMCalculator.h"
+
+//Constructor
+FoMCalculator::FoMCalculator() {
+  fVtxGeo = 0;
+  fBaseFOM = 100.0;
+  
+  // fitting parameters ported from vertexFinder (FIXME)
+  fTimeFitWeight = 0.50;  // nominal time weight
+  fConeFitWeight = 0.50;  // nominal cone weight
+  
+  // default Mean time calculator type
+  fMeanTimeCalculatorType = 0;
+}
+
+//Destructor
+FoMCalculator::~FoMCalculator() {
+	fVtxGeo = 0;
+}
+	
+
+void FoMCalculator::LoadVertexGeometry(VertexGeometry* vtxgeo) {
+  this->fVtxGeo = vtxgeo;	
+}
+
+
+void FoMCalculator::TimePropertiesLnL(double vtxTime, double vtxParam, double& vtxFOM)
+{ 
+  // nuisance parameters
+  // ===================
+  double scatter = vtxParam; 
+
+  // internal variables
+  // ==================
+  double weight = 0.0;
+  double delta = 0.0;       // time residual of each hit
+  double sigma = 0.0;       // time resolution of each hit
+  double A = 0.0;           // normalisation of first Gaussian
+  int type;                 // Digit type (LAPPD or PMT)
+  
+  double Preal = 0.0;       // probability of real hit
+  double P = 0.0;           // probability of hit
+
+  double chi2 = 0.0;        // log-likelihood: chi2 = -2.0*log(L)
+  double ndof = 0.0;        // total number of hits
+  double fom = 0.0;         // figure of merit
+
+  // tuning parameters
+  // =================
+  double fTimeFitNoiseRate = 0.02;  // hits/ns [0.40 for electrons, 0.02 for muons]
+  // need to simulate the rate of the cosmic background
+  // add noise to model
+  // ==================
+  double nFilterDigits = this->fVtxGeo->GetNFilterDigits(); 
+  double Pnoise; 
+  //Pnoise = fTimeFitNoiseRate/nFilterDigits;//FIXME
+  
+  //bool istruehits = (Interface::Instance())->IsTrueHits();
+  bool istruehits = 0; // for test only. JW
+
+  // loop over digits
+  // ================
+  
+  for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
+    	int detType = this->fVtxGeo->GetDigitType(idigit); 
+      delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
+      sigma = this->fVtxGeo->GetDeltaSigma(idigit);
+      type = this->fVtxGeo->GetDigitType(idigit);
+      if (type == RecoDigit::PMT8inch){  //PMT8Inch
+        sigma = 1.5*sigma;
+        Pnoise = 1e-8; //FIXME; Need implementation of noise model 
+      } 
+      if (type == RecoDigit::lappd_v0){  //lappd
+        sigma = 1.2*sigma;
+        Pnoise = 1e-8;  //FIXME; Need implementation of noise model 
+      }
+      A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
+      Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
+      P = (1.0-Pnoise)*Preal + Pnoise; 
+      chi2 += -2.0*log(P);
+      ndof += 1.0; 
+//      cout<<"(tm, t0, dt, sigma) = "<<this->fVtxGeo->GetDelta(idigit)<<", "<<vtxTime<<", "<<delta<<", "<<sigma<<endl;
+  }	
+  
+//  TString configType = Parameters::Instance()->GetConfigurationType();
+//  	
+//  if(configType == "LAPPD")	{
+//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
+//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
+//      if( detType == "lappd_v0" /*&& this->fVtxGeo->IsFiltered(idigit)*/){
+//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
+//        sigma = 1.2 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
+//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
+//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
+//        P = (1.0-Pnoise)*Preal + Pnoise; 
+//        chi2 += -2.0*log(P);
+//        ndof += 1.0; 
+//      }
+//    }
+//  }
+//  
+//  else if(configType == "PMT") {
+//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
+//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
+//      if( detType == "PMT8inch" && this->fVtxGeo->GetDigitQ(idigit)>5/*&& this->fVtxGeo->IsFiltered(idigit)*/){
+//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
+//        sigma = 1.5 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
+//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
+//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
+//        P = (1.0-Pnoise)*Preal + Pnoise; 
+//        chi2 += -2.0*log(P);
+//        ndof += 1.0; 
+//      }
+//    }	
+//  }
+//  
+//  else if(configType == "Combined") {
+//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
+//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
+//      delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
+//      sigma = this->fVtxGeo->GetDeltaSigma(idigit);
+//      if(detType == "lappd_v0") sigma = 1.2*sigma;
+//      if(detType == "PMT8inch") sigma = 1.5*sigma;
+//      A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
+//      Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
+//      P = (1.0-Pnoise)*Preal + Pnoise; 
+//      chi2 += -2.0*log(P);
+//      ndof += 1.0; 
+//    }	
+//  }
+//  
+//  else if (configType == "Two-stage") {
+//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
+//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
+//      if( detType == "lappd_v0" /*&& this->fVtxGeo->IsFiltered(idigit)*/){
+//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
+//        sigma = 1.2 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
+//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
+//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
+//        P = (1.0-Pnoise)*Preal + Pnoise; 
+//        chi2 += -2.0*log(P);
+//        ndof += 1.0; 
+//      }
+//    }	
+//  }
+
+
+  // calculate figure of merit
+  if( ndof>0.0 ){
+    fom = fBaseFOM - 5.0*chi2/ndof;
+  }  
+
+  // return figure of merit
+  // ======================
+  vtxFOM = fom;
+  
+
+  return;
+}
+
+
+
+
+void FoMCalculator::ConePropertiesFoM(double coneEdge, double& coneFOM)
+{  
+  // calculate figure of merit
+  // =========================
+  double coneEdgeLow = 21.0;  // cone edge (low side)      
+  double coneEdgeHigh = 3.0;  // cone edge (high side)   [muons: 3.0, electrons: 7.0]
+
+  double deltaAngle = 0.0;
+  double digitCharge = 0.0;
+ 
+  double coneCharge = 0.0;
+  double allCharge = 0.0;
+
+  double fom = 0.0;
+
+  for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){ 	
+    if( this->fVtxGeo->IsFiltered(idigit) && this->fVtxGeo->GetDigitType(idigit) == RecoDigit::PMT8inch){
+      deltaAngle = this->fVtxGeo->GetAngle(idigit) - coneEdge;
+      digitCharge = this->fVtxGeo->GetDigitQ(idigit);
+
+      if( deltaAngle<=0.0 ){
+        coneCharge += digitCharge*( 0.75 + 0.25/( 1.0 + (deltaAngle*deltaAngle)/(coneEdgeLow*coneEdgeLow) ) );
+      }
+      else{
+        coneCharge += digitCharge*( 0.00 + 1.00/( 1.0 + (deltaAngle*deltaAngle)/(coneEdgeHigh*coneEdgeHigh) ) );
+      }
+
+      allCharge += digitCharge;
+    }
+  }
+
+  if( allCharge>0.0 ){
+    fom = fBaseFOM*coneCharge/allCharge;
+  }
+
+  // return figure of merit
+  // ======================
+  coneFOM = fom;
+
+  return;
+}
+
+
+
+
+//Given the position of the point vertex (x, y, z) and n digits, calculate the mean expected vertex time
+double FoMCalculator::FindSimpleTimeProperties(double myConeEdge) {
+	double meanTime = 0.0;
+	// weighted average
+	if(fMeanTimeCalculatorType == 0) {
+    // calculate mean and rms of hits inside cone
+    // ==========================================
+    double Swx = 0.0;
+    double Sw = 0.0;
+    
+    double delta = 0.0;
+    double sigma = 0.0;
+    double weight = 0.0;
+    double deweight = 0.0;
+    double deltaAngle = 0.0;
+    
+    double myConeEdgeSigma = 7.0;  // [degrees]
+    
+    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){
+      int detType = this->fVtxGeo->GetDigitType(idigit); 
+      if( this->fVtxGeo->IsFiltered(idigit) ){
+        delta = this->fVtxGeo->GetDelta(idigit);    
+        sigma = this->fVtxGeo->GetDeltaSigma(idigit);
+        weight = 1.0/(sigma*sigma); 
+        // profile in angle
+        deltaAngle = this->fVtxGeo->GetAngle(idigit) - myConeEdge;      
+        // deweight hits outside cone
+        if( deltaAngle<=0.0 ){
+          deweight = 1.0;
+        }
+        else{
+          deweight = 1.0/(1.0+(deltaAngle*deltaAngle)/(myConeEdgeSigma*myConeEdgeSigma));
+        }
+        Swx += deweight*weight*delta; //delta is expected vertex time 
+        Sw  += deweight*weight;
+      }
+    }
+    if( Sw>0.0 ){
+      meanTime = Swx*1.0/Sw;
+    }
+	}
+	
+	// most probable time
+	else if(fMeanTimeCalculatorType == 1) {
+		double sigma = 0.0;
+		double deltaAngle = 0.0;
+		double weight = 0.0;
+		double deweight = 0.0;
+    double myConeEdgeSigma = 7.0;  // [degrees]
+		vector<double> deltaTime1;
+		vector<double> deltaTime2;
+		vector<double> TimeWeight;
+		
+		for( int idigit=0; idigit<fVtxGeo->GetNDigits(); idigit++ ){
+      if(fVtxGeo->IsFiltered(idigit)){
+        deltaTime1.push_back(fVtxGeo->GetDelta(idigit));  
+        deltaTime2.push_back(fVtxGeo->GetDelta(idigit));   
+        sigma = fVtxGeo->GetDeltaSigma(idigit);
+        weight = 1.0/(sigma*sigma); 
+        deltaAngle = fVtxGeo->GetAngle(idigit) - myConeEdge;
+        if( deltaAngle<=0.0 ){
+          deweight = 1.0;
+        }
+        else{
+          deweight = 1.0/(1.0+(deltaAngle*deltaAngle)/(myConeEdgeSigma*myConeEdgeSigma));
+        }
+        TimeWeight.push_back(deweight*weight);
+      }
+    }
+    int n = deltaTime1.size();
+    std::sort(deltaTime1.begin(),deltaTime1.end());
+    double timeMin = deltaTime1.at(int((n-1)*0.05)); // 5% of the total entries
+    double timeMax = deltaTime1.at(int((n-1)*0.90)); // 90% of the total entries
+    int nbins = int(n/5);
+    TH1D *hDeltaTime = new TH1D("hDeltaTime", "hDeltaTime", nbins, timeMin, timeMax);
+    for(int i=0; i<n; i++) {
+      //hDeltaTime->Fill(deltaTime2.at(i), TimeWeight.at(i));	
+      hDeltaTime->Fill(deltaTime2.at(i));	
+    }
+    meanTime = hDeltaTime->GetBinCenter(hDeltaTime->GetMaximumBin());
+    delete hDeltaTime; hDeltaTime = 0;
+	}
+	
+	else std::cout<<"FoMCalculator Error: Wrong type of Mean time calculator! "<<std::endl;
+  
+  return meanTime; //return expected vertex time
+}
+
+void FoMCalculator::PointPositionChi2(double vtxX, double vtxY, double vtxZ, double vtxParam0, double vtxTime, double& fom)
+{  
+  // figure of merit
+  // ===============
+  double vtxFOM = 0.0;
+  double penaltyFOM = 0.0;
+  double fixPositionFOM = 0.0;
+  
+  // calculate residuals
+  // ===================
+  this->fVtxGeo->CalcPointResiduals(vtxX, vtxY, vtxZ, 0.0, 0.0, 0.0, 0.0); //calculate expected point vertex time for each digit
+
+  // calculate figure of merit
+  // =========================
+  this->TimePropertiesLnL(vtxTime,vtxParam0, vtxFOM);
+
+  // calculate penalty
+  // =================
+  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
+
+  // calculate overall figure of merit
+  // =================================
+  fom = vtxFOM + penaltyFOM + fixPositionFOM;
+  // truncate
+  if( fom<-9999. ) fom = -9999.;
+
+  return;
+}
+
+
+
+
+
+void FoMCalculator::PointDirectionChi2(double vtxX, double vtxY, 
+	                                       double vtxZ, double dirX, double dirY, double dirZ, 
+	                                       double coneAngle, double& fom)
+{  
+  // figure of merit
+  // ===============
+  double coneFOM = 0.0;
+  double fixPositionFOM = 0.0;
+  
+  // calculate residuals
+  // ===================
+  this->fVtxGeo->CalcPointResiduals(vtxX, vtxY, vtxZ, 0.0, 
+                                 dirX, dirY, dirZ); //load expected vertex time for each digit
+
+  // calculate figure of merit
+  // =========================
+  this->ConePropertiesFoM(coneAngle, coneFOM);
+
+  // calculate overall figure of merit
+  // =================================
+  fom = coneFOM;
+
+  // truncate
+  if( fom<-9999. ) fom = -9999.;
+
+  return;
+}
+
+void FoMCalculator::PointVertexChi2(double vtxX, double vtxY, double vtxZ, 
+	                                    double dirX, double dirY, double dirZ, double vtxParam0,
+	                                    double coneAngle, double vtxTime, double& fom)
+{  
+  // figure of merit
+  // ===============
+  double vtxFOM = 0.0;
+  double penaltyFOM = 0.0;
+  double fixPositionFOM = 0.0;
+  double fixDirectionFOM = 0.0;
+
+  // calculate residuals
+  // ===================
+  this->fVtxGeo->CalcPointResiduals(vtxX, vtxY, vtxZ, 0.0, 
+                                 dirX, dirY, dirZ); //calculate expected vertex time for each digit
+  // calculate figure of merit
+  // =========================
+  double timeFOM = 0.0;
+  double coneFOM = 0.0;
+  
+  this->ConePropertiesFoM(coneAngle,coneFOM);
+  this->TimePropertiesLnL(vtxTime, vtxParam0, timeFOM);
+  
+  double fTimeFitWeight = this->fTimeFitWeight;
+  double fConeFitWeight = this->fConeFitWeight;
+  vtxFOM = (fTimeFitWeight*timeFOM+fConeFitWeight*coneFOM)/(fTimeFitWeight+fConeFitWeight);
+
+  // calculate penalty
+  // =================
+  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
+
+  // calculate overall figure of merit
+  // =================================
+  
+  fom = vtxFOM + penaltyFOM + fixPositionFOM + fixDirectionFOM;
+  // truncate
+  if( fom<-9999. ) fom = -9999.;
+
+  return;
+}
+
+void FoMCalculator::ExtendedVertexChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double vtxParam0, double coneAngle, double vtxTime, double& fom)
+{  
+  // figure of merit
+  // ===============
+  double vtxFOM = 0.0;
+  double timeFOM = 0.0;
+  double coneFOM = 0.0;
+  double penaltyFOM = 0.0;
+  double fixPositionFOM = 0.0;
+  double fixDirectionFOM = 0.0;
+
+  // calculate residuals
+  // ===================
+  this->fVtxGeo->CalcExtendedResiduals(vtxX,vtxY,vtxZ,0.0,dirX,dirY,dirZ);
+  
+  // calculate figure of merit
+  // =========================
+
+  this->ConePropertiesFoM(coneAngle,coneFOM);
+  this->TimePropertiesLnL(vtxTime,vtxParam0, timeFOM);
+  //this->FitExtendedTimePropertiesLnL(vtxTime,timeFOM);
+  
+  double fTimeFitWeight = this->fTimeFitWeight;
+  double fConeFitWeight = this->fConeFitWeight;
+  vtxFOM = (fTimeFitWeight*timeFOM+fConeFitWeight*coneFOM)/(fTimeFitWeight+fConeFitWeight);
+
+  // calculate penalty
+  // =================
+  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
+
+  // calculate overall figure of merit
+  // =================================
+  fom = vtxFOM + penaltyFOM + fixPositionFOM + fixDirectionFOM;
+
+  // truncate
+  if( fom<-9999. ) fom = -9999.;
+
+  return;
+}
+
+//KEPT FOR HISTORY, BUT FITTER IS CURRENTLY NOT WORKING
+//void FoMCalculator::CorrectedVertexChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double& vtxAngle, double& vtxTime, double& fom)
+//{  
+//  // figure of merit
+//  // ===============
+//  double vtxFOM = 0.0;
+//  double timeFOM = 0.0;
+//  double coneFOM = 0.0;
+//  double penaltyFOM = 0.0;
+//  double fixPositionFOM = 0.0;
+//  double fixDirectionFOM = 0.0;
+//
+//  // calculate residuals
+//  // ===================
+//  this->fVtxGeo->CalcExtendedResiduals(vtxX,vtxY,vtxZ,0.0,dirX,dirY,dirZ);
+//  
+//  // calculate figure of merit
+//  // =========================
+//
+//  this->ConePropertiesFoM(vtxAngle,coneFOM);
+//  fom = coneFOM;
+//
+//  // truncate
+//  if( fom<-999.999*fBaseFOM ) fom = -999.999*fBaseFOM;
+//
+//  return;
+//}
+//
+//void FoMCalculator::ConePropertiesLnL(double coneParam0, double coneParam1, double coneParam2, double& coneAngle, double& coneFOM)
+//{  
+//  
+//  // nuisance parameters
+//  // ===================
+//  double alpha  = coneParam0; // track length parameter = 0.25
+//  double alpha0 = coneParam1; // track length parameter = 0.5
+//  double beta   = coneParam2; // particle ID:  0.0[electron]->1.0[muon] = 0.75
+//
+//  // internal variables
+//  // ==================
+//  double deltaAngle = 0.0; //
+//  double sigmaAngle = 7.0; //Cherenkov Angle resolution
+//  double Angle0 = Parameters::CherenkovAngle(); //Cherenkov Angle: 42 degree
+//  double deltaAngle0 = Angle0*alpha0; //?
+//  
+//  double digitQ = 0.0;
+//  double sigmaQmin = 1.0;
+//  double sigmaQmax = 10.0;
+//  double sigmaQ = 0.0;
+//
+//  double A = 0.0;
+//  
+//  double PconeA = 0.0;
+//  double PconeB = 0.0;
+//  double Pmu = 0.0;
+//  double Pel = 0.0;
+//
+//  double Pcharge = 0.0;
+//  double Pangle = 0.0;
+//  double P = 0.0;
+//
+//  double chi2 = 0.0;
+//  double ndof = 0.0;
+//
+//  double angle = 46.0;
+//  double fom = 0.0;
+//
+//  // hard-coded parameters: 200 kton (100 kton)
+//  // ==========================================
+//  double lambdaMuShort = 0.5; //  0.5;
+//  double lambdaMuLong  = 5.0; // 15.0;
+//  double alphaMu =       1.0; //  4.5;
+//
+//  double lambdaElShort = 1.0; //  2.5;
+//  double lambdaElLong =  7.5; // 15.0;
+//  double alphaEl =       6.0; //  3.5;
+//
+//  // numerical integrals
+//  // ===================
+//  fSconeA = 21.9938;  
+//  fSconeB =  0.0000;
+//  
+//  // Number of P.E. angular distribution
+//  // inside cone
+//  int nbinsInside = 420; //divide the angle range by 420 bins
+//  for( int n=0; n<nbinsInside; n++ ){
+//    deltaAngle = -Angle0 + (n+0.5)*(Angle0/(double)nbinsInside); // angle axis
+//    fSconeB += 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
+//                           *( 1.0/(1.0+(deltaAngle*deltaAngle)/(deltaAngle0*deltaAngle0)) )
+//                           *( Angle0/(double)nbinsInside );
+//  }
+//
+//  // outside cone
+//  if( fIntegralsDone == 0 ){ // default 0
+//    fSmu = 0.0;
+//    fSel = 0.0;
+//
+//    int nbinsOutside = 1380;
+//    for( int n=0; n<nbinsOutside; n++ ){
+//      deltaAngle = 0.0 + (n+0.5)*(138.0/(double)nbinsOutside);
+//
+//      fSmu += 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
+//                          *( 1.0/(1.0+alphaMu*(lambdaMuShort/lambdaMuLong)) )*( 1.0/(1.0+(deltaAngle*deltaAngle)/(lambdaMuShort*lambdaMuShort)) 
+//	  			            + alphaMu*(lambdaMuShort/lambdaMuLong)/(1.0+(deltaAngle*deltaAngle)/(lambdaMuLong*lambdaMuLong)) )
+//                          *( 138.0/(double)nbinsOutside );
+//
+//      fSel += 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
+//                          *( 1.0/(1.0+alphaEl*(lambdaElShort/lambdaElLong)) )*( 1.0/(1.0+(deltaAngle*deltaAngle)/(lambdaElShort*lambdaElShort)) 
+//				          + alphaEl*(lambdaElShort/lambdaElLong)/(1.0+(deltaAngle*deltaAngle)/(lambdaElLong*lambdaElLong)) )
+//                          *( 138.0/(double)nbinsOutside );
+//    }
+//
+//    fIntegralsDone = 1;
+//  }
+//
+//  // loop over digits
+//  // ================
+//  for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){
+//
+//    if( this->fVtxGeo->IsFiltered(idigit) ){
+//      digitQ = this->fVtxGeo->GetDigitQ(idigit);
+//      deltaAngle = this->fVtxGeo->GetAngle(idigit) - Angle0;
+//
+//      // pulse height distribution
+//      // =========================
+//      if( deltaAngle<=0 ){ //inside Cone
+//	      sigmaQ = sigmaQmax;
+//      }
+//      else{ //outside Cone
+//        sigmaQ = sigmaQmin + (sigmaQmax-sigmaQmin)/(1.0+(deltaAngle*deltaAngle)/(sigmaAngle*sigmaAngle));
+//      }
+//
+//      A = 1.0/(log(2.0)+0.5*TMath::Pi()*sigmaQ);
+//
+//      if( digitQ<1.0 ){
+//        Pcharge = 2.0*A*digitQ/(1.0+digitQ*digitQ);
+//      }
+//      else{
+//        Pcharge = A/(1.0+(digitQ-1.0)*(digitQ-1.0)/(sigmaQ*sigmaQ));
+//      }
+//
+//      // angular distribution
+//      // ====================
+//      A = 1.0/( alpha*fSconeA + (1.0-alpha)*fSconeB
+//               + beta*fSmu + (1.0-beta)*fSel ); // numerical integrals
+//
+//      if( deltaAngle<=0 ){
+//
+//        // pdfs inside cone:
+//        PconeA = 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) );
+//        PconeB = 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
+//                          *( 1.0/(1.0+(deltaAngle*deltaAngle)/(deltaAngle0*deltaAngle0)) );
+//
+//        Pangle = A*( alpha*PconeA+(1.0-alpha)*PconeB );
+//      }		
+//      else{
+//
+//        // pdfs outside cone
+//        Pmu = 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
+//                       *( 1.0/(1.0+alphaMu*(lambdaMuShort/lambdaMuLong)) )*( 1.0/(1.0+(deltaAngle*deltaAngle)/(lambdaMuShort*lambdaMuShort)) 
+//                                          + alphaMu*(lambdaMuShort/lambdaMuLong)/(1.0+(deltaAngle*deltaAngle)/(lambdaMuLong*lambdaMuLong)) );
+//
+//        Pel = 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
+//                       *( 1.0/(1.0+alphaEl*(lambdaElShort/lambdaElLong)) )*( 1.0/(1.0+(deltaAngle*deltaAngle)/(lambdaElShort*lambdaElShort)) 
+//                                          + alphaEl*(lambdaElShort/lambdaElLong)/(1.0+(deltaAngle*deltaAngle)/(lambdaElLong*lambdaElLong)) );
+//
+//        Pangle = A*( beta*Pmu+(1.0-beta)*Pel );
+//      }
+//
+//      // overall probability
+//      // ===================
+//      P = Pcharge*Pangle;
+//      
+//      chi2 += -2.0*log(P);
+//      ndof += 1.0;
+//    }
+//  }
+//
+//  // calculate figure of merit
+//  // =========================   
+//  if( ndof>0.0 ){
+//    fom = fBaseFOM - 5.0*chi2/ndof;
+//    angle = beta*43.0 + (1.0-beta)*49.0;
+//  }
+//
+//  // return figure of merit
+//  // ======================
+//  coneAngle = angle;
+//  coneFOM = fom;
+//
+//  return;
+//}
+

--- a/DataModel/FoMCalculator.cpp
+++ b/DataModel/FoMCalculator.cpp
@@ -24,12 +24,8 @@ void FoMCalculator::LoadVertexGeometry(VertexGeometry* vtxgeo) {
 }
 
 
-void FoMCalculator::TimePropertiesLnL(double vtxTime, double vtxParam, double& vtxFOM)
+void FoMCalculator::TimePropertiesLnL(double vtxTime, double& vtxFOM)
 { 
-  // nuisance parameters
-  // ===================
-  double scatter = vtxParam; 
-
   // internal variables
   // ==================
   double weight = 0.0;
@@ -43,24 +39,19 @@ void FoMCalculator::TimePropertiesLnL(double vtxTime, double vtxParam, double& v
 
   double chi2 = 0.0;        // log-likelihood: chi2 = -2.0*log(L)
   double ndof = 0.0;        // total number of hits
-  double fom = 0.0;         // figure of merit
+  double fom = -9999.;         // figure of merit
 
-  // tuning parameters
-  // =================
-  double fTimeFitNoiseRate = 0.02;  // hits/ns [0.40 for electrons, 0.02 for muons]
-  // need to simulate the rate of the cosmic background
   // add noise to model
   // ==================
-  double nFilterDigits = this->fVtxGeo->GetNFilterDigits(); 
-  double Pnoise; 
-  //Pnoise = fTimeFitNoiseRate/nFilterDigits;//FIXME
-  
-  //bool istruehits = (Interface::Instance())->IsTrueHits();
-  bool istruehits = 0; // for test only. JW
+  double Pnoise;
 
+  //FIXME: We need an implementation of noise models for PMTs and LAPPDs
+  //double nFilterDigits = this->fVtxGeo->GetNFilterDigits(); 
+  //double fTimeFitNoiseRate = 0.02;  // hits/ns [0.40 for electrons, 0.02 for muons]
+  //Pnoise = fTimeFitNoiseRate/nFilterDigits;
+  
   // loop over digits
   // ================
-  
   for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
     	int detType = this->fVtxGeo->GetDigitType(idigit); 
       delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
@@ -79,71 +70,7 @@ void FoMCalculator::TimePropertiesLnL(double vtxTime, double vtxParam, double& v
       P = (1.0-Pnoise)*Preal + Pnoise; 
       chi2 += -2.0*log(P);
       ndof += 1.0; 
-//      cout<<"(tm, t0, dt, sigma) = "<<this->fVtxGeo->GetDelta(idigit)<<", "<<vtxTime<<", "<<delta<<", "<<sigma<<endl;
   }	
-  
-//  TString configType = Parameters::Instance()->GetConfigurationType();
-//  	
-//  if(configType == "LAPPD")	{
-//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
-//      if( detType == "lappd_v0" /*&& this->fVtxGeo->IsFiltered(idigit)*/){
-//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-//        sigma = 1.2 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
-//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-//        P = (1.0-Pnoise)*Preal + Pnoise; 
-//        chi2 += -2.0*log(P);
-//        ndof += 1.0; 
-//      }
-//    }
-//  }
-//  
-//  else if(configType == "PMT") {
-//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
-//      if( detType == "PMT8inch" && this->fVtxGeo->GetDigitQ(idigit)>5/*&& this->fVtxGeo->IsFiltered(idigit)*/){
-//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-//        sigma = 1.5 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
-//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-//        P = (1.0-Pnoise)*Preal + Pnoise; 
-//        chi2 += -2.0*log(P);
-//        ndof += 1.0; 
-//      }
-//    }	
-//  }
-//  
-//  else if(configType == "Combined") {
-//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
-//      delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-//      sigma = this->fVtxGeo->GetDeltaSigma(idigit);
-//      if(detType == "lappd_v0") sigma = 1.2*sigma;
-//      if(detType == "PMT8inch") sigma = 1.5*sigma;
-//      A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-//      Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-//      P = (1.0-Pnoise)*Preal + Pnoise; 
-//      chi2 += -2.0*log(P);
-//      ndof += 1.0; 
-//    }	
-//  }
-//  
-//  else if (configType == "Two-stage") {
-//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
-//      if( detType == "lappd_v0" /*&& this->fVtxGeo->IsFiltered(idigit)*/){
-//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-//        sigma = 1.2 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
-//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-//        P = (1.0-Pnoise)*Preal + Pnoise; 
-//        chi2 += -2.0*log(P);
-//        ndof += 1.0; 
-//      }
-//    }	
-//  }
-
 
   // calculate figure of merit
   if( ndof>0.0 ){
@@ -153,8 +80,6 @@ void FoMCalculator::TimePropertiesLnL(double vtxTime, double vtxParam, double& v
   // return figure of merit
   // ======================
   vtxFOM = fom;
-  
-
   return;
 }
 
@@ -167,14 +92,12 @@ void FoMCalculator::ConePropertiesFoM(double coneEdge, double& coneFOM)
   // =========================
   double coneEdgeLow = 21.0;  // cone edge (low side)      
   double coneEdgeHigh = 3.0;  // cone edge (high side)   [muons: 3.0, electrons: 7.0]
-
   double deltaAngle = 0.0;
   double digitCharge = 0.0;
- 
   double coneCharge = 0.0;
   double allCharge = 0.0;
 
-  double fom = 0.0;
+  double fom = -9999.;
 
   for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){ 	
     if( this->fVtxGeo->IsFiltered(idigit) && this->fVtxGeo->GetDigitType(idigit) == RecoDigit::PMT8inch){
@@ -199,7 +122,6 @@ void FoMCalculator::ConePropertiesFoM(double coneEdge, double& coneFOM)
   // return figure of merit
   // ======================
   coneFOM = fom;
-
   return;
 }
 
@@ -294,13 +216,11 @@ double FoMCalculator::FindSimpleTimeProperties(double myConeEdge) {
   return meanTime; //return expected vertex time
 }
 
-void FoMCalculator::PointPositionChi2(double vtxX, double vtxY, double vtxZ, double vtxParam0, double vtxTime, double& fom)
+void FoMCalculator::PointPositionChi2(double vtxX, double vtxY, double vtxZ, double vtxTime, double& fom)
 {  
   // figure of merit
   // ===============
-  double vtxFOM = 0.0;
-  double penaltyFOM = 0.0;
-  double fixPositionFOM = 0.0;
+  double vtxFOM = -9999.;
   
   // calculate residuals
   // ===================
@@ -308,15 +228,11 @@ void FoMCalculator::PointPositionChi2(double vtxX, double vtxY, double vtxZ, dou
 
   // calculate figure of merit
   // =========================
-  this->TimePropertiesLnL(vtxTime,vtxParam0, vtxFOM);
-
-  // calculate penalty
-  // =================
-  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
+  this->TimePropertiesLnL(vtxTime, vtxFOM);
 
   // calculate overall figure of merit
   // =================================
-  fom = vtxFOM + penaltyFOM + fixPositionFOM;
+  fom = vtxFOM;
   // truncate
   if( fom<-9999. ) fom = -9999.;
 
@@ -333,8 +249,7 @@ void FoMCalculator::PointDirectionChi2(double vtxX, double vtxY,
 {  
   // figure of merit
   // ===============
-  double coneFOM = 0.0;
-  double fixPositionFOM = 0.0;
+  double coneFOM = -9999.;
   
   // calculate residuals
   // ===================
@@ -356,15 +271,12 @@ void FoMCalculator::PointDirectionChi2(double vtxX, double vtxY,
 }
 
 void FoMCalculator::PointVertexChi2(double vtxX, double vtxY, double vtxZ, 
-	                                    double dirX, double dirY, double dirZ, double vtxParam0,
+	                                    double dirX, double dirY, double dirZ,
 	                                    double coneAngle, double vtxTime, double& fom)
 {  
   // figure of merit
   // ===============
-  double vtxFOM = 0.0;
-  double penaltyFOM = 0.0;
-  double fixPositionFOM = 0.0;
-  double fixDirectionFOM = 0.0;
+  double vtxFOM = -9999.;
 
   // calculate residuals
   // ===================
@@ -372,40 +284,32 @@ void FoMCalculator::PointVertexChi2(double vtxX, double vtxY, double vtxZ,
                                  dirX, dirY, dirZ); //calculate expected vertex time for each digit
   // calculate figure of merit
   // =========================
-  double timeFOM = 0.0;
-  double coneFOM = 0.0;
+  double timeFOM = -9999.;
+  double coneFOM = -9999.;
   
   this->ConePropertiesFoM(coneAngle,coneFOM);
-  this->TimePropertiesLnL(vtxTime, vtxParam0, timeFOM);
+  this->TimePropertiesLnL(vtxTime, timeFOM);
   
   double fTimeFitWeight = this->fTimeFitWeight;
   double fConeFitWeight = this->fConeFitWeight;
   vtxFOM = (fTimeFitWeight*timeFOM+fConeFitWeight*coneFOM)/(fTimeFitWeight+fConeFitWeight);
 
-  // calculate penalty
-  // =================
-  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
-
   // calculate overall figure of merit
   // =================================
-  
-  fom = vtxFOM + penaltyFOM + fixPositionFOM + fixDirectionFOM;
+  fom = vtxFOM;
   // truncate
   if( fom<-9999. ) fom = -9999.;
 
   return;
 }
 
-void FoMCalculator::ExtendedVertexChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double vtxParam0, double coneAngle, double vtxTime, double& fom)
+void FoMCalculator::ExtendedVertexChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double coneAngle, double vtxTime, double& fom)
 {  
   // figure of merit
   // ===============
-  double vtxFOM = 0.0;
-  double timeFOM = 0.0;
-  double coneFOM = 0.0;
-  double penaltyFOM = 0.0;
-  double fixPositionFOM = 0.0;
-  double fixDirectionFOM = 0.0;
+  double vtxFOM = -9999.;
+  double timeFOM = -9999.;
+  double coneFOM = -9999.;
 
   // calculate residuals
   // ===================
@@ -415,20 +319,15 @@ void FoMCalculator::ExtendedVertexChi2(double vtxX, double vtxY, double vtxZ, do
   // =========================
 
   this->ConePropertiesFoM(coneAngle,coneFOM);
-  this->TimePropertiesLnL(vtxTime,vtxParam0, timeFOM);
-  //this->FitExtendedTimePropertiesLnL(vtxTime,timeFOM);
+  this->TimePropertiesLnL(vtxTime, timeFOM);
   
   double fTimeFitWeight = this->fTimeFitWeight;
   double fConeFitWeight = this->fConeFitWeight;
   vtxFOM = (fTimeFitWeight*timeFOM+fConeFitWeight*coneFOM)/(fTimeFitWeight+fConeFitWeight);
 
-  // calculate penalty
-  // =================
-  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
-
   // calculate overall figure of merit
   // =================================
-  fom = vtxFOM + penaltyFOM + fixPositionFOM + fixDirectionFOM;
+  fom = vtxFOM;
 
   // truncate
   if( fom<-9999. ) fom = -9999.;

--- a/DataModel/FoMCalculator.h
+++ b/DataModel/FoMCalculator.h
@@ -43,20 +43,21 @@ public:
  	
   FoMCalculator();
   ~FoMCalculator();
-  void SetTimeFitWeight(double tweight){ fTimeFitWeight=tweight};
-  void SetConeFitWeight(double cweight){ fConeFitWeight=cweight};
+  void SetTimeFitWeight(double tweight){ fTimeFitWeight=tweight;}
+  void SetConeFitWeight(double cweight){ fConeFitWeight=cweight;}
+  void SetMeanTimeCalculatorType(int type) {fMeanTimeCalculatorType = type;}
   void LoadVertexGeometry(VertexGeometry* vtxgeo);
   double FindSimpleTimeProperties(double myConeEdge);
-  void TimePropertiesLnL(double vtxTime, double vtxParam, double& vtxFom);
+  void TimePropertiesLnL(double vtxTime, double& vtxFom);
   void ConePropertiesFoM(double coneEdge, double& chi2);
-  void PointPositionChi2(double vtxX, double vtxY, double vtxZ, double FixTimeParam0, double& vtxTime, double& fom);
+  void PointPositionChi2(double vtxX, double vtxY, double vtxZ, double vtxTime, double& fom);
   void PointDirectionChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double coneAngle, double& fom);
   void PointVertexChi2(double vtxX, double vtxY, double vtxZ,
 	                                    double dirX, double dirY, double dirZ, 
-	                                    double coneAngle, double& vtxTime, double& fom);
+	                                    double coneAngle, double vtxTime, double& fom);
   void ExtendedVertexChi2(double vtxX, double vtxY, double vtxZ, 
 	                                    double dirX, double dirY, double dirZ, 
-	                                    double vtxParam0, double coneAngle, double& vtxTime, double& fom);
+	                                    double coneAngle, double vtxTime, double& fom);
 //  void ConePropertiesLnL(double coneParam0, double coneParam1, double coneParam2, double& coneAngle, double& coneFOM);
 //  void CorrectedVertexChi2(double vtxX, double vtxY, double vtxZ, 
 //	                                    double dirX, double dirY, double dirZ, 

--- a/DataModel/FoMCalculator.h
+++ b/DataModel/FoMCalculator.h
@@ -1,0 +1,75 @@
+/*************************************************************************
+    > File Name: MinuitOptimizer.hh
+    > Author: Jingbo Wang, Teal Pershing 
+    > mail: jiowang@ucdavis.edu, tjpershing@ucdavis.edu 
+    > Created Time: MAY 07, 2019
+ ************************************************************************/
+
+#ifndef FOMCALCULATOR_H
+#define FOMCALCULATOR_H
+
+#include "TObject.h"
+#include "TMinuit.h"
+#include "TFile.h"
+#include "TH1.h"
+#include "TH1D.h"
+#include <sstream>
+
+#include "VertexGeometry.h"
+#include "Parameters.h"
+#include <vector>
+#include <iostream>
+#include <iomanip>
+
+class FoMCalculator {
+
+public:
+  //fitting parameters used in ExtendedVertexChi2
+  double fBaseFOM;
+  double fTimeFitWeight;
+  double fConeFitWeight;
+
+  int fMeanTimeCalculatorType;
+
+  //ConeFit parameters
+  //double fSconeA;
+  //double fSconeB;
+  //double fSmu;
+  //double fSel;
+  //bool fIntegralsDone;
+  
+  VertexGeometry* fVtxGeo;
+  
+ 	
+  FoMCalculator();
+  ~FoMCalculator();
+  void SetTimeFitWeight(double tweight){ fTimeFitWeight=tweight};
+  void SetConeFitWeight(double cweight){ fConeFitWeight=cweight};
+  void LoadVertexGeometry(VertexGeometry* vtxgeo);
+  double FindSimpleTimeProperties(double myConeEdge);
+  void TimePropertiesLnL(double vtxTime, double vtxParam, double& vtxFom);
+  void ConePropertiesFoM(double coneEdge, double& chi2);
+  void PointPositionChi2(double vtxX, double vtxY, double vtxZ, double FixTimeParam0, double& vtxTime, double& fom);
+  void PointDirectionChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double coneAngle, double& fom);
+  void PointVertexChi2(double vtxX, double vtxY, double vtxZ,
+	                                    double dirX, double dirY, double dirZ, 
+	                                    double coneAngle, double& vtxTime, double& fom);
+  void ExtendedVertexChi2(double vtxX, double vtxY, double vtxZ, 
+	                                    double dirX, double dirY, double dirZ, 
+	                                    double vtxParam0, double coneAngle, double& vtxTime, double& fom);
+//  void ConePropertiesLnL(double coneParam0, double coneParam1, double coneParam2, double& coneAngle, double& coneFOM);
+//  void CorrectedVertexChi2(double vtxX, double vtxY, double vtxZ, 
+//	                                    double dirX, double dirY, double dirZ, 
+//                                      double& vtxAngle, double& vtxTime, double& fom);
+  
+  
+};
+
+#endif
+
+
+
+
+
+
+

--- a/DataModel/MinuitOptimizer.cpp
+++ b/DataModel/MinuitOptimizer.cpp
@@ -19,20 +19,20 @@
 using namespace std;
 
 static MinuitOptimizer* fgMinuitOptimizer = 0;
+static FoMCalculator* fgFoMCalculator = 0;
 static void vertex_time_lnl(int&, double*, double& f, double* par, int)
 {  
 
   bool printDebugMessages = 0;
   
   double vtxTime = par[0]; // nanoseconds
-//  double vtxParam0 = fgMinuitOptimizer->fFixTimeParam0;
   double vtxParam0 = fgMinuitOptimizer->fFixTimeParam0; //scatterring parameter
   if( fgMinuitOptimizer->fFitTimeParams ){
     vtxParam0 = par[1]; 
   }
   double fom = 0.0;
   fgMinuitOptimizer->time_fit_itr();  
-  fgMinuitOptimizer->TimePropertiesLnL(vtxTime,vtxParam0, fom);
+  fgFoMCalculator->TimePropertiesLnL(vtxTime,vtxParam0, fom);
   f = -fom; // note: need to maximize this fom
   if( printDebugMessages ){
     std::cout << "  [vertex_time_lnl] [" << fgMinuitOptimizer->time_fit_iterations() << "] vtime=" << vtxTime << " vparam=" << vtxParam0 << " fom=" << fom << std::endl;
@@ -50,12 +50,9 @@ static void point_position_chi2(int&, double*, double& f, double* par, int)
   double vtxTime = par[3]; //ns, added by JW
   double vtxParam0 = 0.2; //scatterring parameter
 
-//  double vtime  = 0.0;
   double fom = 0.0;
   fgMinuitOptimizer->point_position_itr();
-  fgMinuitOptimizer->PointPositionChi2(vtxX,vtxY,vtxZ, vtxTime,fom);
-//  fgMinuitOptimizer->fVtxGeo->CalcPointResiduals(vtxX, vtxY, vtxZ, 0.0, 0.0, 0.0, 0.0); //load expected vertex time for each digit
-//  fgMinuitOptimizer->TimePropertiesLnL(vtxTime,vtxParam0, fom);
+  fgFoMCalculator->PointPositionChi2(vtxX,vtxY,vtxZ,fFixTimeParam0, vtxTime,fom);
 
 
   f = -fom; // note: need to maximize this fom
@@ -86,21 +83,12 @@ static void point_direction_chi2(int&, double*, double& f, double* par, int)
   dirY= sin(dirTheta)*sin(dirPhi);
   dirZ = cos(dirTheta);
 
-  double vangle = 0.0;
   double fom = 0.0;
 
   fgMinuitOptimizer->point_direction_itr();
-  fgMinuitOptimizer->PointDirectionChi2(vtxX,vtxY,vtxZ,
+  fgFoMCalculator->PointDirectionChi2(vtxX,vtxY,vtxZ,
                                      dirX,dirY,dirZ,
-                                     vangle,fom);
-//  fgMinuitOptimizer->fVtxGeo->CalcPointResiduals(vtxX, vtxY, vtxZ, 0.0, 
-//                                 dirX, dirY, dirZ); //load expected vertex time for each digit
-//  //Cone fit parameters
-//  double ConeParam0 = fgMinuitOptimizer->fFixConeParam0;
-//  double ConeParam1 = fgMinuitOptimizer->fFixConeParam1;
-//  double ConeParam2 = fgMinuitOptimizer->fFixConeParam2;
-//  fgMinuitOptimizer->ConePropertiesLnL(ConeParam0, ConeParam1, ConeParam2, vangle, fom); 
-//  
+                                     fConeAngle, fom);
   f = -fom; // note: need to maximize this fom
 
   if( printDebugMessages ){
@@ -119,26 +107,24 @@ static void point_vertex_chi2(int&, double*, double& f, double* par, int)
   double vtxX     = par[0]; // centimetres
   double vtxY     = par[1]; // centimetres
   double vtxZ     = par[2]; // centimetres  
-  
   double dirTheta = par[3]; // radians
   double dirPhi   = par[4]; // radians
+  double vtxTime  = par[5]; // ns
 
   double dirX = sin(dirTheta)*cos(dirPhi);
   double dirY = sin(dirTheta)*sin(dirPhi);
   double dirZ = cos(dirTheta);
 
-  double vangle = 0.0;
-  double vtime = 0.0;
   double fom = 0.0;
   
   fgMinuitOptimizer->point_vertex_itr();
-  fgMinuitOptimizer->PointVertexChi2(vtxX,vtxY,vtxZ,dirX,dirY,dirZ,vangle,vtime,fom);
+  fgFoMCalculator->PointVertexChi2(vtxX,vtxY,vtxZ,dirX,dirY,dirZ,fConeAngle, vtxTime,fom);
   f = -fom; // note: need to maximize this fom
 
   if( printDebugMessages ){
     std::cout << " [point_vertex_chi2] [" << fgMinuitOptimizer->point_vertex_iterations() 
     	<< "] (x,y,z)=(" << vtxX << "," << vtxY << "," << vtxZ << ") (px,py,pz)=(" 
-    	<< dirX << "," << dirY << "," << dirZ << ") vtime=" << vtime << " fom=" << fom << std::endl;
+    	<< dirX << "," << dirY << "," << dirZ << ") vtime=" << vtxTime << " fom=" << fom << std::endl;
   }
   return;
 }
@@ -153,111 +139,39 @@ static void extended_vertex_chi2(int&, double*, double& f, double* par, int)
 
   double dirTheta = par[3]; // radians
   double dirPhi   = par[4]; // radians
+  double vtxTime  = par[5]; // ns
 
   double dirX = sin(dirTheta)*cos(dirPhi);
   double dirY = sin(dirTheta)*sin(dirPhi);
   double dirZ = cos(dirTheta);
 
-  double vangle = 0.0;
-  double vtime  = 0.0;
   double fom = 0.0;
 
   fgMinuitOptimizer->extended_vertex_itr();
   
-  fgMinuitOptimizer->ExtendedVertexChi2(vtxX,vtxY,vtxZ,
-                                     dirX,dirY,dirZ,
-                                     vangle,vtime,fom);
+  double vtxParam0 = fgMinuitOptimizer->fFixTimeParam0; //scatterring parameter
+  fgFoMCalculator->ExtendedVertexChi2(vtxX,vtxY,vtxZ,
+                                     dirX,dirY,dirZ, vtxParam0,
+                                     fConeAngle, vtxTime,fom);
 
   f = -fom; // note: need to maximize this fom
 
   if( printDebugMessages ){
     std::cout << " [extended_vertex_chi2] [" << fgMinuitOptimizer->extended_vertex_iterations() 
     	<< "] (x,y,z)=(" << vtxX << "," << vtxY << "," << vtxZ << ") (px,py,pz)=(" << dirX << "," 
-    	<< dirY << "," << dirZ << ") vtime=" << vtime << " fom=" << fom << std::endl;  
+    	<< dirY << "," << dirZ << ") vtime=" << vtxTime << " fom=" << fom << std::endl;  
   }
   return;
 }
 
-static void corrected_vertex_chi2(int&, double*, double& f, double* par, int)
-{
-  bool printDebugMessages = 0;
-  
-  double dl = par[0];
-//  double dirTheta = par[1]; // radians
-//  double dirPhi   = par[2]; // radiansf
-  
-//  double dirX = sin(dirTheta)*cos(dirPhi);
-//  double dirY = sin(dirTheta)*sin(dirPhi);
-//  double dirZ = cos(dirTheta);
-  
-  double dirX = fgMinuitOptimizer->fDirX;
-  double dirY = fgMinuitOptimizer->fDirY;
-  double dirZ = fgMinuitOptimizer->fDirZ;
-  
-  double vtxX = fgMinuitOptimizer->fVtxX + dl * dirX;
-  double vtxY = fgMinuitOptimizer->fVtxY + dl * dirY;;
-  double vtxZ = fgMinuitOptimizer->fVtxZ + dl * dirZ;
-
-  double vangle = 0.0;
-  double vtime  = 0.0;
-  double fom = 0.0;
-
-  if(TMath::Sqrt(vtxX*vtxX + vtxY*vtxY + vtxZ*vtxZ)>152 || vtxY>198 || vtxY<-198) {fom = 9999;}
-  fgMinuitOptimizer->corrected_vertex_itr();
-  
-  fgMinuitOptimizer->CorrectedVertexChi2(vtxX,vtxY,vtxZ,
-                                     dirX,dirY,dirZ,
-                                     vangle,vtime,fom);
-
-  f = -fom; // note: need to maximize this fom
-
-  if( printDebugMessages ){
-    std::cout << " [corrected_vertex_chi2] [" << fgMinuitOptimizer->extended_vertex_iterations() 
-    	<< "] (x,y,z)=(" << vtxX << "," << vtxY << "," << vtxZ << ") (px,py,pz)=(" << dirX << "," 
-    	<< dirY << "," << dirZ << ") vtime=" << vtime << " fom=" << fom << std::endl;  
-  }
-
-  return;
-}
-
-static void vertex_cone_lnl(int&, double*, double& f, double* par, int)
-{
-  bool printDebugMessages = 0;
-  
-  double vtxParam0 = fgMinuitOptimizer->fFixConeParam0;
-  double vtxParam1 = fgMinuitOptimizer->fFixConeParam1;
-  double vtxParam2 = fgMinuitOptimizer->fFixConeParam2;
-
-  if( fgMinuitOptimizer->fFitConeParams ){
-    vtxParam0 = par[0];
-    vtxParam1 = par[1];
-    vtxParam2 = par[2];
-  }
- 
-  double vangle = 0.0;
-  double fom = 0.0;
-
-  fgMinuitOptimizer->cone_fit_itr();
-  fgMinuitOptimizer->ConePropertiesLnL(vtxParam0,vtxParam1,vtxParam2,vangle,fom);
-
-  f = -fom; // note: need to maximize this fom
-
-  if( printDebugMessages ){
-    std::cout << "  [vertex_cone_lnl] [" << fgMinuitOptimizer->cone_fit_iterations() 
-    	<< "] vparam0=" << vtxParam0 << " vparam1=" << vtxParam1 << " vtxParam2=" << vtxParam2 
-    	<< " fom=" << fom << std::endl;
-  }
-
-  return;
-}
 
 //Constructor
 MinuitOptimizer::MinuitOptimizer() {
-	fgMinuitOptimizer = this;
-	fSeedVtx = 0;
-	fVtxGeo = 0;
-	fFittedVtx = new RecoVertex();
-	fVtxX = 0.;
+  fgMinuitOptimizer = this;
+  fgFoMCalculator = new FoMCalculator();
+  fSeedVtx = 0;
+  fFittedVtx = new RecoVertex();
+  fVtxX = 0.;
   fVtxY = 0.;
   fVtxZ = 0.;
   fVtxTime = 0.;
@@ -265,48 +179,45 @@ MinuitOptimizer::MinuitOptimizer() {
   fDirY = 0.;
   fDirZ = 0.;
   fVtxFOM = 0.;
-  fConeAngle = 0.;
-  fBaseFOM = 100.0;
+  fConeAngle = = Parameters::CherenkovAngle();
   fTimeFitItr = 0;
-  fConeFitItr = 0;
   fPointPosItr = 0;
   fPointDirItr = 0;
   fPointVtxItr = 0;
   fExtendedVtxItr = 0;
-  fCorrectedVtxItr = 0;
   fPass = 0;
   fItr = 0;
   fPrintLevel = -1;
-  
+
   // fitting parameters ported from vertexFinder (FIXME)
   fFitTimeParams = 0;     // don't fit by default
   fFixTimeParam0 = 0.20;  // scattering parameter
-  fFitConeParams = 1;     // do fit by default  
-  fFixConeParam0 = 0.25;  // track length parameter
-  fFixConeParam1 = 0.50;  // track length parameter
-  fFixConeParam2 = 0.75;  // particle ID:  0.0[electron]->1.0[muon]
-  fTimeFitWeight = 0.50;  // nominal time weight
-  fConeFitWeight = 0.50;  // nominal cone weight
   
-  //Cone paramters
-  fConeParam0 = 0.;
-  fConeParam1 = 0.;
-  fConeParam2 = 0.;
-	
-	//WCSIM 
-	fXmin = -152.0;
-	fXmax = 152.0;
-	fYmin = -198.0;
-	fYmax = 198.0;
-	fZmin = -152.0;
-	fZmax = 152.0;
-	fTmin = -10.0;
-	fTmax = 10.0;
-	
-	// default Mean time calculator type
-	fMeanTimeCalculatorType = 0;
-	
-	fMinuitPointPosition = new TMinuit();
+  //KEPT FOR HISTORY; NOT IN USE (Cone parameters)
+  //fConeFitItr = 0;
+  //fCorrectedVtxItr = 0;
+  //fFitConeParams = 1;     // do fit by default  
+  //fConeParam0 = 0.;
+  //fConeParam1 = 0.;
+  //fConeParam2 = 0.;
+  //fFixConeParam0 = 0.25;  // track length parameter
+  //fFixConeParam1 = 0.50;  // track length parameter
+  //fFixConeParam2 = 0.75;  // particle ID:  0.0[electron]->1.0[muon]
+
+  //WCSIM 
+  fXmin = -152.0;
+  fXmax = 152.0;
+  fYmin = -198.0;
+  fYmax = 198.0;
+  fZmin = -152.0;
+  fZmax = 152.0;
+  fTmin = -10.0;
+  fTmax = 10.0;
+  
+  // default Mean time calculator type
+  fMeanTimeCalculatorType = 0;
+  
+  fMinuitPointPosition = new TMinuit();
   fMinuitPointPosition->SetPrintLevel(-1);
   fMinuitPointPosition->SetMaxIterations(5000);
 
@@ -322,37 +233,44 @@ MinuitOptimizer::MinuitOptimizer() {
   fMinuitExtendedVertex->SetPrintLevel(-1);
   fMinuitExtendedVertex->SetMaxIterations(5000); 
   
-  fMinuitCorrectedVertex = new TMinuit();
-  fMinuitCorrectedVertex->SetPrintLevel(-1);
-  fMinuitCorrectedVertex->SetMaxIterations(5000);
-
   fMinuitTimeFit = new TMinuit();
   fMinuitTimeFit->SetPrintLevel(-1);
   fMinuitTimeFit->SetMaxIterations(5000);   
 
-  fMinuitConeFit = new TMinuit();
-  fMinuitConeFit->SetPrintLevel(-1);
-  fMinuitConeFit->SetMaxIterations(5000); 
+  //fMinuitCorrectedVertex = new TMinuit();
+  //fMinuitCorrectedVertex->SetPrintLevel(-1);
+  //fMinuitCorrectedVertex->SetMaxIterations(5000);
+
+  //fMinuitConeFit = new TMinuit();
+  //fMinuitConeFit->SetPrintLevel(-1);
+  //fMinuitConeFit->SetMaxIterations(5000); 
 }
 
 //Destructor
 MinuitOptimizer::~MinuitOptimizer() {
 	fSeedVtx = 0;
-	fVtxGeo = 0;
+    delete fgFoMCalculator; fgFoMCalculator = 0;
 	delete fMinuitTimeFit; fMinuitTimeFit = 0;
-	delete fMinuitConeFit; fMinuitConeFit = 0;
 	delete fMinuitPointPosition; fMinuitPointPosition = 0;
 	delete fMinuitPointDirection; fMinuitPointDirection = 0;
 	delete fMinuitPointVertex; fMinuitPointVertex = 0;
 	delete fMinuitExtendedVertex; fMinuitExtendedVertex = 0;
-	delete fMinuitCorrectedVertex; fMinuitCorrectedVertex = 0;
 	delete fFittedVtx; fFittedVtx = 0;
+	//delete fMinuitCorrectedVertex; fMinuitCorrectedVertex = 0;
+	//delete fMinuitConeFit; fMinuitConeFit = 0;
 }
 	
-	
-//100 digits
+
 void MinuitOptimizer::LoadVertexGeometry(VertexGeometry* vtxgeo) {
-  this->fVtxGeo = vtxgeo;	
+  fgFoMCalculator->fVtxGeo = vtxgeo;	
+}
+
+void MinuitOptimizer::SetTimeFitWeight(double tweight) {
+  fgFoMCalculator->SetTimeFitWeight(tweight);	
+}
+
+void MinuitOptimizer::SetConeFitWeight(double cweight) {
+  fgFoMCalculator->SetConeFitWeight(cweight);	
 }
 
 //Load vertex
@@ -380,357 +298,15 @@ void MinuitOptimizer::LoadVertex(double vtxX, double vtxY, double vtxZ, double v
   this->fDirZ = vtxDirZ;
 }
 
-void MinuitOptimizer::TimePropertiesLnL(double vtxTime, double vtxParam, double& vtxFOM)
-{ 
-  // nuisance parameters
-  // ===================
-  double scatter = vtxParam; 
-
-  // internal variables
-  // ==================
-  double weight = 0.0;
-  double delta = 0.0;       // time residual of each hit
-  double sigma = 0.0;       // time resolution of each hit
-  double A = 0.0;           // normalisation of first Gaussian
-  int type;                 // Digit type (LAPPD or PMT)
-  
-  double Preal = 0.0;       // probability of real hit
-  double P = 0.0;           // probability of hit
-
-  double chi2 = 0.0;        // log-likelihood: chi2 = -2.0*log(L)
-  double ndof = 0.0;        // total number of hits
-  double fom = 0.0;         // figure of merit
-  double coneAngle = Parameters::CherenkovAngle();
-  double myConeAngleSigma = 2.0;
-  double deltaAngle = 0.0;
-
-  // tuning parameters
-  // =================
-  double fTimeFitNoiseRate = 0.02;  // hits/ns [0.40 for electrons, 0.02 for muons]
-  // need to simulate the rate of the cosmic background
-  // add noise to model
-  // ==================
-  double nFilterDigits = this->fVtxGeo->GetNFilterDigits(); 
-  double Pnoise; 
-  //Pnoise = fTimeFitNoiseRate/nFilterDigits;//FIXME
-  
-  //bool istruehits = (Interface::Instance())->IsTrueHits();
-  bool istruehits = 0; // for test only. JW
-
-  // loop over digits
-  // ================
-  
-  for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-    	int detType = this->fVtxGeo->GetDigitType(idigit); 
-      delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-      sigma = this->fVtxGeo->GetDeltaSigma(idigit);
-      type = this->fVtxGeo->GetDigitType(idigit);
-      if (type == RecoDigit::PMT8inch){  //PMT8Inch
-        sigma = 1.5*sigma;
-        Pnoise = 1e-8; //FIXME; Need implementation of noise model 
-      } 
-      if (type == RecoDigit::lappd_v0){  //lappd
-        sigma = 1.2*sigma;
-        Pnoise = 1e-8;  //FIXME; Need implementation of noise model 
-      }
-      A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-      Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-      P = (1.0-Pnoise)*Preal + Pnoise; 
-      chi2 += -2.0*log(P);
-      ndof += 1.0; 
-//      cout<<"(tm, t0, dt, sigma) = "<<this->fVtxGeo->GetDelta(idigit)<<", "<<vtxTime<<", "<<delta<<", "<<sigma<<endl;
-  }	
-  
-//  TString configType = Parameters::Instance()->GetConfigurationType();
-//  	
-//  if(configType == "LAPPD")	{
-//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
-//      if( detType == "lappd_v0" /*&& this->fVtxGeo->IsFiltered(idigit)*/){
-//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-//        sigma = 1.2 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
-//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-//        P = (1.0-Pnoise)*Preal + Pnoise; 
-//        chi2 += -2.0*log(P);
-//        ndof += 1.0; 
-//      }
-//    }
-//  }
-//  
-//  else if(configType == "PMT") {
-//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
-//      if( detType == "PMT8inch" && this->fVtxGeo->GetDigitQ(idigit)>5/*&& this->fVtxGeo->IsFiltered(idigit)*/){
-//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-//        sigma = 1.5 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
-//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-//        P = (1.0-Pnoise)*Preal + Pnoise; 
-//        chi2 += -2.0*log(P);
-//        ndof += 1.0; 
-//      }
-//    }	
-//  }
-//  
-//  else if(configType == "Combined") {
-//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
-//      delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-//      sigma = this->fVtxGeo->GetDeltaSigma(idigit);
-//      if(detType == "lappd_v0") sigma = 1.2*sigma;
-//      if(detType == "PMT8inch") sigma = 1.5*sigma;
-//      A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-//      Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-//      P = (1.0-Pnoise)*Preal + Pnoise; 
-//      chi2 += -2.0*log(P);
-//      ndof += 1.0; 
-//    }	
-//  }
-//  
-//  else if (configType == "Two-stage") {
-//    for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){    
-//    	TString detType = this->fVtxGeo->GetDigitType(idigit); 
-//      if( detType == "lappd_v0" /*&& this->fVtxGeo->IsFiltered(idigit)*/){
-//        delta = this->fVtxGeo->GetDelta(idigit) - vtxTime;
-//        sigma = 1.2 * this->fVtxGeo->GetDeltaSigma(idigit); //chose factor 1.2 to optimize the fitter performance
-//        A  = 1.0 / ( 2.0*sigma*sqrt(0.5*TMath::Pi()) ); //normalisation constant
-//        Preal = A*exp(-(delta*delta)/(2.0*sigma*sigma));
-//        P = (1.0-Pnoise)*Preal + Pnoise; 
-//        chi2 += -2.0*log(P);
-//        ndof += 1.0; 
-//      }
-//    }	
-//  }
 
 
-  // calculate figure of merit
-  if( ndof>0.0 ){
-    fom = fBaseFOM - 5.0*chi2/ndof;
-  }  
+void MinuitOptimizer::FitPointTimeWithMinuit() {
+  fgFoMCalculator->fVtxGeo->CalcPointResiduals(fVtxX, fVtxY, fVtxZ, 0.0, 0.0, 0.0, 0.0);
 
-  // return figure of merit
-  // ======================
-  vtxFOM = fom;
-  
-
-  return;
-}
-
-void MinuitOptimizer::ConePropertiesFoM(double& coneFOM)
-{  
-  // calculate figure of merit
-  // =========================
-  double coneEdge = Parameters::CherenkovAngle();     // nominal cone angle
-  double coneEdgeLow = 21.0;  // cone edge (low side)      
-  double coneEdgeHigh = 3.0;  // cone edge (high side)   [muons: 3.0, electrons: 7.0]
-
-  double deltaAngle = 0.0;
-  double digitCharge = 0.0;
- 
-  double coneCharge = 0.0;
-  double allCharge = 0.0;
-
-  double fom = 0.0;
-
-  for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){ 	
-    if( this->fVtxGeo->IsFiltered(idigit) && this->fVtxGeo->GetDigitType(idigit) == RecoDigit::PMT8inch){
-      deltaAngle = this->fVtxGeo->GetAngle(idigit) - coneEdge;
-      digitCharge = this->fVtxGeo->GetDigitQ(idigit);
-
-      if( deltaAngle<=0.0 ){
-        coneCharge += digitCharge*( 0.75 + 0.25/( 1.0 + (deltaAngle*deltaAngle)/(coneEdgeLow*coneEdgeLow) ) );
-      }
-      else{
-        coneCharge += digitCharge*( 0.00 + 1.00/( 1.0 + (deltaAngle*deltaAngle)/(coneEdgeHigh*coneEdgeHigh) ) );
-      }
-
-      allCharge += digitCharge;
-    }
-  }
-
-  if( allCharge>0.0 ){
-    fom = fBaseFOM*coneCharge/allCharge;
-  }
-
-  // return figure of merit
-  // ======================
-  coneFOM = fom;
-
-  return;
-}
-
-void MinuitOptimizer::ConePropertiesLnL(double coneParam0, double coneParam1, double coneParam2, double& coneAngle, double& coneFOM)
-{  
-  
-  // nuisance parameters
-  // ===================
-  double alpha  = coneParam0; // track length parameter = 0.25
-  double alpha0 = coneParam1; // track length parameter = 0.5
-  double beta   = coneParam2; // particle ID:  0.0[electron]->1.0[muon] = 0.75
-
-  // internal variables
-  // ==================
-  double deltaAngle = 0.0; //
-  double sigmaAngle = 7.0; //Cherenkov Angle resolution
-  double Angle0 = Parameters::CherenkovAngle(); //Cherenkov Angle: 42 degree
-  double deltaAngle0 = Angle0*alpha0; //?
-  
-  double digitQ = 0.0;
-  double sigmaQmin = 1.0;
-  double sigmaQmax = 10.0;
-  double sigmaQ = 0.0;
-
-  double A = 0.0;
-  
-  double PconeA = 0.0;
-  double PconeB = 0.0;
-  double Pmu = 0.0;
-  double Pel = 0.0;
-
-  double Pcharge = 0.0;
-  double Pangle = 0.0;
-  double P = 0.0;
-
-  double chi2 = 0.0;
-  double ndof = 0.0;
-
-  double angle = 46.0;
-  double fom = 0.0;
-
-  // hard-coded parameters: 200 kton (100 kton)
-  // ==========================================
-  double lambdaMuShort = 0.5; //  0.5;
-  double lambdaMuLong  = 5.0; // 15.0;
-  double alphaMu =       1.0; //  4.5;
-
-  double lambdaElShort = 1.0; //  2.5;
-  double lambdaElLong =  7.5; // 15.0;
-  double alphaEl =       6.0; //  3.5;
-
-  // numerical integrals
-  // ===================
-  fSconeA = 21.9938;  
-  fSconeB =  0.0000;
-  
-  // Number of P.E. angular distribution
-  // inside cone
-  int nbinsInside = 420; //divide the angle range by 420 bins
-  for( int n=0; n<nbinsInside; n++ ){
-    deltaAngle = -Angle0 + (n+0.5)*(Angle0/(double)nbinsInside); // angle axis
-    fSconeB += 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
-                           *( 1.0/(1.0+(deltaAngle*deltaAngle)/(deltaAngle0*deltaAngle0)) )
-                           *( Angle0/(double)nbinsInside );
-  }
-
-  // outside cone
-  if( fIntegralsDone == 0 ){ // default 0
-    fSmu = 0.0;
-    fSel = 0.0;
-
-    int nbinsOutside = 1380;
-    for( int n=0; n<nbinsOutside; n++ ){
-      deltaAngle = 0.0 + (n+0.5)*(138.0/(double)nbinsOutside);
-
-      fSmu += 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
-                          *( 1.0/(1.0+alphaMu*(lambdaMuShort/lambdaMuLong)) )*( 1.0/(1.0+(deltaAngle*deltaAngle)/(lambdaMuShort*lambdaMuShort)) 
-	  			            + alphaMu*(lambdaMuShort/lambdaMuLong)/(1.0+(deltaAngle*deltaAngle)/(lambdaMuLong*lambdaMuLong)) )
-                          *( 138.0/(double)nbinsOutside );
-
-      fSel += 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
-                          *( 1.0/(1.0+alphaEl*(lambdaElShort/lambdaElLong)) )*( 1.0/(1.0+(deltaAngle*deltaAngle)/(lambdaElShort*lambdaElShort)) 
-				          + alphaEl*(lambdaElShort/lambdaElLong)/(1.0+(deltaAngle*deltaAngle)/(lambdaElLong*lambdaElLong)) )
-                          *( 138.0/(double)nbinsOutside );
-    }
-
-    fIntegralsDone = 1;
-  }
-
-  // loop over digits
-  // ================
-  for( int idigit=0; idigit<this->fVtxGeo->GetNDigits(); idigit++ ){
-
-    if( this->fVtxGeo->IsFiltered(idigit) ){
-      digitQ = this->fVtxGeo->GetDigitQ(idigit);
-      deltaAngle = this->fVtxGeo->GetAngle(idigit) - Angle0;
-
-      // pulse height distribution
-      // =========================
-      if( deltaAngle<=0 ){ //inside Cone
-	      sigmaQ = sigmaQmax;
-      }
-      else{ //outside Cone
-        sigmaQ = sigmaQmin + (sigmaQmax-sigmaQmin)/(1.0+(deltaAngle*deltaAngle)/(sigmaAngle*sigmaAngle));
-      }
-
-      A = 1.0/(log(2.0)+0.5*TMath::Pi()*sigmaQ);
-
-      if( digitQ<1.0 ){
-        Pcharge = 2.0*A*digitQ/(1.0+digitQ*digitQ);
-      }
-      else{
-        Pcharge = A/(1.0+(digitQ-1.0)*(digitQ-1.0)/(sigmaQ*sigmaQ));
-      }
-
-      // angular distribution
-      // ====================
-      A = 1.0/( alpha*fSconeA + (1.0-alpha)*fSconeB
-               + beta*fSmu + (1.0-beta)*fSel ); // numerical integrals
-
-      if( deltaAngle<=0 ){
-
-        // pdfs inside cone:
-        PconeA = 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) );
-        PconeB = 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
-                          *( 1.0/(1.0+(deltaAngle*deltaAngle)/(deltaAngle0*deltaAngle0)) );
-
-        Pangle = A*( alpha*PconeA+(1.0-alpha)*PconeB );
-      }		
-      else{
-
-        // pdfs outside cone
-        Pmu = 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
-                       *( 1.0/(1.0+alphaMu*(lambdaMuShort/lambdaMuLong)) )*( 1.0/(1.0+(deltaAngle*deltaAngle)/(lambdaMuShort*lambdaMuShort)) 
-                                          + alphaMu*(lambdaMuShort/lambdaMuLong)/(1.0+(deltaAngle*deltaAngle)/(lambdaMuLong*lambdaMuLong)) );
-
-        Pel = 1.4944765*sin( (Angle0+deltaAngle)*(TMath::Pi()/180.0) )
-                       *( 1.0/(1.0+alphaEl*(lambdaElShort/lambdaElLong)) )*( 1.0/(1.0+(deltaAngle*deltaAngle)/(lambdaElShort*lambdaElShort)) 
-                                          + alphaEl*(lambdaElShort/lambdaElLong)/(1.0+(deltaAngle*deltaAngle)/(lambdaElLong*lambdaElLong)) );
-
-        Pangle = A*( beta*Pmu+(1.0-beta)*Pel );
-      }
-
-      // overall probability
-      // ===================
-      P = Pcharge*Pangle;
-      
-      chi2 += -2.0*log(P);
-      ndof += 1.0;
-    }
-  }
-
-  // calculate figure of merit
-  // =========================   
-  if( ndof>0.0 ){
-    fom = fBaseFOM - 5.0*chi2/ndof;
-    angle = beta*43.0 + (1.0-beta)*49.0;
-  }
-
-  // return figure of merit
-  // ======================
-  coneAngle = angle;
-  coneFOM = fom;
-
-  return;
-}
-
-//Find the vertex time with the best FOM. Update the vertex with the new time
-void MinuitOptimizer::FitPointTimePropertiesLnL(double& vtxTime, double& vtxFOM)
-{
   // calculate mean and rms
   // ====================== 
   double meanvtxTime = 0.0;
-  meanvtxTime = this->FindSimpleTimeProperties(this->fVtxGeo);  //returns weighted average of the expected vertex time
+  meanvtxTime = fgFoMCalculator->FindSimpleTimeProperties(fConeAngle);  //returns weighted average of the expected vertex time
   // reset counter
   // =============
   time_fit_reset_itr();
@@ -762,10 +338,10 @@ void MinuitOptimizer::FitPointTimePropertiesLnL(double& vtxTime, double& vtxFOM)
   fMinuitTimeFit->GetParameter(0,fitTime,fitTimeErr); //get the best time
   delete [] arglist;
   
-  // calculate figure of merit
+  // fitting done; calculate best-fit figure of merit
   // =========================
-  double fom = -999.999*fBaseFOM;
-  this->TimePropertiesLnL(fitTime,fitParam, fom);
+  double fom = -9999.;
+  fgFoMCalculator->TimePropertiesLnL(fitTime,fitParam, fom);
   
   vtxTime = fitTime;
   vtxFOM = fom;
@@ -773,172 +349,6 @@ void MinuitOptimizer::FitPointTimePropertiesLnL(double& vtxTime, double& vtxFOM)
   fFittedVtx->SetVertex(fVtxX, fVtxY, fVtxZ, vtxTime);
   fFittedVtx->SetFOM(vtxFOM, 1, 1);
   return;
-}
-
-void MinuitOptimizer::FitExtendedTimePropertiesLnL(double& vtxTime, double& vtxFOM)
-{    
-  
-  // return result from point fit
-  // ============================
-  if( fFitTimeParams==0 ){
-    return this->FitPointTimePropertiesLnL(vtxTime,vtxFOM);
-  }
-
-  // calculate mean and rms
-  // ====================== 
-  double meanTime = this->FindSimpleTimeProperties(this->fVtxGeo); 
-
-  // reset counter
-  // =============
-  time_fit_reset_itr();
-
-  // run Minuit
-  // ==========  
-  // two-parameter fit to time profile
-
-  int err = 0;
-  int flag = 0;
-
-  double seedTime = meanTime;
-  double seedParam = this->fFixTimeParam0;
-
-  double fitTime = seedTime;
-  double fitTimeErr = 0.0;  
-
-  double fitParam = seedParam;
-  double fitParamErr = 0.0;
-  
-  double* arglist = new double[10];
-  arglist[0]=1;  // 1: standard minimization
-                 // 2: try to improve minimum
-		 
-
-  // re-initialize everything...
-  fMinuitTimeFit->mncler();
-  fMinuitTimeFit->SetFCN(vertex_time_lnl);
-  fMinuitTimeFit->mnexcm("SET STR",arglist,1,err);
-  fMinuitTimeFit->mnparm(0,"vtxTime",seedTime,1.0,fTmin,fTmax,err); //....TX
-  fMinuitTimeFit->mnparm(1,"vtxParam",seedParam,0.05,0.0,1.0,err);
-  
-  flag = fMinuitTimeFit->Migrad();
-  fMinuitTimeFit->GetParameter(0,fitTime,fitTimeErr);
-  fMinuitTimeFit->GetParameter(1,fitParam,fitParamErr);
-  
-  delete [] arglist;
-
-
-  // calculate figure of merit
-  // =========================
-  double fom = -999.999*fBaseFOM;
-
-  this->TimePropertiesLnL(fitTime,fitParam,fom); 
-
-  // return figure of merit
-  // ======================
-  vtxTime = fitTime;
-  vtxFOM = fom;
-
-  return;
-}
-
-void MinuitOptimizer::FitConePropertiesFoM(double& coneAngle, double& coneFOM)
-{
-  coneAngle = Parameters::CherenkovAngle(); //...chrom1.38 // nominal cone angle
-
-  this->ConePropertiesFoM(coneFOM);
-
-  return;
-}
-
-void MinuitOptimizer::FitPointConePropertiesLnL(double& coneAngle, double& coneFOM)
-{  
-  coneAngle  = Parameters::CherenkovAngle(); //...chrom1.38, nominal cone angle
-  // calculate cone fom
-  // =========================
-  coneFOM = 0.0;
-  double ConeParam0 = this->fFixConeParam0;
-  double ConeParam1 = this->fFixConeParam1;
-  double ConeParam2 = this->fFixConeParam2;
-  this->ConePropertiesLnL(ConeParam0,ConeParam1,ConeParam2,coneAngle,coneFOM);  
-  return;
-}
-
-void MinuitOptimizer::FitExtendedConePropertiesLnL(double& coneAngle, double& coneFOM)
-{  
-  // return result from point fit
-  // ============================
-  if( this->fFitConeParams==0 ){
-    return this->FitPointConePropertiesLnL(coneAngle,coneFOM);
-  }
-
-  // reset counter
-  // =============
-  cone_fit_reset_itr();
-
-  // run Minuit
-  // ==========  
-  // one-parameter fit to angular distribution
-
-  int err = 0;
-  int flag = 0;
-
-  double seedParam0 = this->fFixConeParam0; //track length parameter
-  double seedParam1 = this->fFixConeParam1; //track length parameter
-  double seedParam2 = this->fFixConeParam2; //particle ID:  0.0[electron]->1.0[muon]
-
-  double fitParam0 = seedParam0;
-  double fitParam1 = seedParam1;
-  double fitParam2 = seedParam2;
-
-  double fitParam0Err = 0.0;
-  double fitParam1Err = 0.0; 
-  double fitParam2Err = 0.0;
-
-  double fitAngle  = Parameters::CherenkovAngle();
-  
-  double* arglist = new double[10];
-  arglist[0]=1;  // 1: standard minimization
-                 // 2: try to improve minimum
-
-  // re-initialize everything...
-  fMinuitConeFit->mncler();
-  fMinuitConeFit->SetFCN(vertex_cone_lnl);
-  fMinuitConeFit->mnexcm("SET STR",arglist,1,err);
-  fMinuitConeFit->mnparm(0,"vtxParam0",seedParam0,0.25,0.0,1.0,err);
-  fMinuitConeFit->mnparm(1,"vtxParam1",seedParam1,0.25,0.0,1.0,err);
-  fMinuitConeFit->mnparm(2,"vtxParam2",seedParam2,0.25,0.0,1.0,err);
-
-  flag = fMinuitConeFit->Migrad();
-  fMinuitConeFit->GetParameter(0,fitParam0,fitParam0Err);
-  fMinuitConeFit->GetParameter(1,fitParam1,fitParam1Err);
-  fMinuitConeFit->GetParameter(2,fitParam2,fitParam2Err);
-  
-  delete [] arglist;
-
-  // calculate figure of merit
-  // =========================
-  double fom = -999.999*fBaseFOM;
-  
-  this->ConePropertiesLnL(fitParam0,fitParam1,fitParam2,
-                          fitAngle,fom);  
-
-
-  // --- debug ---
-  fConeParam0 = fitParam0;
-  fConeParam1 = fitParam1;
-  fConeParam2 = fitParam2;
-
-  // return figure of merit
-  // ======================
-  coneAngle = fitAngle;
-  coneFOM = fom;
-
-  return;
-}
-
-void MinuitOptimizer::FitPointTimeWithMinuit() {
-	this->fVtxGeo->CalcPointResiduals(fVtxX, fVtxY, fVtxZ, 0.0, 0.0, 0.0, 0.0);
-  this->FitPointTimePropertiesLnL(fVtxTime, fVtxFOM);
 }
 
 //Fit point position in 3D
@@ -1027,7 +437,7 @@ void MinuitOptimizer::FitPointPositionWithMinuit() {
   if( flag==0 ) fPass = 1; // anything else: abnormal termination 
 
   fItr = point_position_iterations();
-  this->PointPositionChi2(fVtxX,fVtxY,fVtxZ,fVtxTime,fVtxFOM);
+  fgFoMCalculator->PointPositionChi2(fVtxX,fVtxY,fVtxZ,fFixTimeParam0,fVtxTime,fVtxFOM);
   
   // set vertex and direction
   // ========================
@@ -1059,8 +469,6 @@ void MinuitOptimizer::FitPointDirectionWithMinuit() {
   // initialization
   // ==============
   bool foundSeed = ( fSeedVtx->FoundVertex() && fSeedVtx->FoundDirection() );
- 
-  double vtxAngle = Parameters::CherenkovAngle();
 
   double vtxFOM = 0.0;
   
@@ -1150,9 +558,7 @@ void MinuitOptimizer::FitPointDirectionWithMinuit() {
   
   // calculate vertex
   // ================
-  this->PointDirectionChi2(fVtxX,fVtxY,fVtxZ,fDirX,fDirY,fDirZ,fConeAngle,fVtxFOM);
-  //Fix position, scan and update time 
-  //this->FitPointTimePropertiesLnL();
+  fgFoMCalculator->PointDirectionChi2(fVtxX,fVtxY,fVtxZ,fDirX,fDirY,fDirZ,fConeAngle,fVtxFOM);
 
   // set vertex and direction
   // ========================
@@ -1183,7 +589,6 @@ void MinuitOptimizer::FitPointDirectionWithMinuit() {
 
 void MinuitOptimizer::FitPointVertexWithMinuit() {
   
-  double vtxAngle = Parameters::CherenkovAngle();
   double vtxFOM = 0.0;
   
   // seed vertex
@@ -1251,7 +656,9 @@ void MinuitOptimizer::FitPointVertexWithMinuit() {
   double fitZpos = 0.0;
   double fitTheta = 0.0;
   double fitPhi = 0.0;
+  double fitTime = 0.0;
 
+  double fitTimeErr = 0.0;
   double fitXposErr = 0.0;
   double fitYposErr = 0.0;
   double fitZposErr = 0.0;
@@ -1274,13 +681,15 @@ void MinuitOptimizer::FitPointVertexWithMinuit() {
   fMinuitPointVertex->mnparm(2,"z",seedZ,5.0,fZmin,fZmax,err); 
   fMinuitPointVertex->mnparm(3,"theta",seedTheta,0.125*TMath::Pi(),0.0,TMath::Pi(),err);
   fMinuitPointVertex->mnparm(4,"phi",seedPhi,0.25*TMath::Pi(),-1.0*TMath::Pi(),+3.0*TMath::Pi(),err);
-  
+  fMinuitExtendedVertex->mnparm(5,"vtxTime",seedTime,1.0,fTmin,fTmax,err); 
+
   flag = fMinuitPointVertex->Migrad();
   fMinuitPointVertex->GetParameter(0,fitXpos,fitXposErr);
   fMinuitPointVertex->GetParameter(1,fitYpos,fitYposErr);
   fMinuitPointVertex->GetParameter(2,fitZpos,fitZposErr);
   fMinuitPointVertex->GetParameter(3,fitTheta,fitThetaErr);
   fMinuitPointVertex->GetParameter(4,fitPhi,fitPhiErr);
+  fMinuitPointVertex->GetParameter(5,fitTime,fitTimeErr);
   
   delete [] arglist;
   
@@ -1289,7 +698,7 @@ void MinuitOptimizer::FitPointVertexWithMinuit() {
   fVtxX = fitXpos; 
   fVtxY = fitYpos;
   fVtxZ = fitZpos;
-  //fVtxTime = 6600.; //for test only
+  fVtxTime = fitTime; //for test only
 
   fDirX = sin(fitTheta)*cos(fitPhi);
   fDirY = sin(fitTheta)*sin(fitPhi);
@@ -1302,9 +711,9 @@ void MinuitOptimizer::FitPointVertexWithMinuit() {
 
   fItr = point_vertex_iterations();
   
-  // calculate vertex
+  // fitting complete; calculate vertex FOM
   // ================
-  this->PointVertexChi2(fVtxX,fVtxY,fVtxZ,fDirX,fDirY,fDirZ,fConeAngle,fVtxTime,fVtxFOM); 
+  fgFoMCalculator->PointVertexChi2(fVtxX,fVtxY,fVtxZ,fDirX,fDirY,fDirZ,fConeAngle, fVtxTime,fVtxFOM); 
   
   // set vertex and direction
   // ========================
@@ -1343,6 +752,8 @@ void MinuitOptimizer::FitExtendedVertexWithMinuit() {
   bool foundSeed = ( fSeedVtx->FoundVertex() 
                     && fSeedVtx->FoundDirection() );
 
+
+  double seedTime = fSeedVtx->GetTime();
   double seedX = fSeedVtx->GetPosition().X();
   double seedY = fSeedVtx->GetPosition().Y();
   double seedZ = fSeedVtx->GetPosition().Z();
@@ -1399,7 +810,9 @@ void MinuitOptimizer::FitExtendedVertexWithMinuit() {
   double fitZpos = 0.0;
   double fitTheta = 0.0;
   double fitPhi = 0.0;
-
+  double fitTime = 0.0;
+  
+  double fitTimeErr = 0.0;  
   double fitXposErr = 0.0;
   double fitYposErr = 0.0;
   double fitZposErr = 0.0;
@@ -1420,6 +833,7 @@ void MinuitOptimizer::FitExtendedVertexWithMinuit() {
   fMinuitExtendedVertex->mnparm(2,"z",seedZ,5.0,fZmin,fZmax,err);
   fMinuitExtendedVertex->mnparm(3,"theta",seedTheta,0.125*TMath::Pi(),-1.0*TMath::Pi(),2.0*TMath::Pi(),err); 
   fMinuitExtendedVertex->mnparm(4,"phi",seedPhi,0.125*TMath::Pi(),-2.0*TMath::Pi(), 2.0*TMath::Pi(),err);
+  fMinuitExtendedVertex->mnparm(5,"vtxTime",seedTime,1.0,fTmin,fTmax,err); //....TX
   
   flag = fMinuitExtendedVertex->Migrad();
   
@@ -1428,6 +842,7 @@ void MinuitOptimizer::FitExtendedVertexWithMinuit() {
   fMinuitExtendedVertex->GetParameter(2,fitZpos,fitZposErr);
   fMinuitExtendedVertex->GetParameter(3,fitTheta,fitThetaErr);
   fMinuitExtendedVertex->GetParameter(4,fitPhi,fitPhiErr);
+  fMinuitExtendedVertex->GetParameter(5,fitTime,fitTimeErr);
 
   delete [] arglist;
   
@@ -1442,6 +857,7 @@ void MinuitOptimizer::FitExtendedVertexWithMinuit() {
   fVtxX = fitXpos; 
   fVtxY = fitYpos;
   fVtxZ = fitZpos;
+  fVtxTime = fitTime;
   fDirX = sin(fitTheta)*cos(fitPhi);
   fDirY = sin(fitTheta)*sin(fitPhi);
   fDirZ = cos(fitTheta);  
@@ -1453,11 +869,12 @@ void MinuitOptimizer::FitExtendedVertexWithMinuit() {
 
   fItr = extended_vertex_iterations();
   
-  // calculate vertex
+  // fit complete; calculate fit results
   // ================
-  this->ExtendedVertexChi2(fVtxX,fVtxY,fVtxZ,
-                           fDirX,fDirY,fDirZ, 
-                           fConeAngle,fVtxTime,fVtxFOM);
+  double vtxParam0 = fgMinuitOptimizer->fFixTimeParam0; //scatterring parameter
+  fgFoMCalculator->ExtendedVertexChi2(fVtxX,fVtxY,fVtxZ,
+                           fDirX,fDirY,fDirZ, vtxParam0, 
+                           fConeAngle, fVtxTime,fVtxFOM);
                            
   // set vertex and direction
   // ========================
@@ -1479,388 +896,290 @@ void MinuitOptimizer::FitExtendedVertexWithMinuit() {
   return;
 }
 
-void MinuitOptimizer::FitCorrectedVertexWithMinuit() {
-	// initialization
-  // ==============
-  double vtxAngle = Parameters::CherenkovAngle();
-  double vtxFOM = 0.0;
-  // seed vertex
-  // ===========
-  bool foundSeed = ( fSeedVtx->FoundVertex() 
-                    && fSeedVtx->FoundDirection() );
 
-  double seedX = fSeedVtx->GetPosition().X();
-  double seedY = fSeedVtx->GetPosition().Y();
-  double seedZ = fSeedVtx->GetPosition().Z();
-  double seedT = fSeedVtx->GetTime();
+//KEPT FOR HISTORY, BUT FITTER IS CURRENTLY NOT WORKING
+//THESE SHOULD BE MOVED TO BEFORE THE CONSTRUCTOR
+//static void corrected_vertex_chi2(int&, double*, double& f, double* par, int)
+//{
+//  bool printDebugMessages = 0;
+//  
+//  double dl = par[0];
+////  double dirTheta = par[1]; // radians
+////  double dirPhi   = par[2]; // radiansf
+//  
+////  double dirX = sin(dirTheta)*cos(dirPhi);
+////  double dirY = sin(dirTheta)*sin(dirPhi);
+////  double dirZ = cos(dirTheta);
+//  
+//  double dirX = fgMinuitOptimizer->fDirX;
+//  double dirY = fgMinuitOptimizer->fDirY;
+//  double dirZ = fgMinuitOptimizer->fDirZ;
+//  
+//  double vtxX = fgMinuitOptimizer->fVtxX + dl * dirX;
+//  double vtxY = fgMinuitOptimizer->fVtxY + dl * dirY;;
+//  double vtxZ = fgMinuitOptimizer->fVtxZ + dl * dirZ;
+//
+//  double vangle = 0.0;
+//  double vtime  = 0.0;
+//  double fom = 0.0;
+//
+//  if(TMath::Sqrt(vtxX*vtxX + vtxY*vtxY + vtxZ*vtxZ)>152 || vtxY>198 || vtxY<-198) {fom = 9999;}
+//  fgMinuitOptimizer->corrected_vertex_itr();
+//  
+//  fgFoMCalculator->CorrectedVertexChi2(vtxX,vtxY,vtxZ,
+//                                     dirX,dirY,dirZ,
+//                                     vangle,vtime,fom);
+//
+//  f = -fom; // note: need to maximize this fom
+//
+//  if( printDebugMessages ){
+//    std::cout << " [corrected_vertex_chi2] [" << fgMinuitOptimizer->extended_vertex_iterations() 
+//    	<< "] (x,y,z)=(" << vtxX << "," << vtxY << "," << vtxZ << ") (px,py,pz)=(" << dirX << "," 
+//    	<< dirY << "," << dirZ << ") vtime=" << vtime << " fom=" << fom << std::endl;  
+//  }
+//
+//  return;
+//}
 
-  double seedDirX = fSeedVtx->GetDirection().X();
-  double seedDirY = fSeedVtx->GetDirection().Y();
-  double seedDirZ = fSeedVtx->GetDirection().Z();
+//static void vertex_cone_lnl(int&, double*, double& f, double* par, int)
+//{
+//  bool printDebugMessages = 0;
+//  
+//  double vtxParam0 = fgMinuitOptimizer->fFixConeParam0;
+//  double vtxParam1 = fgMinuitOptimizer->fFixConeParam1;
+//  double vtxParam2 = fgMinuitOptimizer->fFixConeParam2;
+//
+//  if( fgMinuitOptimizer->fFitConeParams ){
+//    vtxParam0 = par[0];
+//    vtxParam1 = par[1];
+//    vtxParam2 = par[2];
+//  }
+// 
+//  double vangle = 0.0;
+//  double fom = 0.0;
+//
+//  fgMinuitOptimizer->cone_fit_itr();
+//  fgFoMCalculator->ConePropertiesLnL(vtxParam0,vtxParam1,vtxParam2,vangle,fom);
+//
+//  f = -fom; // note: need to maximize this fom
+//
+//  if( printDebugMessages ){
+//    std::cout << "  [vertex_cone_lnl] [" << fgMinuitOptimizer->cone_fit_iterations() 
+//    	<< "] vparam0=" << vtxParam0 << " vparam1=" << vtxParam1 << " vtxParam2=" << vtxParam2 
+//    	<< " fom=" << fom << std::endl;
+//  }
+//
+//  return;
+//}
+//KEPT FOR HISTORY, BUT NOT CURRENTLY WORKING
+//void MinuitOptimizer::FitCorrectedVertexWithMinuit() {
+//	// initialization
+//  // ==============
+//  double vtxAngle = Parameters::CherenkovAngle();
+//  double vtxFOM = 0.0;
+//  // seed vertex
+//  // ===========
+//  bool foundSeed = ( fSeedVtx->FoundVertex() 
+//                    && fSeedVtx->FoundDirection() );
+//
+//  double seedX = fSeedVtx->GetPosition().X();
+//  double seedY = fSeedVtx->GetPosition().Y();
+//  double seedZ = fSeedVtx->GetPosition().Z();
+//  double seedT = fSeedVtx->GetTime();
+//
+//  double seedDirX = fSeedVtx->GetDirection().X();
+//  double seedDirY = fSeedVtx->GetDirection().Y();
+//  double seedDirZ = fSeedVtx->GetDirection().Z();
+//
+//  double seedTheta = acos(seedDirZ);
+//  double seedPhi = 0.0;
+//
+//  if( seedDirX!=0.0 ){
+//    seedPhi = atan(seedDirY/seedDirX);
+//  }
+//  if( seedDirX<=0.0 ){
+//    if( seedDirY>0.0 ) seedPhi += TMath::Pi();
+//    if( seedDirY<0.0 ) seedPhi -= TMath::Pi();
+//  }
+//  // current status
+//  // ==============
+//  int status = fSeedVtx->GetStatus();
+//  
+//  // reset counter
+//  // =============
+//  corrected_vertex_reset_itr();
+//  
+//  // abort if necessary
+//  // ==================
+//  if( foundSeed==0 ){
+//  	if( fPrintLevel >= 0) {
+//      std::cout << "   <warning> corrected vertex fit failed to find input vertex " << std::endl;   
+//    }
+//    status |= RecoVertex::kFailCorrectedVertex;
+//    fFittedVtx->SetStatus(status);
+//    return;
+//  }
+//  
+//  // run Minuit
+//  // ==========  
+//  // one-parameter fit to vertex parallel position
+//
+//  int err = 0;
+//  int flag = 0;
+//
+//  double fitParallelcor = 0.0;
+//  double fitTheta = 0.0;
+//  double fitPhi = 0.0;
+//
+//  double fitParallelcorErr = 0.0;
+//  double fitThetaErr = 0.0;
+//  double fitPhiErr = 0.0;
+//  
+//  double* arglist = new double[10];
+//  arglist[0]=2;  // 1: standard minimization
+//                 // 2: try to improve minimum
+//  
+//   // re-initialize everything...
+//  fMinuitCorrectedVertex->mncler();
+//  fMinuitCorrectedVertex->SetFCN(corrected_vertex_chi2);
+//  fMinuitCorrectedVertex->mnset();
+//  fMinuitCorrectedVertex->mnexcm("SET STR",arglist,1,err);
+//  fMinuitCorrectedVertex->mnparm(0,"dl",0.0, 5.0, -50.0, 50.0, err);
+////  fMinuitCorrectedVertex->mnparm(1,"theta",seedTheta,0.125*TMath::Pi(),0.0,TMath::Pi(),err); //initial: 0.125*TMath::Pi(),0.0,TMath::Pi()
+////  fMinuitCorrectedVertex->mnparm(2,"phi",seedPhi,0.25*TMath::Pi(),-1.0*TMath::Pi(),+3.0*TMath::Pi(),err); //initial: 0.25*TMath::Pi(),-1.0*TMath::Pi(),+3.0*TMath::Pi()
+////  fMinuitCorrectedVertex->FixParameter(1);
+////  fMinuitCorrectedVertex->FixParameter(2);
+//  flag = fMinuitCorrectedVertex->Migrad();
+//  
+//  fMinuitCorrectedVertex->GetParameter(0,fitParallelcor,fitParallelcorErr);
+//
+//  delete [] arglist;
+//  
+//   // sort results
+//  // ============
+////  fDirX = sin(fitTheta)*cos(fitPhi);
+////  fDirY = sin(fitTheta)*sin(fitPhi);
+////  fDirZ = cos(fitTheta);
+//  fVtxX += fitParallelcor * fDirX; 
+//  fVtxY += fitParallelcor * fDirY;
+//  fVtxZ += fitParallelcor * fDirZ;
+//  
+//  fVtxFOM = 0.0;
+//  
+//  fPass = 0;               // flag = 0: normal termination
+//  if( flag==0 ) fPass = 1; // anything else: abnormal termination 
+//
+//  fItr = corrected_vertex_iterations();
+//  	
+//  // calculate vertex
+//  // ================
+//  fgFoMCalculator->CorrectedVertexChi2(fVtxX,fVtxY,fVtxZ,
+//                           fDirX,fDirY,fDirZ, 
+//                           fConeAngle,fVtxTime,fVtxFOM); //fit vertex time here
+//                           
+//  // set vertex and direction
+//  // ========================
+//  fFittedVtx->SetVertex(fVtxX,fVtxY,fVtxZ,fVtxTime);
+//  fFittedVtx->SetDirection(fDirX,fDirY,fDirZ);
+//  fFittedVtx->SetConeAngle(fConeAngle);
+//  fFittedVtx->SetFOM(fVtxFOM,fItr,fPass);
+//  // set status
+//  // ==========
+//  bool inside_det =  ANNIEGeometry::Instance()->InsideDetector(fVtxX,fVtxY,fVtxZ);
+//  if( !fPass || ! inside_det) status |= RecoVertex::kFailExtendedVertex;
+//  fFittedVtx->SetStatus(status);
+//  if( fPrintLevel >= 0) {
+//    if( !fPass ) std::cout << "   <warning> corrected vertex fit failed to converge! Error code: " << flag << std::endl;
+//  }
+//  // return vertex
+//  // =============  
+//  return;
+//}
 
-  double seedTheta = acos(seedDirZ);
-  double seedPhi = 0.0;
-
-  if( seedDirX!=0.0 ){
-    seedPhi = atan(seedDirY/seedDirX);
-  }
-  if( seedDirX<=0.0 ){
-    if( seedDirY>0.0 ) seedPhi += TMath::Pi();
-    if( seedDirY<0.0 ) seedPhi -= TMath::Pi();
-  }
-  // current status
-  // ==============
-  int status = fSeedVtx->GetStatus();
-  
-  // reset counter
-  // =============
-  corrected_vertex_reset_itr();
-  
-  // abort if necessary
-  // ==================
-  if( foundSeed==0 ){
-  	if( fPrintLevel >= 0) {
-      std::cout << "   <warning> corrected vertex fit failed to find input vertex " << std::endl;   
-    }
-    status |= RecoVertex::kFailCorrectedVertex;
-    fFittedVtx->SetStatus(status);
-    return;
-  }
-  
-  // run Minuit
-  // ==========  
-  // one-parameter fit to vertex parallel position
-
-  int err = 0;
-  int flag = 0;
-
-  double fitParallelcor = 0.0;
-  double fitTheta = 0.0;
-  double fitPhi = 0.0;
-
-  double fitParallelcorErr = 0.0;
-  double fitThetaErr = 0.0;
-  double fitPhiErr = 0.0;
-  
-  double* arglist = new double[10];
-  arglist[0]=2;  // 1: standard minimization
-                 // 2: try to improve minimum
-  
-   // re-initialize everything...
-  fMinuitCorrectedVertex->mncler();
-  fMinuitCorrectedVertex->SetFCN(corrected_vertex_chi2);
-  fMinuitCorrectedVertex->mnset();
-  fMinuitCorrectedVertex->mnexcm("SET STR",arglist,1,err);
-  fMinuitCorrectedVertex->mnparm(0,"dl",0.0, 5.0, -50.0, 50.0, err);
-//  fMinuitCorrectedVertex->mnparm(1,"theta",seedTheta,0.125*TMath::Pi(),0.0,TMath::Pi(),err); //initial: 0.125*TMath::Pi(),0.0,TMath::Pi()
-//  fMinuitCorrectedVertex->mnparm(2,"phi",seedPhi,0.25*TMath::Pi(),-1.0*TMath::Pi(),+3.0*TMath::Pi(),err); //initial: 0.25*TMath::Pi(),-1.0*TMath::Pi(),+3.0*TMath::Pi()
-//  fMinuitCorrectedVertex->FixParameter(1);
-//  fMinuitCorrectedVertex->FixParameter(2);
-  flag = fMinuitCorrectedVertex->Migrad();
-  
-  fMinuitCorrectedVertex->GetParameter(0,fitParallelcor,fitParallelcorErr);
-
-  delete [] arglist;
-  
-   // sort results
-  // ============
-//  fDirX = sin(fitTheta)*cos(fitPhi);
-//  fDirY = sin(fitTheta)*sin(fitPhi);
-//  fDirZ = cos(fitTheta);
-  fVtxX += fitParallelcor * fDirX; 
-  fVtxY += fitParallelcor * fDirY;
-  fVtxZ += fitParallelcor * fDirZ;
-  
-  fVtxFOM = 0.0;
-  
-  fPass = 0;               // flag = 0: normal termination
-  if( flag==0 ) fPass = 1; // anything else: abnormal termination 
-
-  fItr = corrected_vertex_iterations();
-  	
-  // calculate vertex
-  // ================
-  this->CorrectedVertexChi2(fVtxX,fVtxY,fVtxZ,
-                           fDirX,fDirY,fDirZ, 
-                           fConeAngle,fVtxTime,fVtxFOM); //fit vertex time here
-                           
-  // set vertex and direction
-  // ========================
-  fFittedVtx->SetVertex(fVtxX,fVtxY,fVtxZ,fVtxTime);
-  fFittedVtx->SetDirection(fDirX,fDirY,fDirZ);
-  fFittedVtx->SetConeAngle(fConeAngle);
-  fFittedVtx->SetFOM(fVtxFOM,fItr,fPass);
-  // set status
-  // ==========
-  bool inside_det =  ANNIEGeometry::Instance()->InsideDetector(fVtxX,fVtxY,fVtxZ);
-  if( !fPass || ! inside_det) status |= RecoVertex::kFailExtendedVertex;
-  fFittedVtx->SetStatus(status);
-  if( fPrintLevel >= 0) {
-    if( !fPass ) std::cout << "   <warning> corrected vertex fit failed to converge! Error code: " << flag << std::endl;
-  }
-  // return vertex
-  // =============  
-  return;
-}
-
-
-//Given the position of the point vertex (x, y, z) and n digits, calculate the mean expected vertex time
-double MinuitOptimizer::FindSimpleTimeProperties(VertexGeometry* vtxgeo) {
-	double meanTime = 0.0;
-	// weighted average
-	if(fMeanTimeCalculatorType == 0) {
-    // calculate mean and rms of hits inside cone
-    // ==========================================
-    double Swx = 0.0;
-    double Sw = 0.0;
-    
-    double delta = 0.0;
-    double sigma = 0.0;
-    double weight = 0.0;
-    double deweight = 0.0;
-    double deltaAngle = 0.0;
-    
-    double myConeEdge = Parameters::CherenkovAngle();      // [degrees]
-    double myConeEdgeSigma = 7.0;  // [degrees]
-    
-    for( int idigit=0; idigit<vtxgeo->GetNDigits(); idigit++ ){
-      int detType = this->fVtxGeo->GetDigitType(idigit); 
-      if( vtxgeo->IsFiltered(idigit) ){
-        delta = vtxgeo->GetDelta(idigit);    
-        sigma = vtxgeo->GetDeltaSigma(idigit);
-        weight = 1.0/(sigma*sigma); 
-        // profile in angle
-        deltaAngle = vtxgeo->GetAngle(idigit) - myConeEdge;      
-        // deweight hits outside cone
-        if( deltaAngle<=0.0 ){
-          deweight = 1.0;
-        }
-        else{
-          deweight = 1.0/(1.0+(deltaAngle*deltaAngle)/(myConeEdgeSigma*myConeEdgeSigma));
-        }
-        Swx += deweight*weight*delta; //delta is expected vertex time 
-        Sw  += deweight*weight;
-      }
-    }
-    if( Sw>0.0 ){
-      meanTime = Swx*1.0/Sw;
-    }
-	}
-	
-	// most probable time
-	else if(fMeanTimeCalculatorType == 1) {
-		double sigma = 0.0;
-		double deltaAngle = 0.0;
-		double weight = 0.0;
-		double deweight = 0.0;
-		double myConeEdge = Parameters::CherenkovAngle();      // [degrees]
-    double myConeEdgeSigma = 7.0;  // [degrees]
-		vector<double> deltaTime1;
-		vector<double> deltaTime2;
-		vector<double> TimeWeight;
-		
-		for( int idigit=0; idigit<vtxgeo->GetNDigits(); idigit++ ){
-      if(vtxgeo->IsFiltered(idigit)){
-        deltaTime1.push_back(vtxgeo->GetDelta(idigit));  
-        deltaTime2.push_back(vtxgeo->GetDelta(idigit));   
-        sigma = vtxgeo->GetDeltaSigma(idigit);
-        weight = 1.0/(sigma*sigma); 
-        deltaAngle = vtxgeo->GetAngle(idigit) - myConeEdge;
-        if( deltaAngle<=0.0 ){
-          deweight = 1.0;
-        }
-        else{
-          deweight = 1.0/(1.0+(deltaAngle*deltaAngle)/(myConeEdgeSigma*myConeEdgeSigma));
-        }
-        TimeWeight.push_back(deweight*weight);
-      }
-    }
-    int n = deltaTime1.size();
-    std::sort(deltaTime1.begin(),deltaTime1.end());
-    double timeMin = deltaTime1.at(int((n-1)*0.05)); // 5% of the total entries
-    double timeMax = deltaTime1.at(int((n-1)*0.90)); // 90% of the total entries
-    int nbins = int(n/5);
-    TH1D *hDeltaTime = new TH1D("hDeltaTime", "hDeltaTime", nbins, timeMin, timeMax);
-    for(int i=0; i<n; i++) {
-      //hDeltaTime->Fill(deltaTime2.at(i), TimeWeight.at(i));	
-      hDeltaTime->Fill(deltaTime2.at(i));	
-    }
-    meanTime = hDeltaTime->GetBinCenter(hDeltaTime->GetMaximumBin());
-    delete hDeltaTime; hDeltaTime = 0;
-	}
-	
-	else std::cout<<"MinuitOptimizer Error: Wrong type of Mean time calculator! "<<std::endl;
-  
-  return meanTime; //return expected vertex time
-}
-
-void MinuitOptimizer::PointPositionChi2(double vtxX, double vtxY, double vtxZ, double& vtxTime, double& fom)
-{  
-  // figure of merit
-  // ===============
-  double vtxFOM = 0.0;
-  double penaltyFOM = 0.0;
-  double fixPositionFOM = 0.0;
-  
-  // calculate residuals
-  // ===================
-  this->fVtxGeo->CalcPointResiduals(vtxX, vtxY, vtxZ, 0.0, 0.0, 0.0, 0.0); //calculate expected point vertex time for each digit
-
-  // calculate figure of merit
-  // =========================
-  double vtxParam0 = this->fFixTimeParam0;
-  this->TimePropertiesLnL(vtxTime,vtxParam0, vtxFOM);
-
-  // calculate penalty
-  // =================
-  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
-
-  // calculate overall figure of merit
-  // =================================
-  fom = vtxFOM + penaltyFOM + fixPositionFOM;
-  // truncate
-  if( fom<-999.999*fBaseFOM ) fom = -999.999*fBaseFOM;
-
-  return;
-}
-
-void MinuitOptimizer::PointDirectionChi2(double vtxX, double vtxY, 
-	                                       double vtxZ, double dirX, double dirY, double dirZ, 
-	                                       double& vtxAngle, double& fom)
-{  
-  // figure of merit
-  // ===============
-  double coneFOM = 0.0;
-  double fixPositionFOM = 0.0;
-  
-  // calculate residuals
-  // ===================
-  this->fVtxGeo->CalcPointResiduals(vtxX, vtxY, vtxZ, 0.0, 
-                                 dirX, dirY, dirZ); //load expected vertex time for each digit
-
-  // calculate figure of merit
-  // =========================
-  //this->FitPointConePropertiesLnL(vtxAngle,coneFOM);
-  this->FitConePropertiesFoM(vtxAngle,coneFOM);
-
-  // calculate overall figure of merit
-  // =================================
-  fom = coneFOM;
-
-  // truncate
-  if( fom<-999.999*fBaseFOM ) fom = -999.999*fBaseFOM;
-
-  return;
-}
-
-void MinuitOptimizer::PointVertexChi2(double vtxX, double vtxY, double vtxZ, 
-	                                    double dirX, double dirY, double dirZ, 
-	                                    double& vtxAngle, double& vtxTime, double& fom)
-{  
-  // figure of merit
-  // ===============
-  double vtxFOM = 0.0;
-  double penaltyFOM = 0.0;
-  double fixPositionFOM = 0.0;
-  double fixDirectionFOM = 0.0;
-
-  // calculate residuals
-  // ===================
-  this->fVtxGeo->CalcPointResiduals(vtxX, vtxY, vtxZ, 0.0, 
-                                 dirX, dirY, dirZ); //calculate expected vertex time for each digit
-  // calculate figure of merit
-  // =========================
-  double timeFOM = 0.0;
-  double coneFOM = 0.0;
-  
-  //this->FitPointConePropertiesLnL(vtxAngle, coneFOM);
-  this->FitConePropertiesFoM(vtxAngle,coneFOM);
-  this->FitPointTimePropertiesLnL(vtxTime, timeFOM);
-  
-  double fTimeFitWeight = this->fTimeFitWeight;
-  double fConeFitWeight = this->fConeFitWeight;
-  vtxFOM = (fTimeFitWeight*timeFOM+fConeFitWeight*coneFOM)/(fTimeFitWeight+fConeFitWeight);
-
-  // calculate penalty
-  // =================
-  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
-
-  // calculate overall figure of merit
-  // =================================
-  
-  fom = vtxFOM + penaltyFOM + fixPositionFOM + fixDirectionFOM;
-  // truncate
-  if( fom<-999.999*fBaseFOM ) fom = -999.999*fBaseFOM;
-
-  return;
-}
-
-void MinuitOptimizer::ExtendedVertexChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double& vtxAngle, double& vtxTime, double& fom)
-{  
-  // figure of merit
-  // ===============
-  double vtxFOM = 0.0;
-  double timeFOM = 0.0;
-  double coneFOM = 0.0;
-  double penaltyFOM = 0.0;
-  double fixPositionFOM = 0.0;
-  double fixDirectionFOM = 0.0;
-
-  // calculate residuals
-  // ===================
-  this->fVtxGeo->CalcExtendedResiduals(vtxX,vtxY,vtxZ,0.0,dirX,dirY,dirZ);
-  
-  // calculate figure of merit
-  // =========================
-
-  this->FitConePropertiesFoM(vtxAngle,coneFOM);
-  this->FitExtendedTimePropertiesLnL(vtxTime,timeFOM);
-  
-  double fTimeFitWeight = this->fTimeFitWeight;
-  double fConeFitWeight = this->fConeFitWeight;
-  vtxFOM = (fTimeFitWeight*timeFOM+fConeFitWeight*coneFOM)/(fTimeFitWeight+fConeFitWeight);
-
-  // calculate penalty
-  // =================
-  //this->PenaltyChi2(vtxX,vtxY,vtxZ,penaltyFOM);
-
-  // calculate overall figure of merit
-  // =================================
-  fom = vtxFOM + penaltyFOM + fixPositionFOM + fixDirectionFOM;
-
-  // truncate
-  if( fom<-999.999*fBaseFOM ) fom = -999.999*fBaseFOM;
-
-  return;
-}
-
-void MinuitOptimizer::CorrectedVertexChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double& vtxAngle, double& vtxTime, double& fom)
-{  
-  // figure of merit
-  // ===============
-  double vtxFOM = 0.0;
-  double timeFOM = 0.0;
-  double coneFOM = 0.0;
-  double penaltyFOM = 0.0;
-  double fixPositionFOM = 0.0;
-  double fixDirectionFOM = 0.0;
-
-  // calculate residuals
-  // ===================
-  this->fVtxGeo->CalcExtendedResiduals(vtxX,vtxY,vtxZ,0.0,dirX,dirY,dirZ);
-  
-  // calculate figure of merit
-  // =========================
-
-  this->FitConePropertiesFoM(vtxAngle,coneFOM);
-  fom = coneFOM;
-
-  // truncate
-  if( fom<-999.999*fBaseFOM ) fom = -999.999*fBaseFOM;
-
-  return;
-}
-
-
+//void MinuitOptimizer::FitPointConePropertiesLnL(double& coneAngle, double& coneFOM)
+//{  
+//  coneAngle  = Parameters::CherenkovAngle(); //...chrom1.38, nominal cone angle
+//  // calculate cone fom
+//  // =========================
+//  coneFOM = 0.0;
+//  double ConeParam0 = this->fFixConeParam0;
+//  double ConeParam1 = this->fFixConeParam1;
+//  double ConeParam2 = this->fFixConeParam2;
+//  fgFoMCalculator->ConePropertiesLnL(ConeParam0,ConeParam1,ConeParam2,coneAngle,coneFOM);  
+//  return;
+//}
+//
+//void MinuitOptimizer::FitExtendedConePropertiesLnL(double& coneAngle, double& coneFOM)
+//{  
+//  // return result from point fit
+//  // ============================
+//  if( this->fFitConeParams==0 ){
+//    return this->FitPointConePropertiesLnL(coneAngle,coneFOM);
+//  }
+//
+//  // reset counter
+//  // =============
+//  cone_fit_reset_itr();
+//
+//  // run Minuit
+//  // ==========  
+//  // one-parameter fit to angular distribution
+//
+//  int err = 0;
+//  int flag = 0;
+//
+//  double seedParam0 = this->fFixConeParam0; //track length parameter
+//  double seedParam1 = this->fFixConeParam1; //track length parameter
+//  double seedParam2 = this->fFixConeParam2; //particle ID:  0.0[electron]->1.0[muon]
+//
+//  double fitParam0 = seedParam0;
+//  double fitParam1 = seedParam1;
+//  double fitParam2 = seedParam2;
+//
+//  double fitParam0Err = 0.0;
+//  double fitParam1Err = 0.0; 
+//  double fitParam2Err = 0.0;
+//
+//  double fitAngle  = Parameters::CherenkovAngle();
+//  
+//  double* arglist = new double[10];
+//  arglist[0]=1;  // 1: standard minimization
+//                 // 2: try to improve minimum
+//
+//  // re-initialize everything...
+//  fMinuitConeFit->mncler();
+//  fMinuitConeFit->SetFCN(vertex_cone_lnl);
+//  fMinuitConeFit->mnexcm("SET STR",arglist,1,err);
+//  fMinuitConeFit->mnparm(0,"vtxParam0",seedParam0,0.25,0.0,1.0,err);
+//  fMinuitConeFit->mnparm(1,"vtxParam1",seedParam1,0.25,0.0,1.0,err);
+//  fMinuitConeFit->mnparm(2,"vtxParam2",seedParam2,0.25,0.0,1.0,err);
+//
+//  flag = fMinuitConeFit->Migrad();
+//  fMinuitConeFit->GetParameter(0,fitParam0,fitParam0Err);
+//  fMinuitConeFit->GetParameter(1,fitParam1,fitParam1Err);
+//  fMinuitConeFit->GetParameter(2,fitParam2,fitParam2Err);
+//  
+//  delete [] arglist;
+//
+//  // calculate figure of merit
+//  // =========================
+//  double fom = -9999.;
+//  
+//  this->ConePropertiesLnL(fitParam0,fitParam1,fitParam2,
+//                          fitAngle,fom);  
+//
+//
+//  // --- debug ---
+//  fConeParam0 = fitParam0;
+//  fConeParam1 = fitParam1;
+//  fConeParam2 = fitParam2;
+//
+//  // return figure of merit
+//  // ======================
+//  coneAngle = fitAngle;
+//  coneFOM = fom;
+//
+//  return;
+//}
 
 

--- a/DataModel/MinuitOptimizer.h
+++ b/DataModel/MinuitOptimizer.h
@@ -73,10 +73,11 @@ public:
  	MinuitOptimizer();
   ~MinuitOptimizer();
   void SetPrintLevel(int printlevel) {fPrintLevel = printlevel;}
-  void SetMeanTimeCalculatorType(int type) {fMeanTimeCalculatorType = type;}
   void SetTimeFitWeight(double tweight);
   void SetConeFitWeight(double cweight);
-  void SetConeAngle(double cangle){ fConeAngle=cangle};
+  void SetMeanTimeCalculatorType(int type);
+  void SetNumberOfIterations(int iterations);
+  void SetConeAngle(double cangle){ fConeAngle=cangle;}
   void LoadVertexGeometry(VertexGeometry* vtxgeo);
   void LoadVertex(RecoVertex* vtx);
   void LoadVertex(double vtxX, double vtxY, double vtxZ, double vtxTime, double vtxDirX, double vtxDirY, double vtxDirZ);

--- a/DataModel/MinuitOptimizer.h
+++ b/DataModel/MinuitOptimizer.h
@@ -17,6 +17,7 @@
 
 #include "RecoVertex.h"
 #include "VertexGeometry.h"
+#include "FoMCalculator.h"
 
 #include <vector>
 #include <iostream>
@@ -43,122 +44,93 @@ public:
   int fItr = 0;
   
   int fTimeFitItr;
-  int fConeFitItr;
   int fPointPosItr;
   int fPointDirItr;
   int fPointVtxItr;
   int fExtendedVtxItr;
-  int fCorrectedVtxItr;
-  
-  //ConeFit parameters
-  double fSconeA;
-  double fSconeB;
-  double fSmu;
-  double fSel;
-  bool fIntegralsDone;
-  
-  //coneparameters
-  double fConeParam0;
-  double fConeParam1;
-  double fConeParam2;
-  
+
+  //fitting parameters
+  // --- fitting ---
+  bool fFitTimeParams;
+  double fFixTimeParam0;
+
+
   //Fit range
   double fXmin, fXmax, fYmin, fYmax, fZmin, fZmax;
   double fTmin, fTmax;
   
   RecoVertex* fSeedVtx;
   RecoVertex* fFittedVtx;
-  VertexGeometry* fVtxGeo;
   
   TMinuit* fMinuitPointPosition;
   TMinuit* fMinuitPointDirection;
   TMinuit* fMinuitPointVertex; 
   TMinuit* fMinuitExtendedVertex; 
-  TMinuit* fMinuitCorrectedVertex;
 
   TMinuit* fMinuitTimeFit;
-  TMinuit* fMinuitConeFit;
   
  	
  	MinuitOptimizer();
   ~MinuitOptimizer();
   void SetPrintLevel(int printlevel) {fPrintLevel = printlevel;}
   void SetMeanTimeCalculatorType(int type) {fMeanTimeCalculatorType = type;}
+  void SetTimeFitWeight(double tweight);
+  void SetConeFitWeight(double cweight);
+  void SetConeAngle(double cangle){ fConeAngle=cangle};
   void LoadVertexGeometry(VertexGeometry* vtxgeo);
   void LoadVertex(RecoVertex* vtx);
   void LoadVertex(double vtxX, double vtxY, double vtxZ, double vtxTime, double vtxDirX, double vtxDirY, double vtxDirZ);
-  void FitPointTimePropertiesLnL(double& vtxTime, double& vtxFOM);
-  void FitExtendedTimePropertiesLnL(double& vtxTime, double& vtxFOM);
-  void FitConePropertiesFoM(double& coneAngle, double& coneFOM);
-  void FitPointConePropertiesLnL(double& coneAngle, double& coneFOM);
-  void FitExtendedConePropertiesLnL(double& coneAngle, double& coneFOM);
   void FitPointTimeWithMinuit();
   void FitPointPositionWithMinuit();
   void FitPointDirectionWithMinuit();
   void FitPointVertexWithMinuit();
   void FitExtendedVertexWithMinuit();
-  void FitCorrectedVertexWithMinuit();
-  
-  double FindSimpleTimeProperties(VertexGeometry* vtxgeo);
-  void TimePropertiesLnL(double vtxTime, double vtxParam, double& vtxFom);
-  void ConePropertiesFoM(double& chi2);
-  void ConePropertiesLnL(double coneParam0, double coneParam1, double coneParam2, double& coneAngle, double& coneFOM);
-  void PointPositionChi2(double vtxX, double vtxY, double vtxZ, double& vtxTime, double& fom);
-  void PointDirectionChi2(double vtxX, double vtxY, double vtxZ, double dirX, double dirY, double dirZ, double& vtxAngle, double& fom);
-  void PointVertexChi2(double vtxX, double vtxY, double vtxZ,
-	                                    double dirX, double dirY, double dirZ, 
-	                                    double& vtxAngle, double& vtxTime, double& fom);
-	void ExtendedVertexChi2(double vtxX, double vtxY, double vtxZ, 
-	                                    double dirX, double dirY, double dirZ, 
-	                                    double& vtxAngle, double& vtxTime, double& fom);
-  void CorrectedVertexChi2(double vtxX, double vtxY, double vtxZ, 
-	                                    double dirX, double dirY, double dirZ, 
-	                                    double& vtxAngle, double& vtxTime, double& fom);
   
   double GetTime() {return fVtxTime;}
   double GetFOM() {return fVtxFOM;}
   RecoVertex* GetFittedVertex() {return fFittedVtx;}
   
   void time_fit_itr()        { fTimeFitItr++; }
-  void cone_fit_itr()        { fConeFitItr++; }
   void point_position_itr()  { fPointPosItr++; }
   void point_direction_itr() { fPointDirItr++; }
   void point_vertex_itr()    { fPointVtxItr++; }
   void extended_vertex_itr() { fExtendedVtxItr++; }
-  void corrected_vertex_itr() { fCorrectedVtxItr++; }
 
   void time_fit_reset_itr()        { fTimeFitItr = 0; }
-  void cone_fit_reset_itr()        { fConeFitItr = 0; }
   void point_position_reset_itr()  { fPointPosItr = 0; }
   void point_direction_reset_itr() { fPointDirItr = 0; }
   void point_vertex_reset_itr()    { fPointVtxItr = 0; }
   void extended_vertex_reset_itr() { fExtendedVtxItr = 0; }
-  void corrected_vertex_reset_itr() { fCorrectedVtxItr = 0; }
 
   int time_fit_iterations()        { return fTimeFitItr; }
-  int cone_fit_iterations()        { return fConeFitItr; }
   int point_position_iterations()  { return fPointPosItr; }
   int point_direction_iterations() { return fPointDirItr; }
   int point_vertex_iterations()    { return fPointVtxItr; }
   int extended_vertex_iterations() { return fExtendedVtxItr; }
-  int corrected_vertex_iterations() { return fCorrectedVtxItr; }
+ 
+  //KEPT FOR HISTORY; CURRENTLY NOT IN USE 
+  //coneparameters
+  //bool fFitConeParams;
+  //double fFixConeParam0;
+  //double fFixConeParam1;
+  //double fFixConeParam2;
+  //double fConeParam0;
+  //double fConeParam1;
+  //double fConeParam2;
+  //TMinuit* fMinuitConeFit;
   
-  
-public: 
-  //fitting parameters
-  // --- fitting ---
-  bool fFitTimeParams;
-  double fFixTimeParam0;
-
-  bool fFitConeParams;
-  double fFixConeParam0;
-  double fFixConeParam1;
-  double fFixConeParam2;
-  
-  double fTimeFitWeight;
-  double fConeFitWeight;
-  
-  int fMeanTimeCalculatorType;
+  //int fConeFitItr;
+  //int fCorrectedVtxItr;
+  //TMinuit* fMinuitCorrectedVertex;
+  //void FitPointConePropertiesLnL(double& coneAngle, double& coneFOM);
+  //void FitExtendedConePropertiesLnL(double& coneAngle, double& coneFOM);
+  //void FitCorrectedVertexWithMinuit();
+  //void cone_fit_itr()        { fConeFitItr++; }
+  //void cone_fit_reset_itr()        { fConeFitItr = 0; }
+  //int cone_fit_iterations()        { return fConeFitItr; }
+  //void corrected_vertex_itr() { fCorrectedVtxItr++; }
+  //void corrected_vertex_reset_itr() { fCorrectedVtxItr = 0; }
+  //int corrected_vertex_iterations() { return fCorrectedVtxItr; }
 
 };
 

--- a/DataModel/RecoVertex.cpp
+++ b/DataModel/RecoVertex.cpp
@@ -14,7 +14,7 @@ RecoVertex::RecoVertex( Position pos)
 {
   this->Reset();
   this->SetVertex(pos);
-  this->SetFOM(0.0,1,1);
+  this->SetFOM(-9999.,1,1);
 
   ANNIERecoObjectTable::Instance()->NewVertex();
 }
@@ -25,7 +25,7 @@ RecoVertex::RecoVertex( Position pos, Direction dir)
 
   this->SetVertex(pos);
   this->SetDirection(dir);
-  this->SetFOM(0.0,1,1);
+  this->SetFOM(-9999.,1,1);
   
   ANNIERecoObjectTable::Instance()->NewVertex();
 }
@@ -153,10 +153,9 @@ void RecoVertex::Reset()
   fFoundDirection = 0;
 
   fConeAngle = 0.0;
-  fConeAngle = 42.0;
   fTrackLength = 0.0;
 
-  fFOM = 0.0;
+  fFOM = -9999.;
   fIterations = 0;
   fPass = 0;
   

--- a/UserTools/LikelihoodFitterCheck/LikelihoodFitterCheck.cpp
+++ b/UserTools/LikelihoodFitterCheck/LikelihoodFitterCheck.cpp
@@ -77,7 +77,8 @@ bool LikelihoodFitterCheck::Execute(){
 	double recoVtxX, recoVtxY, recoVtxZ, recoVtxT, recoDirX, recoDirY, recoDirZ;
   double trueVtxX, trueVtxY, trueVtxZ, trueVtxT, trueDirX, trueDirY, trueDirZ;
   double seedX, seedY, seedZ, seedT, seedDirX, seedDirY, seedDirZ;
-  
+  double ConeAngle = Parameters::CherenkovAngle();
+
   // Get true Vertex information
   Position vtxPos = fTrueVertex->GetPosition();
 	Direction vtxDir = fTrueVertex->GetDirection();
@@ -91,11 +92,10 @@ bool LikelihoodFitterCheck::Execute(){
   
   if(verbosity>0) cout<<"True vertex  = ("<<trueVtxX<<", "<<trueVtxY<<", "<<trueVtxZ<<", "<<trueVtxT<<", "<<trueDirX<<", "<<trueDirY<<", "<<trueDirZ<<")"<<endl;
   
-  MinuitOptimizer * myOptimizer = new MinuitOptimizer();
-	VertexGeometry* myvtxgeo = VertexGeometry::Instance();
+  FoMCalculator * myFoMCalculator = new FoMCalculator();
+  VertexGeometry* myvtxgeo = VertexGeometry::Instance();
   myvtxgeo->LoadDigits(fDigitList);
-  myOptimizer->LoadVertexGeometry(myvtxgeo); //Load vertex geometry
-  myOptimizer->SetMeanTimeCalculatorType(0); //
+  myFoMCalculator->LoadVertexGeometry(myvtxgeo); //Load vertex geometry
   //parallel direction
   double dl = 1.0; // step size  = 1 cm along the track
   double dx = dl * trueDirX;
@@ -113,13 +113,12 @@ bool LikelihoodFitterCheck::Execute(){
     seedDirZ = trueDirZ;
     myvtxgeo->CalcExtendedResiduals(seedX, seedY, seedZ, 0.0, seedDirX, seedDirY, seedDirZ);
     int nhits = myvtxgeo->GetNDigits();
-    double meantime = myOptimizer->FindSimpleTimeProperties(myvtxgeo);
+    double meantime = myFoMCalculator->FindSimpleTimeProperties(ConeAngle);
     Double_t fom = -999.999*100;
     double timefom = -999.999*100;
     double conefom = -999.999*100;
-    double coneAngle = 42.0;
-    myOptimizer->TimePropertiesLnL(meantime,0.2,timefom);
-    myOptimizer->FitConePropertiesFoM(coneAngle,conefom);
+    myFoMCalculator->TimePropertiesLnL(meantime,timefom);
+    myFoMCalculator->ConePropertiesFoM(ConeAngle,conefom);
     fom = timefom*0.5+conefom*0.5;
     cout<<"timeFOM, coneFOM, fom = "<<timefom<<", "<<conefom<<", "<<fom<<endl;
     fom = timefom;
@@ -146,14 +145,14 @@ bool LikelihoodFitterCheck::Execute(){
     seedDirY = trueDirY;
     seedDirZ = trueDirZ;
     myvtxgeo->CalcExtendedResiduals(seedX, seedY, seedZ, 0.0, seedDirX, seedDirY, seedDirZ);
-    int nhits = myOptimizer->fVtxGeo->GetNDigits();
-    double meantime = myOptimizer->FindSimpleTimeProperties(myvtxgeo);
+    int nhits = myvtxgeo->GetNDigits();
+    double meantime = myFoMCalculator->FindSimpleTimeProperties(ConeAngle);
     Double_t fom = -999.999*100;
     double timefom = -999.999*100;
     double conefom = -999.999*100;
     double coneAngle = 42.0;
-    myOptimizer->TimePropertiesLnL(meantime,0.2,timefom);
-    myOptimizer->FitConePropertiesFoM(coneAngle,conefom);
+    myFoMCalculator->TimePropertiesLnL(meantime,timefom);
+    myFoMCalculator->ConePropertiesFoM(ConeAngle,conefom);
     fom = timefom*0.5+conefom*0.5;
     //fom = timefom;
     cout<<"timeFOM, coneFOM, fom = "<<timefom<<", "<<conefom<<", "<<fom<<endl;
@@ -181,14 +180,14 @@ bool LikelihoodFitterCheck::Execute(){
         	seedDirY = trueDirY;
         	seedDirZ = trueDirZ;
         	myvtxgeo->CalcExtendedResiduals(seedX, seedY, seedZ, seedT, seedDirX, seedDirY, seedDirZ);
-        	int nhits = myOptimizer->fVtxGeo->GetNDigits();
-          double meantime = myOptimizer->FindSimpleTimeProperties(myvtxgeo);
+        	int nhits = myvtxgeo->GetNDigits();
+          double meantime = myFoMCalculator->FindSimpleTimeProperties(ConeAngle);
           Double_t fom = -999.999*100;
           double timefom = -999.999*100;
           double conefom = -999.999*100;
           double coneAngle = 42.0;
-          myOptimizer->TimePropertiesLnL(meantime,0.2,timefom);
-          myOptimizer->FitConePropertiesFoM(coneAngle,conefom);
+          myFoMCalculator->TimePropertiesLnL(meantime,timefom);
+          myFoMCalculator->ConePropertiesFoM(coneAngle,conefom);
           fom = timefom*0.5+conefom*0.5;
           //fom = timefom;
           cout<<"k,m, timeFOM, coneFOM, fom = "<<k<<", "<<m<<", "<<timefom<<", "<<conefom<<", "<<fom<<endl;
@@ -196,7 +195,7 @@ bool LikelihoodFitterCheck::Execute(){
         }
       }
     }
-
+  delete myFoMCalculator;
   return true;
 }
 

--- a/UserTools/LikelihoodFitterCheck/LikelihoodFitterCheck.h
+++ b/UserTools/LikelihoodFitterCheck/LikelihoodFitterCheck.h
@@ -8,6 +8,10 @@
 #include "TH1.h"
 #include "TH2D.h"
 
+#include "FoMCalculator.h"
+#include "VertexGeometry.h"
+#include "Parameters.h"
+
 class LikelihoodFitterCheck: public Tool {
 
 

--- a/UserTools/VertexGeometryCheck/VertexGeometryCheck.cpp
+++ b/UserTools/VertexGeometryCheck/VertexGeometryCheck.cpp
@@ -106,18 +106,19 @@ bool VertexGeometryCheck::Execute(){
   trueDirX = vtxDir.X();
   trueDirY = vtxDir.Y();
   trueDirZ = vtxDir.Z();
-	
-	MinuitOptimizer * myOptimizer = new MinuitOptimizer();
-	VertexGeometry* myvtxgeo = VertexGeometry::Instance();
+
+  double ConeAngle = Parameters::CherenkovAngle();
+
+  FoMCalculator * myFoMCalculator = new FoMCalculator();
+  VertexGeometry* myvtxgeo = VertexGeometry::Instance();
   myvtxgeo->LoadDigits(fDigitList);
-	int nhits = myvtxgeo->GetNDigits();
-  myOptimizer->LoadVertexGeometry(myvtxgeo); //Load vertex geometry
+  myFoMCalculator->LoadVertexGeometry(myvtxgeo); //Load vertex geometry
+  int nhits = myvtxgeo->GetNDigits();
   myvtxgeo->CalcExtendedResiduals(trueVtxX, trueVtxY, trueVtxZ, trueVtxT, trueDirX, trueDirY, trueDirZ);
-  myOptimizer->SetMeanTimeCalculatorType(0); //
-  double meantime = myOptimizer->FindSimpleTimeProperties(myvtxgeo);
+  double meantime = myFoMCalculator->FindSimpleTimeProperties(ConeAngle);
   fmeanres->Fill(meantime);
   double fom = -999.999*100;
-  myOptimizer->TimePropertiesLnL(meantime,0.2,fom);  
+  myFoMCalculator->TimePropertiesLnL(meantime,fom);  
   for(int n=0;n<nhits;n++) {
     digitX = fDigitList->at(n).GetPosition().X();
     digitY = fDigitList->at(n).GetPosition().Y();
@@ -167,6 +168,7 @@ bool VertexGeometryCheck::Execute(){
     if(myvtxgeo->GetDigitType(n)==RecoDigit::lappd_v0) flappdtimesmear->Fill(Parameters::TimeResolution(RecoDigit::lappd_v0, myvtxgeo->GetDigitQ(n)));
     if(myvtxgeo->GetDigitType(n)==RecoDigit::PMT8inch) fpmttimesmear->Fill(Parameters::TimeResolution(RecoDigit::PMT8inch, myvtxgeo->GetDigitQ(n)));
   }
+  delete myFoMCalculator;
   return true;
 }
 

--- a/UserTools/VertexGeometryCheck/VertexGeometryCheck.h
+++ b/UserTools/VertexGeometryCheck/VertexGeometryCheck.h
@@ -4,6 +4,9 @@
 #include <string>
 #include <iostream>
 
+#include "FoMCalculator.h"
+#include "VertexGeometry.h"
+#include "Parameters.h"
 #include "Tool.h"
 
 class VertexGeometryCheck: public Tool {

--- a/UserTools/VtxExtendedVertexFinder/VtxExtendedVertexFinder.cpp
+++ b/UserTools/VtxExtendedVertexFinder/VtxExtendedVertexFinder.cpp
@@ -153,7 +153,7 @@ RecoVertex* VtxExtendedVertexFinder::FitExtendedVertex(RecoVertex* myVertex) {
 }
 
 RecoVertex* VtxExtendedVertexFinder::FitGridSeeds(std::vector<RecoVertex>* vSeedVtxList) {
-  double vtxFOM = 0.0;
+  double vtxFOM = -9999.;
   double bestFOM = -1.0;
   int vtxRecoStatus = -1;
   unsigned int nlast = vSeedVtxList->size();


### PR DESCRIPTION
This commit separates the negative log-likelihood and figure-of-merit calculations from the MinuitOptimizer completely.  This is a needed modification to the DataModel to make the likelihood functions used for fitting available to other optimizers.

All likelihood, figure-of-merit, and simple property calculations are now handled by the FoMCalculator class.  An instance of FoMCalculator is used in the MinuitOptimizer.

Some additional changes made:
  - The more complex cone fitter (which has not been used up to this point) is now explicitly commented out.  Everything has been left in case someone eventually wants to try and get them working.
  - RecoVertex classes are now initialized with an FOM of -9999. to discern a failed/nonexceucted fit from a (very) poor fit.
  - LikelihoodFitterCheck and VertexGeometryCheck now use the FoMCalculators to map the figure-of-merit space around the muon track. 

The MinuitOptimizer class in it's current form has been tested and found to produce the same reconstruction performance as before the restructuring was executed.