### PR TITLE
reduce output of Monitoring tools to a minimal level

### DIFF
--- a/UserTools/MonitorMRDEventDisplay/MonitorMRDEventDisplay.h
+++ b/UserTools/MonitorMRDEventDisplay/MonitorMRDEventDisplay.h
@@ -77,20 +77,21 @@ class MonitorMRDEventDisplay: public Tool {
 		time_t t;
   		std::stringstream title_time; 
   		double integration_period = 5.; 	//5 minutes integration for rate calculation?
+  		double integration_period2 = 60.;
 
   		//storing variables
-		std::vector<std::vector<unsigned int> > live_tdc, vector_tdc;
-		std::vector<unsigned int> vector_nchannels, vector_nslots;
+		std::vector<std::vector<unsigned int> > live_tdc, vector_tdc, live_tdc_hour, vector_tdc_hour;
+		std::vector<unsigned int> vector_nchannels, vector_nslots, vector_nchannels_hour;
 		std::vector<unsigned int> tdc_paddle, tdc_paddle_hour;
-		std::vector<std::vector<ULong64_t> > live_timestamp;
-		std::vector<ULong64_t> vector_timestamp;
+		std::vector<std::vector<ULong64_t> > live_timestamp, live_timestamp_hour;
+		std::vector<ULong64_t> vector_timestamp, vector_timestamp_hour;
 
 		//plot variables
-		TH2F *rate_crate1;
-		TH2F *rate_crate2;
-		TH1F *TDC_hist;
+		TH2F *rate_crate1, *rate_crate1_hour;
+		TH2F *rate_crate2, *rate_crate2_hour;
+		TH1F *TDC_hist, *TDC_hist_hour;
 		TH1F *TDC_hist_coincidence;
-		TH1F *n_paddles_hit;
+		TH1F *n_paddles_hit, *n_paddles_hit_hour;
 		TH1F *n_paddles_hit_coincidence;
 		double min_ch, max_ch;
 		bool update_plots;

--- a/UserTools/MonitorMRDLive/MonitorMRDLive.cpp
+++ b/UserTools/MonitorMRDLive/MonitorMRDLive.cpp
@@ -22,7 +22,7 @@ bool MonitorMRDLive::Initialise(std::string configfile, DataModel &data){
   m_variables.Get("AveragePlots",draw_average);
 
   if (outpath == "fromStore") m_data->CStore.Get("OutPath",outpath);
-  std::cout <<"Output path for plots is "<<outpath<<std::endl;
+  if (verbosity > 1) std::cout <<"Output path for plots is "<<outpath<<std::endl;
 
   num_active_slots=0;
   n_active_slots_cr1=0;
@@ -35,11 +35,11 @@ bool MonitorMRDLive::Initialise(std::string configfile, DataModel &data){
     file>>temp_crate>>temp_slot;
     if (file.eof()) break;
     if (temp_crate-min_crate<0 || temp_crate-min_crate>=num_crates) {
-        std::cout <<"Specified crate "<<temp_crate<<" out of range [7...8]. Continue with next entry."<<std::endl;
+        std::cout <<"ERROR (MonitorMRDLive): Specified crate "<<temp_crate<<" out of range [7...8]. Continue with next entry."<<std::endl;
         continue;
     }
     if (temp_slot<1 || temp_slot>num_slots){
-        std::cout <<"Specified slot out of range [1...24]. Continue with next entry."<<std::endl;
+        std::cout <<"ERROR (MonitorMRDLive): Specified slot out of range [1...24]. Continue with next entry."<<std::endl;
         continue;
     }
     active_channel[temp_crate-min_crate][temp_slot-1]=1;        //crates numbering starts at 7, slot numbering at 1
@@ -50,8 +50,8 @@ bool MonitorMRDLive::Initialise(std::string configfile, DataModel &data){
   file.close();
   num_active_slots = n_active_slots_cr1+n_active_slots_cr2;
 
-  //omit warning messages from ROOT
-  gROOT->ProcessLine("gErrorIgnoreLevel = 1001;");
+  //omit warning messages from ROOT: info messages - 1001, warning messages - 2001, error messages - 3001
+  gROOT->ProcessLine("gErrorIgnoreLevel = 3001;");
 
   return true;
 
@@ -228,7 +228,7 @@ void MonitorMRDLive::MRDTDCPlots(){
                 h2D_cr1->SetBinContent(Slot.at(i),Channel.at(i)+1,Value.at(i));
                 hSlot_Channel.at(index)->SetBinContent(Channel.at(i)+1,Value.at(i));
             } else {
-              std::cout <<"Slot # "<<Slot.at(i)<<" is not connected according to the configuration file. Abort this entry..."<<std::endl;
+              std::cout <<"ERROR (MonitorMRDLive): Slot # "<<Slot.at(i)<<" is not connected according to the configuration file. Abort this entry..."<<std::endl;
               continue;
             }
         } else if (Crate.at(i) == min_crate+1) {
@@ -239,14 +239,14 @@ void MonitorMRDLive::MRDTDCPlots(){
                 h2D_cr2->SetBinContent(Slot.at(i),Channel.at(i)+1,Value.at(i));
                 hSlot_Channel.at(n_active_slots_cr1+index)->SetBinContent(Channel.at(i)+1,Value.at(i));
           }else {
-            std::cout <<"Slot # "<<Slot.at(i)<<" is not connected according to the configuration file. Abort this entry..."<<std::endl;
+            std::cout <<"ERROR (MonitorMRDLive): Slot # "<<Slot.at(i)<<" is not connected according to the configuration file. Abort this entry..."<<std::endl;
             continue;
           }
         }
-        else std::cout <<"The read-in crate number does not exist. Continue with next event... "<<std::endl;
+        else std::cout <<"ERROR (MonitorMRDLive): The read-in crate number does not exist. Continue with next event... "<<std::endl;
       }
 
-      if (verbosity > 2)std::cout <<"Iterating over slots..."<<std::endl;
+      if (verbosity > 2) std::cout <<"Iterating over slots..."<<std::endl;
 
       for (int i_slot=0;i_slot<num_slots;i_slot++){
 

--- a/configfiles/Monitoring/MonitorMRDEventDisplayConfig
+++ b/configfiles/Monitoring/MonitorMRDEventDisplayConfig
@@ -1,7 +1,7 @@
 # MonitorMRDEventDisplay config file
 
-verbose 1
-#OutputPath /ANNIECode/MRDMonitorTest/
+verbose 0
+#OutputPath /ANNIECode/MRDMonitorOutputTest/
 OutputPath fromStore
 ActiveSlots configfiles/Monitoring/MRD_activech.txt #define which slots of the crate are connected
 InActiveChannels configfiles/Monitoring/MRD_inactivech.txt  #define which channels of the active slots are not connected

--- a/configfiles/Monitoring/MonitorMRDTimeConfig
+++ b/configfiles/Monitoring/MonitorMRDTimeConfig
@@ -3,7 +3,7 @@
 verbose 0
 #OutputPath /ANNIECode/MRDMonitorTest/
 OutputPath fromStore
-ActiveSlots /ToolAnalysis/configfiles/Monitoring/MRD_activech.txt #define which channels of the crate are connected
+ActiveSlots configfiles/Monitoring/MRD_activech.txt #define which channels of the crate are connected
 StartTime 1970/1/1	#default: 1970/1/1
 OffsetDate 0
 #OffsetDate 25200000


### PR DESCRIPTION
The MonitorMRD tools were reworked to have no output except for error warnings when setting the verbosity level to 0. This should minimize the memory that is allocated when writing the log output of the toolchain to an output file.