### PR TITLE
Fixed a bug in reco tools causing a warning in the ToolAnalysis build

### DIFF
--- a/UserTools/VtxSeedGenerator/VtxSeedGenerator.cpp
+++ b/UserTools/VtxSeedGenerator/VtxSeedGenerator.cpp
@@ -186,6 +186,7 @@ bool VtxSeedGenerator::GenerateSeedGrid(int NSeeds) {
       vSeedVtxList->push_back(thisgridseed);
     }
   }
+  return true;
 }
 
 double VtxSeedGenerator::GetMedianSeedTime(Position pos){


### PR DESCRIPTION
Missing  a "return true" at the end of a bool function.