### PR TITLE
Merge MCParticles from all MC triggers,

### DIFF
--- a/UserTools/LoadWCSim/LoadWCSim.h
+++ b/UserTools/LoadWCSim/LoadWCSim.h
@@ -97,7 +97,7 @@ class LoadWCSim: public Tool {
 	// alternatively? Better? Save the parentage in each MCHit. Each MCHit will contain
 	// the index of it's parent MCParticle in the MCParticles vector
 	std::map<int,int>* trackid_to_mcparticleindex=nullptr;
-	std::vector<int> GetHitParentId(WCSimRootCherenkovDigiHit* digihit, WCSimRootTrigger* firstTrig);
+	std::vector<int> GetHitParentIds(WCSimRootCherenkovDigiHit* digihit, WCSimRootTrigger* firstTrig);
 	std::map<int,int> timeArrayOffsetMap;
 	void BuildTimeArrayOffsetMap(WCSimRootTrigger* firstTrig);
 	


### PR DESCRIPTION
WCSim by default splits up the particles it saves according to the trigger they started in. Similarly they were loaded as such into ToolAnalysis (LoadWCSim processes one trigger per execution).
This means that the primary muon for a prompt event wouldn't be available for delayed events, which may not be desired.
This change now loads *all* MCParticles for the event on loading the first MC trigger, and does not clear those particles until the next set is to be loaded.

One noteworthy point about this is: particle times are relative to the trigger (as they have been up to now). The MCParticle times are therefore updated on each loop to account for the new Trigger time.
This means delayed triggers may now start to see MCParticles with significantly negative times - those are particles from the Prompt event that happened some time before the trigger for this Delayed event.
