### PR TITLE
DigitBuilderROOT tool updated, and examples of usage added to configfiles/VertexReco

### DIFF
--- a/UserTools/DigitBuilderROOT/DigitBuilderROOT.h
+++ b/UserTools/DigitBuilderROOT/DigitBuilderROOT.h
@@ -27,28 +27,31 @@ class DigitBuilderROOT: public Tool {
   bool Execute();
   bool Finalise();
 
- 	void PushTrueVertex(bool savetodisk);
- 	void PushRecoDigits(bool savetodisk);
+  void PushTrueVertex(bool savetodisk);
+  void PushRecoDigits(bool savetodisk);
+  void PushTrueWaterTrackLength(double WaterT);
+  void PushTrueMRDTrackLength(double MRDT);
+  
   void Reset();
 
  private:
   
   int verbosity=1;
-	/// \brief verbosity levels: if 'verbosity' > this level, the message type will be logged.
-	int v_error=0;
-	int v_warning=1;
-	int v_message=2;
-	int v_debug=3;
-	std::string logmessage;
-
-	std::string NtupleFile;
-	TChain* P2Chain;
+  /// \brief verbosity levels: if 'verbosity' > this level, the message type will be logged.
+  int v_error=0;
+  int v_warning=1;
+  int v_message=2;
+  int v_debug=3;
+  std::string logmessage;
+  
+  std::string NtupleFile;
+  TChain* P2Chain;
   int TotalEntries;
   int EntryNum = 0;
 
-	std::vector<RecoDigit>* fDigitList;				///< Reconstructed Hits including both LAPPD hits and PMT hits
- 
-	RecoVertex* fMuonVertex = nullptr; 	 ///< true muon start vertex
+  std::vector<RecoDigit>* fDigitList;				///< Reconstructed Hits including both LAPPD hits and PMT hits
+  
+  RecoVertex* fMuonVertex = nullptr; 	 ///< true muon start vertex
 
   // Digits
   int fNhits = 0;
@@ -68,14 +71,26 @@ class DigitBuilderROOT: public Tool {
   double fTrueDirX;
   double fTrueDirY;
   double fTrueDirZ;
-  double fTrueEnergy; 
+  double fTrueMuonEnergy; 
+  double fTrueTrackLengthInWater;
+  double fTrueTrackLengthInMRD;
 
-  // Event Cut Status from previous run
+  int fPi0Count;
+  int fPiPlusCount;
+  int fPiMinusCount;
+  int fK0Count;
+  int fKPlusCount;
+  int fKMinusCount;
+
   bool fEventCutStatus;
+  int fEventStatusApplied;
+  int fEventStatusFlagged;
 
-	uint64_t fMCEventNum;
-	uint16_t fMCTriggerNum;
-	uint32_t fEventNumber; // will need to be tracked separately, since we flatten triggers
+  uint64_t fMCEventNum;
+  uint16_t fMCTriggerNum;
+  uint32_t fEventNumber; // will need to be tracked separately, since we flatten triggers
+  uint32_t fRunNumber; 
+  uint32_t fSubRunNumber; 
 };
 
 

--- a/UserTools/VtxExtendedVertexFinder/VtxExtendedVertexFinder.cpp
+++ b/UserTools/VtxExtendedVertexFinder/VtxExtendedVertexFinder.cpp
@@ -181,6 +181,12 @@ RecoVertex* VtxExtendedVertexFinder::FitGridSeeds(std::vector<RecoVertex>* vSeed
     }
     delete myOptimizer; myOptimizer = 0;
   }
+  if (verbosity>4){
+    std::cout << "Best fit vertex information: " << std::endl;
+    std::cout << "bestFOM: " << bestFOM << std::endl;
+    std::cout << "best fit reco status: " << bestGridVertex->GetStatus() << std::endl;
+    std::cout << "BestVertex info: " << bestGridVertex->Print() << std::endl;
+  }
   return bestGridVertex;
 }
 

