### PR TITLE
Hide all object files created following compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 Analyse
 ToolDAQ
+*.o


### PR DESCRIPTION
The object files make seeing the git branch status difficult; addition will hide them from git.