### PR TITLE
Modified initialization numbers for RecoVertex

### DIFF
--- a/DataModel/RecoVertex.cpp
+++ b/DataModel/RecoVertex.cpp
@@ -146,8 +146,8 @@ RecoVertex* RecoVertex::CloneVertex(RecoVertex* b) {
 
 void RecoVertex::Reset()
 { 
-  fPosition = Position(-999.,-999.,-999.);
-  fTime = double(0.0);
+  fPosition = Position(-9999.,-9999.,-9999.);
+  fTime = double(-9999.);
   fFoundVertex = 0;
   fDirection = Direction(0.,0.,0.);
   fFoundDirection = 0;

--- a/UserTools/MCRecoEventLoader/MCRecoEventLoader.cpp
+++ b/UserTools/MCRecoEventLoader/MCRecoEventLoader.cpp
@@ -67,6 +67,7 @@ bool MCRecoEventLoader::Execute(){
 
   this->PushTrueVertex(true);
   this->PushTrueStopVertex(true);
+  this->PushTrueMuonEnergy(TrueMuonEnergy);
   this->PushTrueWaterTrackLength(WaterTrackLength);
   this->PushTrueMRDTrackLength(MRDTrackLength);
 
@@ -85,6 +86,10 @@ void MCRecoEventLoader::Reset() {
   // Reset 
   fMuonStartVertex->Reset();
   fMuonStopVertex->Reset();
+  TrueMuonEnergy = -9999.;
+  WaterTrackLength = -9999.;
+  MRDTrackLength = -9999.;
+  
 }
 
 void MCRecoEventLoader::FindTrueVertexFromMC() {
@@ -119,8 +124,7 @@ void MCRecoEventLoader::FindTrueVertexFromMC() {
   double muonstoptime = primarymuon.GetStopTime();
   Direction muondirection = primarymuon.GetStartDirection();
   
-  double muonenergy = primarymuon.GetStartEnergy();
-  m_data->Stores.at("RecoEvent")->Set("TrueMuonEnergy", muonenergy);
+  TrueMuonEnergy = primarymuon.GetStartEnergy();
 
   // MCParticleProperties tool fills in MRD track in m, but
   // Water track in cm...
@@ -222,6 +226,11 @@ void MCRecoEventLoader::PushTrueVertex(bool savetodisk) {
 void MCRecoEventLoader::PushTrueStopVertex(bool savetodisk) {
   Log("MCRecoEventLoader Tool: Push true stop vertex to the RecoEvent store",v_message,verbosity);
   m_data->Stores.at("RecoEvent")->Set("TrueStopVertex", fMuonStopVertex, savetodisk); 
+}
+
+void MCRecoEventLoader::PushTrueMuonEnergy(double MuE) {
+	Log("MCRecoEventLoader Tool: Push true muon energy to the RecoEvent store",v_message,verbosity);
+	m_data->Stores.at("RecoEvent")->Set("TrueMuonEnergy", MuE);  ///> Add digits to RecoEvent
 }
 
 void MCRecoEventLoader::PushTrueWaterTrackLength(double WaterT) {

--- a/UserTools/MCRecoEventLoader/MCRecoEventLoader.h
+++ b/UserTools/MCRecoEventLoader/MCRecoEventLoader.h
@@ -29,8 +29,9 @@ class MCRecoEventLoader: public Tool {
   RecoVertex* fMuonStartVertex = nullptr; 	 ///< true muon start vertex
   RecoVertex* fMuonStopVertex = nullptr; 	 ///< true muon stop vertex
   std::vector<MCParticle>* fMCParticles=nullptr;  ///< truth tracks
-  double WaterTrackLength = -999.;
-  double MRDTrackLength = -999.;
+  double TrueMuonEnergy = -9999.;
+  double WaterTrackLength = -9999.;
+  double MRDTrackLength = -9999.;
 
   /// \brief Find true neutrino vertex
   ///
@@ -60,6 +61,7 @@ class MCRecoEventLoader: public Tool {
   void PushTrueStopVertex(bool savetodisk);
 
   /// \brief Push muon track lengths to RecoEvent Store
+  void PushTrueMuonEnergy(double MuE);
   void PushTrueWaterTrackLength(double WaterT);
   void PushTrueMRDTrackLength(double MRDT);
 


### PR DESCRIPTION
Modified the initialization of the vertex time for a RecoVertex class to be -9999.  Previously, initialization was set to 0; it was difficult to determine if the muon time for WCSim simulations (where the interaction time is at t=0) was truly loaded properly or not.

Also made sure the muon energy is re-initialized in the beginning of MCRecoEventLoader's execute loop.