### PR TITLE
Stop the ToolChain I wanna get off

### DIFF
--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -543,23 +543,27 @@ bool LoadWCSim::Execute(){
 	EventNumber++;
 	MCTriggernum++;
 	if(verbosity>2) cout<<"checking if we're done on trigs in this event"<<endl;
+	bool newentry=false;
 	if(MCTriggernum==WCSimEntry->wcsimrootevent->GetNumberOfEvents()){
 		MCTriggernum=0;
 		MCEventNum++;
+		newentry=true;
 		if(verbosity>2) cout<<"this is the last trigger in the event: next loop will process a new event"<<endl;
 	} else {
 		if(verbosity>2) cout<<"there are further triggers in this event: next loop will process the trigger "<<MCTriggernum<<"/"<<WCSimEntry->wcsimrootevent->GetNumberOfEvents()<<endl;
 	}
 	
 	// Pre-load next entry so we can stop the loop if it this was the last one in the chain
-	if(MCEventNum>=MaxEntries && MaxEntries>0){
-		cout<<"LoadWCSim Tool: Reached max entries specified in config file, terminating ToolChain"<<endl;
-		m_data->vars.Set("StopLoop",1);
-	} else {
-		int nbytesread = WCSimEntry->GetEntry(MCEventNum);  // <0 if out of file
-		if(nbytesread<=0){
-			Log("LoadWCSim Tool: Reached last entry of WCSim input file, terminating ToolChain",v_warning,verbosity);
+	if(newentry){  // if next loop is processing the next trigger in the same entry, no need to re-load it
+		if(MCEventNum>=MaxEntries && MaxEntries>0){
+			cout<<"LoadWCSim Tool: Reached max entries specified in config file, terminating ToolChain"<<endl;
 			m_data->vars.Set("StopLoop",1);
+		} else {
+			int nbytesread = WCSimEntry->GetEntry(MCEventNum);  // <0 if out of file
+			if(nbytesread<=0){
+				Log("LoadWCSim Tool: Reached last entry of WCSim input file, terminating ToolChain",v_warning,verbosity);
+				m_data->vars.Set("StopLoop",1);
+			}
 		}
 	}
 	return true;

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -194,6 +194,18 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	ParticleId_to_VetoCharge = new std::map<int,double>;
 	trackid_to_mcparticleindex = new std::map<int,int>;
 	
+	// Pre-load first entry
+	int nbytesread = WCSimEntry->GetEntry(MCEventNum);  // <0 if out of file
+	if(nbytesread<=0){
+		logmessage = "LoadWCSim Tool had no entry "+to_string(MCEventNum);
+		if(nbytesread==-4){
+			logmessage+=": Overran end of TChain! Have you specified more iterations than are available in ToolChainConfig?";
+		} else if(nbytesread==0){
+			logmessage+=": No TChain loaded! Is your filepath correct?";
+		}
+		Log(logmessage,v_error,verbosity);
+	}
+	
 	return true;
 }
 
@@ -204,18 +216,6 @@ bool LoadWCSim::Execute(){
 	//m_data->Stores.at("ANNIEEvent")->Clear();
 	
 	if(verbosity) cout<<"Executing tool LoadWCSim with MC entry "<<MCEventNum<<", trigger "<<MCTriggernum<<endl;
-	int nbytesread = WCSimEntry->GetEntry(MCEventNum);  // <0 if out of file
-	if(nbytesread<=0){
-		cerr<<"############################"<<endl;
-		logmessage = "LoadWCSim Tool had no entry "+to_string(MCEventNum);
-		if(nbytesread==-4){
-			logmessage+=": Overran end of TChain! Have you specified more iterations than are available in ToolChainConfig?";
-		} else if(nbytesread==0){
-			logmessage+=": No TChain loaded! Is your filepath correct?";
-		}
-		Log(logmessage,v_error,verbosity);
-		cerr<<"############################"<<endl;
-	}
 	MCFile = WCSimEntry->GetCurrentFile()->GetName();
 	
 	MCParticles->clear();
@@ -538,6 +538,7 @@ bool LoadWCSim::Execute(){
 	//RawLAPPDData
 	//CalibratedLAPPDData
 	//RecoParticles
+	if(verbosity>1) cout<<"done loading event"<<endl;
 	
 	EventNumber++;
 	MCTriggernum++;
@@ -549,13 +550,18 @@ bool LoadWCSim::Execute(){
 	} else {
 		if(verbosity>2) cout<<"there are further triggers in this event: next loop will process the trigger "<<MCTriggernum<<"/"<<WCSimEntry->wcsimrootevent->GetNumberOfEvents()<<endl;
 	}
-	if(false && MCEventNum>=NumEvents){
-		cout<<"LoadWCSim Tool: Reached last entry of WCSim input file, terminating ToolChain"<<endl;
-		m_data->vars.Set("StopLoop",1);
-	} else if(MCEventNum>=MaxEntries && MaxEntries>0){
+	
+	// Pre-load next entry so we can stop the loop if it this was the last one in the chain
+	if(MCEventNum>=MaxEntries && MaxEntries>0){
 		cout<<"LoadWCSim Tool: Reached max entries specified in config file, terminating ToolChain"<<endl;
+		m_data->vars.Set("StopLoop",1);
+	} else {
+		int nbytesread = WCSimEntry->GetEntry(MCEventNum);  // <0 if out of file
+		if(nbytesread<=0){
+			Log("LoadWCSim Tool: Reached last entry of WCSim input file, terminating ToolChain",v_warning,verbosity);
+			m_data->vars.Set("StopLoop",1);
+		}
 	}
-	if(verbosity>1) cout<<"done loading event"<<endl;
 	return true;
 }
 

--- a/UserTools/LoadWCSimLAPPD/LAPPDTree.h
+++ b/UserTools/LoadWCSimLAPPD/LAPPDTree.h
@@ -102,7 +102,7 @@ public :
    TBranch        *b_lappdhit_neighstrip_righttime;   //!
 
    LAPPDTree(TTree *tree=0);
-   LAPPDTree(const char* filepath, bool addsubdirs);
+   LAPPDTree(const char* filepath, bool addsubdirs=false);
    virtual ~LAPPDTree();
    virtual Int_t    Cut(Long64_t entry);
    virtual Int_t    GetEntry(Long64_t entry);
@@ -302,7 +302,7 @@ Int_t LAPPDTree::Cut(Long64_t entry)
    return 1;
 }
 
-TChain* LAPPDTree::AddFiles(const char* inputdir, bool addsubfolders=false){
+TChain* LAPPDTree::AddFiles(const char* inputdir, bool addsubfolders){
 	// Add files by pattern, directory. Optionally check subdirectories, but only 1 level deep. 
 	if(strcmp(inputdir,"")==0){ cerr<<"no wcsim_lappd file to load"<<endl; return nullptr; }
 	if(verbose){

--- a/UserTools/LoadWCSimLAPPD/LAPPDTree.h
+++ b/UserTools/LoadWCSimLAPPD/LAPPDTree.h
@@ -302,7 +302,7 @@ Int_t LAPPDTree::Cut(Long64_t entry)
    return 1;
 }
 
-TChain* LAPPDTree::AddFiles(const char* inputdir, bool addsubfolders){
+TChain* LAPPDTree::AddFiles(const char* inputdir, bool addsubfolders=false){
 	// Add files by pattern, directory. Optionally check subdirectories, but only 1 level deep. 
 	if(strcmp(inputdir,"")==0){ cerr<<"no wcsim_lappd file to load"<<endl; return nullptr; }
 	if(verbose){

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
@@ -61,10 +61,11 @@ bool LoadWCSimLAPPD::Initialise(std::string configfile, DataModel &data){
 	// Make class private members; e.g. the LAPPDTree
 	// ==============================================
 	if(verbose>2) cout<<"LoadWCSimLAPPD Tool: loading file "<<MCFile<<endl;
-	file= new TFile(MCFile.c_str(),"READ");
-	lappdtree= (TTree*) file->Get("LAPPDTree");
-	NumEvents=lappdtree->GetEntries();
-	LAPPDEntry= new LAPPDTree(lappdtree);
+	//file= new TFile(MCFile.c_str(),"READ");
+	//lappdtree= (TTree*) file->Get("LAPPDTree");
+	//NumEvents=lappdtree->GetEntries();
+	//LAPPDEntry= new LAPPDTree(lappdtree);
+	LAPPDEntry = new LAPPDTree(MCFile.c_str());
 	
 	// Make the ANNIEEvent Store if it doesn't exist
 	// =============================================


### PR DESCRIPTION
ROOT hangs the application when using `TChain::GetEntries()` with large TChains, but bypassing this retrieval removes the mechanism for stopping the ToolChain from once all TChain entries are exhausted. 
This commit instead implements pre-loading the next entry and using return failure as an indication of the end of TChain.