### PR TITLE
Minor Geometry updates

### DIFF
--- a/DataModel/Hit.h
+++ b/DataModel/Hit.h
@@ -31,7 +31,6 @@ class Hit : public SerialisableObject{
 	}
 	
 	protected:
-	// XXX ~~~~~~ adding members? Don't forget to update the operators of derived classes! ~~~~~~ XXX
 	int TubeId;
 	double Time;
 	double Charge;
@@ -47,7 +46,11 @@ class Hit : public SerialisableObject{
 
 //  Derived classes
 
-class MCHit : virtual public Hit {
+class MCHit : public Hit {
+	// XXX ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ XXX
+	// XXX ~~~~~~~~~~~~~~~~~~~~~~~~ UPDATING THIS CLASS? ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ XXX
+	// XXX ~~~~~ Everything added in this class must be duplicated in MCLAPPDHit!~~~~ XXX
+	// XXX ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ XXX
 	
 	friend class boost::serialization::access;
 	
@@ -58,48 +61,6 @@ class MCHit : virtual public Hit {
 	
 	const std::vector<int>* GetParents() const { return &Parents; }
 	void SetParents(std::vector<int> parentsin){ Parents = parentsin; }
-	
-	// compiler warns about default implementation of move assignment operator for
-	// classes inheriting from a virtual base class. We need to specify them manually.
-	MCHit(const MCHit& rhs) : Hit(rhs){  // Copy Ctor
-		Parents = rhs.Parents;
-	};
-	MCHit& operator=(const MCHit& rhs){  // Copy Assignment
-		Hit::operator=(rhs);
-		Parents = rhs.Parents;
-		return *this;
-	};
-	MCHit(MCHit&& rhs) /*: Hit(rhs)*/ {      // Move Ctor
-		// calling base Hit methods seems to invoke a copy construction to convert MCHit to Hit...
-		TubeId  = std::move(rhs.TubeId);
-		Time    = std::move(rhs.Time);
-		Charge  = std::move(rhs.Charge);
-		Parents = std::move(rhs.Parents);
-		// no other initialization needed
-	};
-	MCHit& operator=(MCHit&& rhs){       // Move Assignment
-		// no initial cleanup of 'this' needed
-		//Hit::operator=(rhs);
-		TubeId  = std::move(rhs.TubeId);
-		Time    = std::move(rhs.Time);
-		Charge  = std::move(rhs.Charge);
-		Parents = std::move(rhs.Parents);
-		return *this;
-	};
-	
-	// see MCLAPPDHit for the usage of this method
-	MCHit& PartialAssign(const MCHit& rhs){
-		// Initialize only the non-inherited members of this class
-		Parents = rhs.Parents;
-		return *this;
-	}
-	
-	// see MCLAPPDHit for the usage of this method
-	MCHit& PartialAssign(MCHit&& rhs){
-		// Initialize only the non-inherited members of this class
-		Parents = std::move(rhs.Parents);
-		return *this;
-	}
 	
 	bool Print(){
 		cout<<"TubeId : "<<TubeId<<endl;
@@ -119,7 +80,6 @@ class MCHit : virtual public Hit {
 	}
 	
 	protected:
-	// XXX ~~~~~~ adding members? Don't forget to update PartialAssign methods! ~~~~~~~ XXX
 	std::vector<int> Parents;
 	
 	template<class Archive> void serialize(Archive & ar, const unsigned int version){
@@ -146,10 +106,3 @@ class RecoHit : public Hit {
 */
 
 #endif
-
-//    person(const std::string& name, int age);        // Ctor
-//    person(const person &) = default;                // Copy Ctor
-//    person(person &&) noexcept = default;            // Move Ctor
-//    person& operator=(const person &) = default;     // Copy Assignment
-//    person& operator=(person &&) noexcept = default; // Move Assignment
-//    ~person() noexcept = default;                    // Dtor

--- a/DataModel/Hit.h
+++ b/DataModel/Hit.h
@@ -13,6 +13,7 @@ class Hit : public SerialisableObject{
 	public:
 	Hit() : TubeId(0), Time(0), Charge(0){serialise=true;}
 	Hit(int thetubeid, double thetime, double thecharge) : TubeId(thetubeid), Time(thetime), Charge(thecharge){serialise=true;}
+	virtual ~Hit(){};
 	
 	inline int GetTubeId() const {return TubeId;}
 	inline double GetTime() const {return Time;}
@@ -30,6 +31,7 @@ class Hit : public SerialisableObject{
 	}
 	
 	protected:
+	// XXX ~~~~~~ adding members? Don't forget to update the operators of derived classes! ~~~~~~ XXX
 	int TubeId;
 	double Time;
 	double Charge;
@@ -52,9 +54,52 @@ class MCHit : virtual public Hit {
 	public:
 	MCHit() : Hit(), Parents(std::vector<int>{}) {serialise=true;}
 	MCHit(int tubeid, double thetime, double thecharge, std::vector<int> theparents) : Hit(tubeid, thetime, thecharge), Parents(theparents) {serialise=true;}
+	virtual ~MCHit(){};
 	
 	const std::vector<int>* GetParents() const { return &Parents; }
 	void SetParents(std::vector<int> parentsin){ Parents = parentsin; }
+	
+	// compiler warns about default implementation of move assignment operator for
+	// classes inheriting from a virtual base class. We need to specify them manually.
+	MCHit(const MCHit& rhs) : Hit(rhs){  // Copy Ctor
+		Parents = rhs.Parents;
+	};
+	MCHit& operator=(const MCHit& rhs){  // Copy Assignment
+		Hit::operator=(rhs);
+		Parents = rhs.Parents;
+		return *this;
+	};
+	MCHit(MCHit&& rhs) /*: Hit(rhs)*/ {      // Move Ctor
+		// calling base Hit methods seems to invoke a copy construction to convert MCHit to Hit...
+		TubeId  = std::move(rhs.TubeId);
+		Time    = std::move(rhs.Time);
+		Charge  = std::move(rhs.Charge);
+		Parents = std::move(rhs.Parents);
+		// no other initialization needed
+	};
+	MCHit& operator=(MCHit&& rhs){       // Move Assignment
+		// no initial cleanup of 'this' needed
+		//Hit::operator=(rhs);
+		TubeId  = std::move(rhs.TubeId);
+		Time    = std::move(rhs.Time);
+		Charge  = std::move(rhs.Charge);
+		Parents = std::move(rhs.Parents);
+		return *this;
+	};
+	
+	// see MCLAPPDHit for the usage of this method
+	MCHit& PartialAssign(const MCHit& rhs){
+		// Initialize only the non-inherited members of this class
+		Parents = rhs.Parents;
+		return *this;
+	}
+	
+	// see MCLAPPDHit for the usage of this method
+	MCHit& PartialAssign(MCHit&& rhs){
+		// Initialize only the non-inherited members of this class
+		Parents = std::move(rhs.Parents);
+		return *this;
+	}
 	
 	bool Print(){
 		cout<<"TubeId : "<<TubeId<<endl;
@@ -74,6 +119,7 @@ class MCHit : virtual public Hit {
 	}
 	
 	protected:
+	// XXX ~~~~~~ adding members? Don't forget to update PartialAssign methods! ~~~~~~~ XXX
 	std::vector<int> Parents;
 	
 	template<class Archive> void serialize(Archive & ar, const unsigned int version){
@@ -100,3 +146,10 @@ class RecoHit : public Hit {
 */
 
 #endif
+
+//    person(const std::string& name, int age);        // Ctor
+//    person(const person &) = default;                // Copy Ctor
+//    person(person &&) noexcept = default;            // Move Ctor
+//    person& operator=(const person &) = default;     // Copy Assignment
+//    person& operator=(person &&) noexcept = default; // Move Assignment
+//    ~person() noexcept = default;                    // Dtor

--- a/DataModel/LAPPDHit.h
+++ b/DataModel/LAPPDHit.h
@@ -15,11 +15,60 @@ class LAPPDHit : virtual public Hit{
 	public:
 	LAPPDHit() : Hit(), Position(0), LocalPosition(0) {serialise=true;}
 	LAPPDHit(int thetubeid, double thetime, double thecharge, std::vector<double> theposition, std::vector<double> thelocalposition) : Hit(thetubeid,thetime,thecharge), Position(theposition), LocalPosition(thelocalposition) {serialise=true;}
+	virtual ~LAPPDHit(){};
 	
 	inline std::vector<double> GetPosition() const {return Position;}
 	inline std::vector<double> GetLocalPosition() const {return LocalPosition;}
 	inline void SetPosition(std::vector<double> pos){Position=pos;}
 	inline void SetLocalPosition(std::vector<double> locpos){LocalPosition=locpos;}
+	
+	// compiler warns about default implementation of move assignment operator for
+	// classes inheriting from a virtual base class. We need to specify them manually.
+	LAPPDHit(const LAPPDHit& rhs) : Hit(rhs){  // Copy Ctor
+		Position = rhs.Position;
+		LocalPosition = rhs.LocalPosition;
+	};
+	LAPPDHit& operator=(const LAPPDHit& rhs){  // Copy Assignment
+		Hit::operator=(rhs);
+		Position = rhs.Position;
+		LocalPosition = rhs.LocalPosition;
+		return *this;
+	};
+	LAPPDHit(LAPPDHit&& rhs) /*: Hit(rhs)*/ {      // Move Ctor
+		// calling base Hit methods seems to invoke a copy construction to convert MCHit to Hit...
+		TubeId  = std::move(rhs.TubeId);
+		Time    = std::move(rhs.Time);
+		Charge  = std::move(rhs.Charge);
+		Position = std::move(rhs.Position);
+		LocalPosition = std::move(rhs.LocalPosition);
+		// no other initialization needed
+	};
+	LAPPDHit& operator=(LAPPDHit&& rhs){       // Move Assignment
+		// no initial cleanup of 'this' needed
+		//Hit::operator=(rhs);
+		TubeId  = std::move(rhs.TubeId);
+		Time    = std::move(rhs.Time);
+		Charge  = std::move(rhs.Charge);
+		Position = std::move(rhs.Position);
+		LocalPosition = std::move(rhs.LocalPosition);
+		return *this;
+	};
+	
+	// see MCLAPPDHit for the usage of this method
+	LAPPDHit& PartialAssign(const LAPPDHit& rhs){
+		// Initialize only the non-inherited members of this class
+		Position = rhs.Position;
+		LocalPosition = rhs.LocalPosition;
+		return *this;
+	}
+	
+	// see MCLAPPDHit for the usage of this method
+	LAPPDHit& PartialAssign(LAPPDHit&& rhs){
+		// Initialize only the non-inherited members of this class
+		Position = std::move(rhs.Position);
+		LocalPosition = std::move(rhs.LocalPosition);
+		return *this;
+	}
 	
 	bool Print() {
 		cout<<"TubeId : "<<TubeId<<endl;
@@ -34,6 +83,7 @@ class LAPPDHit : virtual public Hit{
 	}
 	
 	protected:
+	// XXX ~~~~~~ adding members? Don't forget to update PartialAssign methods! ~~~~~~~ XXX
 	std::vector<double> Position;
 	std::vector<double> LocalPosition;
 	
@@ -55,15 +105,78 @@ class MCLAPPDHit : public MCHit, public LAPPDHit{
 	friend class boost::serialization::access;
 	
 	public:
-	MCLAPPDHit() : LAPPDHit(), MCHit() {serialise=true;}
-	MCLAPPDHit(int thetubeid, double thetime, double thecharge, std::vector<double> theposition, std::vector<double> thelocalposition, std::vector<int> theparents){
-		TubeId = thetubeid;
-		Time=thetime;
-		Charge=thecharge;
-		Position=theposition;
-		LocalPosition=thelocalposition;
-		Parents=theparents;
-		serialise=true;
+	MCLAPPDHit() : Hit(), LAPPDHit(), MCHit() {serialise=true;}
+	MCLAPPDHit(int thetubeid, double thetime, double thecharge, std::vector<double> theposition, std::vector<double> thelocalposition, std::vector<int> theparents) : Hit(thetubeid, thetime, thecharge), LAPPDHit(0,0,0,theposition,thelocalposition), MCHit(0,0,0,theparents){
+//		TubeId = thetubeid;
+//		Time=thetime;
+//		Charge=thecharge;
+//		Position=theposition;
+//		LocalPosition=thelocalposition;
+//		Parents=theparents;
+//		serialise=true;
+	}
+	
+	// because this class inherits the base Hit class through two paths, we need to use virtual inheritance
+	// so that there is only one version of the base Hit class members. That's why MCHit and LAPPDHit inherit
+	// from Hit as 'virtual public Hit'.
+	// When performing construction and assignment of MCLAPPDHit, which inherited class
+	// (MCHit or LAPPDHit) should handle initialization/copying/moving of the Hit members?
+	// Niether - it must be handled by the most derived class (MCLAPPDHit).
+	// We then operate on the base Hit directly ourselves, and use the PartialAssign members of
+	// MCHit and MCLAPPDHit to handle the additional members they provide.
+	
+	// move assignment operator
+	// we could probably use the default here too, as no memory management occurs... but let's be "safe".
+	MCLAPPDHit& operator=(MCLAPPDHit&& rhs){
+		// safety check for 'x = x;'
+		if (this==&rhs) return *this;
+		
+//		// use LAPPDHit::operator= to move over the base Hit and LAPPDHit parameters
+//		//static_cast<LAPPDHit&>(*this) = static_cast<LAPPDHit&&>(rhs);
+//		LAPPDHit::operator=(std::move(rhs));  // or this way
+//		
+//		// then we need to handle the MCHit members manually. :(
+//		std::swap(Parents, rhs.Parents);  // no membery cleanup of 'this' needed first
+		
+		Hit::operator=(std::move(rhs));
+		MCHit::PartialAssign(std::move(rhs));
+		LAPPDHit::PartialAssign(std::move(rhs));
+		
+		return *this;
+	}
+	
+	// copy assignment operator
+	// we could use the default in our case, since we have no memory management issues
+	//MCLAPPDHit& operator=(const MCLAPPDHit &) = default;
+	// but it would be inefficient as it would copy the Hit members twice... probably.
+	MCLAPPDHit& operator=(MCLAPPDHit rhs){
+		// safety check for 'x = x;'
+		if (this==&rhs) return *this;
+		
+//		// use LAPPDHit::operator= to copy over the base Hit and LAPPDHit parameters
+//		static_cast<LAPPDHit&>(*this) = static_cast<LAPPDHit&>(rhs);
+//		// then copy over MCHit members manually
+//		Parents = rhs.Parents;
+		
+		Hit::operator=(rhs);
+		MCHit::PartialAssign(rhs);
+		LAPPDHit::PartialAssign(rhs);
+		
+		return *this;
+	}
+	
+	// copy constructor
+	//MCLAPPDHit(const MCLAPPDHit&) = default;
+	MCLAPPDHit(const MCLAPPDHit& rhs) : Hit(rhs), MCHit(rhs), LAPPDHit(rhs){};
+	
+	// move constructor
+	//MCLAPPDHit(MCLAPPDHit&&) noexcept = default;
+//	MCLAPPDHit(MCLAPPDHit&& rhs) : MCLAPPDHit(){
+//		*this = rhs;  // is this sufficient: intialize and assign... 
+//	}
+	MCLAPPDHit(MCLAPPDHit&& rhs) : Hit(std::move(rhs)){
+		MCHit::PartialAssign(std::move(rhs));
+		LAPPDHit::PartialAssign(std::move(rhs));
 	}
 	
 	bool Print() {

--- a/DataModel/LAPPDHit.h
+++ b/DataModel/LAPPDHit.h
@@ -8,7 +8,7 @@
 using std::cout;
 using std::endl;
 
-class LAPPDHit : virtual public Hit{
+class LAPPDHit : public Hit{
 	
 	friend class boost::serialization::access;
 	
@@ -21,54 +21,6 @@ class LAPPDHit : virtual public Hit{
 	inline std::vector<double> GetLocalPosition() const {return LocalPosition;}
 	inline void SetPosition(std::vector<double> pos){Position=pos;}
 	inline void SetLocalPosition(std::vector<double> locpos){LocalPosition=locpos;}
-	
-	// compiler warns about default implementation of move assignment operator for
-	// classes inheriting from a virtual base class. We need to specify them manually.
-	LAPPDHit(const LAPPDHit& rhs) : Hit(rhs){  // Copy Ctor
-		Position = rhs.Position;
-		LocalPosition = rhs.LocalPosition;
-	};
-	LAPPDHit& operator=(const LAPPDHit& rhs){  // Copy Assignment
-		Hit::operator=(rhs);
-		Position = rhs.Position;
-		LocalPosition = rhs.LocalPosition;
-		return *this;
-	};
-	LAPPDHit(LAPPDHit&& rhs) /*: Hit(rhs)*/ {      // Move Ctor
-		// calling base Hit methods seems to invoke a copy construction to convert MCHit to Hit...
-		TubeId  = std::move(rhs.TubeId);
-		Time    = std::move(rhs.Time);
-		Charge  = std::move(rhs.Charge);
-		Position = std::move(rhs.Position);
-		LocalPosition = std::move(rhs.LocalPosition);
-		// no other initialization needed
-	};
-	LAPPDHit& operator=(LAPPDHit&& rhs){       // Move Assignment
-		// no initial cleanup of 'this' needed
-		//Hit::operator=(rhs);
-		TubeId  = std::move(rhs.TubeId);
-		Time    = std::move(rhs.Time);
-		Charge  = std::move(rhs.Charge);
-		Position = std::move(rhs.Position);
-		LocalPosition = std::move(rhs.LocalPosition);
-		return *this;
-	};
-	
-	// see MCLAPPDHit for the usage of this method
-	LAPPDHit& PartialAssign(const LAPPDHit& rhs){
-		// Initialize only the non-inherited members of this class
-		Position = rhs.Position;
-		LocalPosition = rhs.LocalPosition;
-		return *this;
-	}
-	
-	// see MCLAPPDHit for the usage of this method
-	LAPPDHit& PartialAssign(LAPPDHit&& rhs){
-		// Initialize only the non-inherited members of this class
-		Position = std::move(rhs.Position);
-		LocalPosition = std::move(rhs.LocalPosition);
-		return *this;
-	}
 	
 	bool Print() {
 		cout<<"TubeId : "<<TubeId<<endl;
@@ -83,7 +35,6 @@ class LAPPDHit : virtual public Hit{
 	}
 	
 	protected:
-	// XXX ~~~~~~ adding members? Don't forget to update PartialAssign methods! ~~~~~~~ XXX
 	std::vector<double> Position;
 	std::vector<double> LocalPosition;
 	
@@ -98,86 +49,17 @@ class LAPPDHit : virtual public Hit{
 	}
 };
 
-//  Derived classes, if there's a reason to have them
-
-class MCLAPPDHit : public MCHit, public LAPPDHit{
+//  Derived classes
+class MCLAPPDHit : public LAPPDHit{
 	
 	friend class boost::serialization::access;
 	
 	public:
-	MCLAPPDHit() : Hit(), LAPPDHit(), MCHit() {serialise=true;}
-	MCLAPPDHit(int thetubeid, double thetime, double thecharge, std::vector<double> theposition, std::vector<double> thelocalposition, std::vector<int> theparents) : Hit(thetubeid, thetime, thecharge), LAPPDHit(0,0,0,theposition,thelocalposition), MCHit(0,0,0,theparents){
-//		TubeId = thetubeid;
-//		Time=thetime;
-//		Charge=thecharge;
-//		Position=theposition;
-//		LocalPosition=thelocalposition;
-//		Parents=theparents;
-//		serialise=true;
-	}
+	MCLAPPDHit() : LAPPDHit(), Parents(std::vector<int>{}) {serialise=true;}
+	MCLAPPDHit(int thetubeid, double thetime, double thecharge, std::vector<double> theposition, std::vector<double> thelocalposition, std::vector<int> theparents) : LAPPDHit(thetubeid, thetime, thecharge,theposition,thelocalposition), Parents(theparents) {serialise=true;}
 	
-	// because this class inherits the base Hit class through two paths, we need to use virtual inheritance
-	// so that there is only one version of the base Hit class members. That's why MCHit and LAPPDHit inherit
-	// from Hit as 'virtual public Hit'.
-	// When performing construction and assignment of MCLAPPDHit, which inherited class
-	// (MCHit or LAPPDHit) should handle initialization/copying/moving of the Hit members?
-	// Niether - it must be handled by the most derived class (MCLAPPDHit).
-	// We then operate on the base Hit directly ourselves, and use the PartialAssign members of
-	// MCHit and MCLAPPDHit to handle the additional members they provide.
-	
-	// move assignment operator
-	// we could probably use the default here too, as no memory management occurs... but let's be "safe".
-	MCLAPPDHit& operator=(MCLAPPDHit&& rhs){
-		// safety check for 'x = x;'
-		if (this==&rhs) return *this;
-		
-//		// use LAPPDHit::operator= to move over the base Hit and LAPPDHit parameters
-//		//static_cast<LAPPDHit&>(*this) = static_cast<LAPPDHit&&>(rhs);
-//		LAPPDHit::operator=(std::move(rhs));  // or this way
-//		
-//		// then we need to handle the MCHit members manually. :(
-//		std::swap(Parents, rhs.Parents);  // no membery cleanup of 'this' needed first
-		
-		Hit::operator=(std::move(rhs));
-		MCHit::PartialAssign(std::move(rhs));
-		LAPPDHit::PartialAssign(std::move(rhs));
-		
-		return *this;
-	}
-	
-	// copy assignment operator
-	// we could use the default in our case, since we have no memory management issues
-	//MCLAPPDHit& operator=(const MCLAPPDHit &) = default;
-	// but it would be inefficient as it would copy the Hit members twice... probably.
-	MCLAPPDHit& operator=(MCLAPPDHit rhs){
-		// safety check for 'x = x;'
-		if (this==&rhs) return *this;
-		
-//		// use LAPPDHit::operator= to copy over the base Hit and LAPPDHit parameters
-//		static_cast<LAPPDHit&>(*this) = static_cast<LAPPDHit&>(rhs);
-//		// then copy over MCHit members manually
-//		Parents = rhs.Parents;
-		
-		Hit::operator=(rhs);
-		MCHit::PartialAssign(rhs);
-		LAPPDHit::PartialAssign(rhs);
-		
-		return *this;
-	}
-	
-	// copy constructor
-	//MCLAPPDHit(const MCLAPPDHit&) = default;
-	MCLAPPDHit(const MCLAPPDHit& rhs) : Hit(rhs), MCHit(rhs), LAPPDHit(rhs){};
-	
-	// move constructor
-	//MCLAPPDHit(MCLAPPDHit&&) noexcept = default;
-//	MCLAPPDHit(MCLAPPDHit&& rhs) : MCLAPPDHit(){
-//		*this = rhs;  // is this sufficient: intialize and assign... 
-//	}
-	MCLAPPDHit(MCLAPPDHit&& rhs) : Hit(std::move(rhs)){
-		MCHit::PartialAssign(std::move(rhs));
-		LAPPDHit::PartialAssign(std::move(rhs));
-	}
+	const std::vector<int>* GetParents() const { return &Parents; }
+	void SetParents(std::vector<int> parentsin){ Parents = parentsin; }
 	
 	bool Print() {
 		cout<<"TubeId : "<<TubeId<<endl;
@@ -212,6 +94,9 @@ class MCLAPPDHit : public MCHit, public LAPPDHit{
 			// - it only adds parent MCParticle indices, and these aren't saved... 
 		}
 	}
+	
+	protected:
+	std::vector<int> Parents;
 };
 
 /*


### PR DESCRIPTION
Reimplement old functions (GetNumTankPMTs) for the "new" channelkey system. This got neglected previously. 
Change the way MCLAPPDHit class is defined to avoid multiple inheritance and virtual base classes. Although it means all (relevant) members and methods of MCHit must be duplicated in MCLAPPDHit, and the resulting MCLAPPDHit is not an MCHit, it seems this is nonetheless simpler and more robust than the alternative. 