--- a/UserTools/VtxSeedGenerator/VtxSeedGenerator.cpp
+++ b/UserTools/VtxSeedGenerator/VtxSeedGenerator.cpp
@@ -42,21 +42,22 @@ bool VtxSeedGenerator::Initialise(std::string configfile, DataModel &data){
 }
 
 bool VtxSeedGenerator::Execute(){
-	Log("===========================================================================================",v_debug,verbosity);
-	
-	Log("VtxSeedGenerator Tool: Executing",v_debug,verbosity);
-	
-	// Reset everything
-	this->Reset();
+  Log("===========================================================================================",v_debug,verbosity);
   
-	auto get_recoevent = m_data->Stores.count("RecoEvent");
-	if(!get_recoevent){
-		Log("VtxSeedGenerator Tool: RecoEvent store doesn't exist!",v_error,verbosity);
-		return false;
-	};
-	
-	
-	// check if event passes the cut
+  Log("VtxSeedGenerator Tool: Executing",v_debug,verbosity);
+  
+  // Reset everything
+  this->Reset();
+  
+  auto get_recoevent = m_data->Stores.count("RecoEvent");
+  if(!get_recoevent){
+  	Log("VtxSeedGenerator Tool: RecoEvent store doesn't exist!",v_error,verbosity);
+  	return false;
+  };
+  
+  
+  // check if event passes the cut
+  Log("VtxSeedGenerator Tool: Loading EventCutStatus",v_debug,verbosity);
   bool EventCutstatus = false;
   auto get_evtstatus = m_data->Stores.at("RecoEvent")->Get("EventCutStatus",EventCutstatus);
   if(!get_evtstatus) {
@@ -68,27 +69,29 @@ bool VtxSeedGenerator::Execute(){
     return true;	
   }
   
-		
-	// Load digits
-	auto get_recodigit = m_data->Stores.at("RecoEvent")->Get("RecoDigit",fDigitList);  ///> Get digits from "RecoEvent" 
-  if(!get_recodigit){ 
-  	Log("VtxSeedGenerator  Tool: Error retrieving RecoDigits,no digit from the RecoEvent store!",v_error,verbosity); 
-  	return true;
+  Log("VtxSeedGenerator Tool: Loading Digits",v_debug,verbosity);
+  // Load digits
+  auto get_recodigit = m_data->Stores.at("RecoEvent")->Get("RecoDigit",fDigitList);  ///> Get digits from "RecoEvent" 
+  if (!get_recodigit){ 
+  Log("VtxSeedGenerator  Tool: Error retrieving RecoDigits,no digit from the RecoEvent store!",v_error,verbosity); 
+  return false;
   }
 
   // Generate vertex candidates and push to "RecoEvent" store
   if (UseSeedGrid){
+    Log("VtxSeedGenerator Tool: Generating seed grid",v_debug,verbosity);
     this->GenerateSeedGrid(fNumSeeds);
   } else {
+    Log("VtxSeedGenerator Tool: Generating quadfitter seeds",v_debug,verbosity);
     this->GenerateVertexSeeds(fNumSeeds);
   }
   this->PushVertexSeeds(true);
-
+  Log("VtxSeedGenerator Tool: Execution complete",v_debug,verbosity);
   return true;
 }
 
 bool VtxSeedGenerator::Finalise(){
-	delete vSeedVtxList; vSeedVtxList = 0;
+  delete vSeedVtxList; vSeedVtxList = 0;
   Log("VtxSeedGenerator exitting", v_debug,verbosity);
   return true;
 }
@@ -117,7 +120,8 @@ bool VtxSeedGenerator::GenerateSeedGrid(int NSeeds) {
   if( NSeeds<=1 ) return false;
 
   // form list of golden digits used in class methods
-  // Here, the digit type (PMT or LAPPD or all) is specified. 
+  // Here, the digit type (PMT or LAPPD or all) is specified.
+  Log("VtxSeedGenerator Tool: Getting clean RecoDigits for event", v_debug,verbosity);
   vSeedDigitList.clear();  
   RecoDigit digit;
   for( fThisDigit=0; fThisDigit<fDigitList->size(); fThisDigit++ ){
@@ -143,7 +147,7 @@ bool VtxSeedGenerator::GenerateSeedGrid(int NSeeds) {
   //We will use Vogel's method to populate disks with equidistant points
   //inside the ANNIE tank.  The z separation for each disk will be approx. the
   //average separation of points on the disk.
-  
+  Log("VtxSeedGenerator Tool: Generating grid of positions", v_debug,verbosity);
   //Here, we need to get the radius and height of the ANNIE tank from the geo
   double pmtradius = ANNIEGeometry::Instance()->GetPMTRadius();	
   double pmtlength = ANNIEGeometry::Instance()->GetCylLength();
@@ -186,6 +190,7 @@ bool VtxSeedGenerator::GenerateSeedGrid(int NSeeds) {
       vSeedVtxList->push_back(thisgridseed);
     }
   }
+  Log("VtxSeedGenerator Tool: Grid of positions and median times calculated", v_debug,verbosity);
   return true;
 }
 

--- a/configfiles/VertexReco/ROOTLoadExtGrid/DigitBuilderROOTConfig
+++ b/configfiles/VertexReco/ROOTLoadExtGrid/DigitBuilderROOTConfig
@@ -1,0 +1,6 @@
+# DigitBuilderROOT config file
+
+verbosity 5
+InputFile /AnnieShare/FullRecoChain/LiliaFiles_05202019/PMTLAPPDReco_05202019.root
+# There are three configurations: "PMT_only", "LAPPD_only", "All"
+PhotoDetectorConfiguration All

--- a/configfiles/VertexReco/ROOTLoadExtGrid/PhaseIITreeMakerConfig
+++ b/configfiles/VertexReco/ROOTLoadExtGrid/PhaseIITreeMakerConfig
@@ -1,0 +1,10 @@
+verbose 3
+
+muonRecoDebug_fill 1
+muonMCTruth_fill 1
+muonTruthRecoDiff_fill 1
+pionKaonCount_fill 1
+
+OutputFile output_test.root 
+NumEventsWritten 2000
+

--- a/configfiles/VertexReco/ROOTLoadExtGrid/README.md
+++ b/configfiles/VertexReco/ROOTLoadExtGrid/README.md
@@ -1,0 +1,25 @@
+# Configure files
+
+***********************
+#Description
+**********************
+
+Configure files are simple text files for passing variables to the Tools.
+
+Text files are read by the Store class (src/Store) and automatically asigned to an internal map for the relavent Tool to use.
+
+
+************************
+#Useage
+************************
+
+Any line starting with a "#" will be ignored by the Store, as will blank lines.
+
+Variables should be stored one per line as follows:
+
+
+Name Value #Comments 
+
+
+Note: Only one value is permitted per name and they are stored in a string stream and templated cast back to the type given.
+

--- a/configfiles/VertexReco/ROOTLoadExtGrid/ToolChainConfig
+++ b/configfiles/VertexReco/ROOTLoadExtGrid/ToolChainConfig
@@ -1,0 +1,23 @@
+#ToolChain dynamic setup file
+
+##### Runtime Paramiters #####
+verbose 0 ## Verbosity level of ToolChain
+error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
+attempt_recover 1 ## 1= will attempt to finalise if an execute fails
+
+###### Logging #####
+log_mode Interactive # Interactive=cout , Remote= remote logging system "serservice_name Remote_Logging" , Local = local file log;
+log_local_path ./log
+log_service LogStore
+
+###### Service discovery ##### Ignore these settings for local analysis
+service_publish_sec -1
+service_kick_sec -1
+
+##### Tools To Add #####
+Tools_File ./configfiles/VertexReco/ROOTLoadExtGrid/ToolsConfig  ## list of tools to run and their config files
+
+##### Run Type #####
+Inline -1 ## number of Execute steps in program, -1 infinite loop that is ended by user
+Interactive 0 ## set to 1 if you want to run the code interactively
+

--- a/configfiles/VertexReco/ROOTLoadExtGrid/ToolsConfig
+++ b/configfiles/VertexReco/ROOTLoadExtGrid/ToolsConfig
@@ -1,0 +1,5 @@
+DigitBuilderROOT DigitBuilderROOT ./configfiles/VertexReco/ROOTLoadExtGrid/DigitBuilderROOTConfig
+VtxSeedGenerator VtxSeedGenerator ./configfiles/VertexReco/ROOTLoadExtGrid/VtxSeedGeneratorConfig
+VtxExtendedVertexFinder VtxExtendedVertexFinder ./configfiles/VertexReco/ROOTLoadExtGrid/VtxExtendedVertexFinderConfig
+PhaseIITreeMaker PhaseIITreeMaker ./configfiles/VertexReco/ROOTLoadExtGrid/PhaseIITreeMakerConfig
+#SaveRecoEvent SaveRecoEvent ./configfiles/VertexReco/PhaseIIExtGrid/SaveRecoEventConfig

--- a/configfiles/VertexReco/ROOTLoadExtGrid/VtxExtendedVertexFinderConfig
+++ b/configfiles/VertexReco/ROOTLoadExtGrid/VtxExtendedVertexFinderConfig
@@ -1,0 +1,5 @@
+# VtxPointPositionFinder config file
+
+verbosity 6
+UseTrueVertexAsSeed 0
+FitAllOnSeedGrid 1

--- a/configfiles/VertexReco/ROOTLoadExtGrid/VtxSeedGeneratorConfig
+++ b/configfiles/VertexReco/ROOTLoadExtGrid/VtxSeedGeneratorConfig
@@ -1,0 +1,6 @@
+# VtxSeedGenerator config file
+
+verbosity 3
+NumberOfSeeds 100
+UseSeedGrid 1
+SeedType 2


### PR DESCRIPTION
The DigitBuilderROOT tool has been updated to work with the current phaseII output ntuple files.

The DigitBuilderROOT tool allows a user to re-load a phaseII ROOT ntuple file into the RecoEvent store for re-running the reconstruction tools.  This allows for re-processing of files that have already been run once, or have already been filtered to a specific type of event using the EventSelector tool.