### PR TITLE
Addition of Tank PMT loading framework to LoadGeometry tool

### DIFF
--- a/UserTools/LoadGeometry/LoadGeometry.cpp
+++ b/UserTools/LoadGeometry/LoadGeometry.cpp
@@ -24,14 +24,19 @@ bool LoadGeometry::Initialise(std::string configfile, DataModel &data){
 
   //Check files exist 
   if(!this->FileExists(fDetectorGeoFile)){
-		Log("LoadGeometry Tool: File for Detector Geometry does not exist!",v_error,verbosity); 
-        std::cout << "Filepath was... " << fDetectorGeoFile << std::endl;
-		return false;
+    Log("LoadGeometry Tool: File for Detector Geometry does not exist!",v_error,verbosity); 
+    std::cout << "Filepath was... " << fDetectorGeoFile << std::endl;
+    return false;
   }
   if(!this->FileExists(fFACCMRDGeoFile)){
-		Log("LoadGeometry Tool: File for FACC/MRD Geometry does not exist!",v_error,verbosity);
-        std::cout << "Filepath was... " << fFACCMRDGeoFile << std::endl;
-		return false;
+    Log("LoadGeometry Tool: File for FACC/MRD Geometry does not exist!",v_error,verbosity);
+    std::cout << "Filepath was... " << fFACCMRDGeoFile << std::endl;
+    return false;
+  }
+  if(!this->FileExists(fTankPMTGeoFile)){
+    Log("LoadGeometry Tool: File for Tank PMT Geometry does not exist!",v_error,verbosity);
+    std::cout << "Filepath was... " << fTankPMTGeoFile << std::endl;
+    return false;
   }
 
   //Initialize the geometry using the geometry CSV file entries 
@@ -39,6 +44,9 @@ bool LoadGeometry::Initialise(std::string configfile, DataModel &data){
 
   //Load MRD Geometry Detector/Channel Information
   this->LoadFACCMRDDetectors();
+
+  //Load TankPMT Geometry Detector/Channel Information
+  this->LoadTankPMTDetectors();
 
   m_data->Stores.at("ANNIEEvent")->Header->Set("AnnieGeometry",AnnieGeometry,true);
   
@@ -241,19 +249,20 @@ bool LoadGeometry::ParseMRDDataEntry(std::vector<std::string> SpecLine,
     if (MRDLegendEntries.at(i) == "cable_label") cable_label = svalue;
   } 
 
+  // Parse whether this is an MRD or Veto Paddle
+  std::string dettype = "unknown";
+  if (detector_system == 0) dettype = "Veto";
+  else if (detector_system == 1) dettype = "MRD";
   //FIXME Need the direction of the MRD PMT
-  //FIXME Do we want the Paddle's center position?  Or PMT?
   //FIXME: things that are not loaded in with the default det/channel format:
-  //  - detector_system (fed as "MRD"), orientation, layer, side, num
   //  - discrim_slot, discrim_ch
   //  - patch_panel_row, patch_panel_col, amp_slot, amp_channel
   //  - nominal_HV, polarity
   //  - cable_label, paddle_label
-  //  - x_width, y_width, z_width
   //
   if(verbosity>4) std::cout << "Filling a FACC/MRD data line into Detector/Channel classes" << std::endl;
   Detector adet(detector_num,
-                "MRD",
+                dettype,
                 "MRD", //Change to orientation for PaddleDetector class?
                 Position( x_center/100.,
                           y_center/100.,
@@ -310,6 +319,163 @@ bool LoadGeometry::ParseMRDDataEntry(std::vector<std::string> SpecLine,
   return true;
 }
 
+void LoadGeometry::LoadTankPMTDetectors(){
+  //First, get the Tank PMT file legend key
+  Log("LoadGeometry tool: Now loading TankPMT detectors",v_message,verbosity);
+  std::string TankPMTLegend = this->GetLegendLine(fTankPMTGeoFile);
+  std::vector<std::string> TankPMTLegendEntries;
+  boost::split(TankPMTLegendEntries,TankPMTLegend, boost::is_any_of(","), boost::token_compress_on); 
+ 
+  std::string line;
+  ifstream myfile(fTankPMTGeoFile.c_str());
+  if (myfile.is_open()){
+    //First, get to where data starts
+    while(getline(myfile,line)){
+      if(line.find("#")!=std::string::npos) continue;
+      if(line.find(DataStartLineLabel)!=std::string::npos) break;
+    }
+    //Loop over lines, collect all detector specs 
+    while(getline(myfile,line)){
+      std::cout << line << std::endl; //has our stuff;
+      if(line.find("#")!=std::string::npos) continue;
+      if(line.find(DataEndLineLabel)!=std::string::npos) break;
+      std::vector<std::string> SpecLine;
+      boost::split(SpecLine,line, boost::is_any_of(","), boost::token_compress_on); 
+      if(verbosity>4) std::cout << "This line of data: " << line << std::endl;
+      //Parse data line, make corresponding detector/channel
+      bool add_ok = this->ParseTankPMTDataEntry(SpecLine,TankPMTLegendEntries);
+      if(not add_ok){
+        std::cerr<<"Failed to add Tank PMT Detector to Geometry!"<<std::endl;
+      }
+    }
+  } else {
+    Log("LoadGeometry tool: Something went wrong opening the Tank PMT file!!!",v_error,verbosity);
+  }
+  if(myfile.is_open()) myfile.close();
+    Log("LoadGeometry tool: Tank PMT Detector/Channel loading complete",v_message,verbosity);
+}
+
+bool LoadGeometry::ParseTankPMTDataEntry(std::vector<std::string> SpecLine,
+        std::vector<std::string> TankPMTLegendEntries){
+
+  //Parse the line for information needed to fill the Tdetector & channel classes
+  int detector_num,channel_num,panel_number,signal_crate,signal_slot,signal_channel,
+      mt_crate, mt_slot, mt_channel, hv_crate,hv_slot,hv_channel,nominal_HV,polarity;
+  double x_pos,y_pos,z_pos,x_dir,y_dir,z_dir;
+  std::string detector_tank_location,PMT_type,cable_label,detector_status;
+
+  //Search for Legend entry.  Fill value type if found.
+  Log("LoadGeometry tool: parsing data line into variables",v_debug,verbosity);
+  for (int i=0; i<SpecLine.size(); i++){
+    int ivalue;
+    double dvalue;
+    std::string svalue;
+    for (int j=0; j<TankPMTIntegerValues.size(); j++){
+      if(TankPMTLegendEntries.at(i) == TankPMTIntegerValues.at(j)){
+        ivalue = std::stoi(SpecLine.at(i));
+        break;
+      }
+    }
+    for (int j=0; j<TankPMTStringValues.size(); j++){
+      if(TankPMTLegendEntries.at(i) == TankPMTStringValues.at(j)){
+        svalue = SpecLine.at(i);
+        break;
+      }
+    }
+    for (int j=0; j<TankPMTDoubleValues.size(); j++){
+      if(TankPMTLegendEntries.at(i) == TankPMTDoubleValues.at(j)){
+        dvalue = std::stod(SpecLine.at(i));
+        break;
+      }
+    }
+
+    //Integers
+    if (TankPMTLegendEntries.at(i) == "detector_num") detector_num = ivalue;
+    if (TankPMTLegendEntries.at(i) == "channel_num") channel_num = ivalue;
+    if (TankPMTLegendEntries.at(i) == "panel_number") panel_number = ivalue;
+    if (TankPMTLegendEntries.at(i) == "signal_crate") signal_crate = ivalue;
+    if (TankPMTLegendEntries.at(i) == "signal_slot") signal_slot = ivalue;
+    if (TankPMTLegendEntries.at(i) == "signal_channel") signal_channel = ivalue;
+    if (TankPMTLegendEntries.at(i) == "mt_crate") mt_crate = ivalue;
+    if (TankPMTLegendEntries.at(i) == "mt_slot") mt_slot = ivalue;
+    if (TankPMTLegendEntries.at(i) == "mt_channel") mt_channel = ivalue;
+    if (TankPMTLegendEntries.at(i) == "hv_crate") hv_crate = ivalue;
+    if (TankPMTLegendEntries.at(i) == "hv_slot") hv_slot = ivalue;
+    if (TankPMTLegendEntries.at(i) == "hv_channel") hv_channel = ivalue;
+    if (TankPMTLegendEntries.at(i) == "nominal_HV") nominal_HV = ivalue;
+    //Doubles
+    if (TankPMTLegendEntries.at(i) == "x_pos") x_pos = dvalue;
+    if (TankPMTLegendEntries.at(i) == "y_pos") y_pos = dvalue;
+    if (TankPMTLegendEntries.at(i) == "z_pos") z_pos = dvalue;
+    if (TankPMTLegendEntries.at(i) == "x_dir") x_dir = dvalue;
+    if (TankPMTLegendEntries.at(i) == "y_dir") y_dir = dvalue;
+    if (TankPMTLegendEntries.at(i) == "z_dir") z_dir = dvalue;
+    //Strings
+    if (TankPMTLegendEntries.at(i) == "detector_tank_location") detector_tank_location = svalue;
+    if (TankPMTLegendEntries.at(i) == "PMT_type") PMT_type = svalue;
+    if (TankPMTLegendEntries.at(i) == "cable_label") cable_label = svalue;
+    if (TankPMTLegendEntries.at(i) == "detector_status") detector_status = svalue;
+  } 
+
+  //Parse out the Detector Status for filling into Detector class
+  detectorstatus detstatus;
+  channelstatus chanstatus;
+  if(detector_status == "ON"){
+    detstatus = detectorstatus::ON;
+    chanstatus = channelstatus::ON;
+  }
+  else if(detector_status == "OFF"){
+    detstatus = detectorstatus::OFF;
+    chanstatus = channelstatus::OFF;
+  }
+  else if(detector_status == "UNSTABLE"){
+    detstatus = detectorstatus::UNSTABLE;
+    chanstatus = channelstatus::UNSTABLE;
+  }
+  else {
+    Log("LoadGeometry Tool: Undefined status of Tank PMT detector",v_error,verbosity);
+    if (verbosity > v_error) std::cout << "channel_num is " << channel_num << std::endl;
+  } 
+
+  //FIXME: things that are not loaded in with the default det/channel format:
+  //      - panel_number
+  
+  if(verbosity>4) std::cout << "Filling a Tank PMT data line into Detector/Channel classes" << std::endl;
+  Detector adet(detector_num,
+                "Tank",
+                detector_tank_location, 
+                Position( x_pos/1000.,
+                          y_pos/1000.,
+                          z_pos/1000.),
+                Direction(x_dir,
+                          y_dir,
+                          z_dir),
+                PMT_type,
+                detstatus,
+                0.);
+
+  Channel pmtchannel( channel_num,
+                      Position(0,0,0.),
+                      -1, // stripside
+                      -1, // stripnum
+                      signal_crate,
+                      signal_slot,
+                      signal_channel,
+                      mt_crate,
+                      mt_slot,
+                      mt_channel,
+                      hv_crate,
+                      hv_slot,
+                      hv_channel,
+                      chanstatus); //channel status same as detector status here
+  
+  // Add this channel to the geometry
+  if(verbosity>4) cout<<"Adding channel "<<channel_num<<" to detector "<<detector_num<<endl;
+  adet.AddChannel(pmtchannel);
+  if(verbosity>5) cout<<"Adding detector to Geometry"<<endl;
+  AnnieGeometry->AddDetector(adet);
+  return true;
+}
 
 bool LoadGeometry::FileExists(std::string name) {
   ifstream myfile(name.c_str());

--- a/UserTools/LoadGeometry/LoadGeometry.h
+++ b/UserTools/LoadGeometry/LoadGeometry.h
@@ -24,6 +24,11 @@ class LoadGeometry: public Tool {
   void LoadFACCMRDDetectors();
   bool  ParseMRDDataEntry(std::vector<std::string> SpecLine,
                                std::vector<std::string> MRDLegendEntries);
+  
+  void LoadTankPMTDetectors();
+  bool ParseTankPMTDataEntry(std::vector<std::string> SpecLine,
+                               std::vector<std::string> PMTLegendEntries);
+
   Geometry* AnnieGeometry;
 
  private:
@@ -41,18 +46,27 @@ class LoadGeometry: public Tool {
   //Vector of strings indicating variables of interest and their data types in
   //The MRD file.  Used in the LoadFACCMRDDetectors() method
   std::vector<std::string> MRDIntegerValues{"detector_num","channel_num","detector_system","orientation","layer","side","num",
-                                   "rack","TDC slot","TDC channel","discrim_slot","discrim_ch",
+                                   "rack","TDC_slot","TDC_channel","discrim_slot","discrim_ch",
                                    "patch_panel_row","patch_panel_col","amp_slot","amp_channel",
                                    "hv_crate","hv_slot","hv_channel","nominal_HV","polarity"};
   std::vector<std::string> MRDDoubleValues{"x_center","y_center","z_center","x_width","y_width","z_width"};
   std::vector<std::string> MRDStringValues{"PMT_type","cable_label","paddle_label","notes"};
 
-	//verbosity levels: if 'verbosity' < this level, the message type will be logged.
-	int verbosity=1;
+  //Vector of strings indicating variables of interest and their data types in
+  //The TankPMT file.  Used in the LoadTankPMTDetectors() method
+  std::vector<std::string> TankPMTIntegerValues{"detector_num","channel_num","panel_number"
+                                   "signal_crate","signal_slot","signal_channel",
+                                   "mt_crate","mt_slot","mt_channel",
+                                   "hv_crate","hv_slot","hv_channel","nominal_HV"};
+  std::vector<std::string> TankPMTDoubleValues{"x_pos","y_pos","z_pos","x_dir","y_dir","z_dir"};
+  std::vector<std::string> TankPMTStringValues{"detector_tank_location","PMT_type","cable_label","notes"};
+
+  //verbosity levels: if 'verbosity' < this level, the message type will be logged.
+  int verbosity=1;
   int v_error=0;
-	int v_warning=1;
-	int v_message=2;
-	int v_debug=3;
+  int v_warning=1;
+  int v_message=2;
+  int v_debug=3;
 };
 
 

--- a/configfiles/LoadGeometry/FullTankPMTGeometry.csv
+++ b/configfiles/LoadGeometry/FullTankPMTGeometry.csv
@@ -1,0 +1,21 @@
+#,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+#THIS IS A DUMMY FILE; VALUES ARENOT LEGITIMATE AND MUST BE UPDATED WITH ALL REAL ONES
+#Some notes to help with making the real one though...
+#  - detector_num and channel_num start at the end of the MRD detector and channel numbers.
+#  - Top and bottom PMTs have no panel number, so it's just set to -1
+#  - Side PMTs are all WATCHMAN, Hamamatsu, and WATCHBOY; top are all ETL; bottom are all LUX
+#
+LEGEND_LINE,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+detector_num,channel_num,detector_tank_location,panel_number,x_pos,y_pos,z_pos,x_dir,y_dir,z_dir,signal_crate,signal_slot,signal_channel,mt_crate,mt_slot,mt_channel,hv_crate,hv_slot,hv_channel,nominal_HV,PMT_type,cable_label,detector_status,notes
+
+#,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+DATA_START,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+332,332,Barrel,1,-105.0,0,0,1.,0,0,6,0,0,6,1,0,1,0,0,1550,HamamatsuModel,HM076,OFF,
+333,333,Barrel,2,105,0,0,-1.0,0,0,6,0,1,6,1,0,1,0,1,1550,WatchboyModel,WB002,ON,
+334,334,Barrel,3,0,0,105.0,0,0,-1,6,0,2,6,1,0,1,0,2,1550,WatchboyModel,WB032,ON,
+335,335,Barrel,4,74.2,15,-74.2,-0.707,0,0.707,6,0,3,6,1,0,1,0,3,1550,WatchmanModel,WM1,ON,
+336,336,Top,-1,5,106,5,0,-1,0,6,0,4,6,1,2,1,0,4,1550,ETELModel,178,ON,
+337,337,Top,-1,0,106,20,0,-1,0,6,0,5,6,1,2,1,0,5,1550,ETELModel,472,UNSTABLE,
+338,338,Bottom,-1,4,-111,4,0,1,0,6,0,6,6,1,2,1,0,6,1550,LUXModel,N4,ON,
+339,339,Bottom,-1,-4,-111,4,0,-1,0,6,0,7,6,1,2,1,0,7,1550,LUXModel,S1,ON,
+DATA_END,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,

--- a/configfiles/LoadGeometry/LoadGeometryConfig
+++ b/configfiles/LoadGeometry/LoadGeometryConfig
@@ -1,4 +1,4 @@
 verbosity 0
 FACCMRDGeoFile ./configfiles/LoadGeometry/FullMRDGeometry.csv
 DetectorGeoFile ./configfiles/LoadGeometry/DetectorGeometrySpecs.csv
-
+TankPMTGeoFile ./configfiles/LoadGeometry/FullTankPMTGeometry.csv


### PR DESCRIPTION
Methods needed to load the Tank PMT detector and channel classes have been added to the LoadGeometry tool.  A dummy file with the proper framework for loading tank PMT information is also included.  This file does not have real numbers; the actual PMT information must be put in place.