### PR TITLE
ACDC Parsing with proper board handling

### DIFF
--- a/UserTools/LAPPDParseACC/LAPPDParseACC.h
+++ b/UserTools/LAPPDParseACC/LAPPDParseACC.h
@@ -22,12 +22,14 @@ class LAPPDParseACC: public Tool {
   bool Finalise();
 
 
+  bool FindChannelKeyFromACDCFile(int acdc_board, int acdc_ch, unsigned long& key, map<unsigned long, Channel>* lappd_channels_from_geom);
+  void GetAllLAPPDChannels(Geometry* geom, map<unsigned long, Channel>* all_lappd_channels);
+
  private:
    ifstream dfs, mfs;
-   vector<int> boards;
    string meta_header;
-   int n_cells;
-   int n_chs;
+   int _event_no;
+   streampos data_stream_pos;
 
 
 

--- a/UserTools/LAPPDParseACC/README.md
+++ b/UserTools/LAPPDParseACC/README.md
@@ -1,44 +1,32 @@
 # LAPPDParseACC
 
-This tool is made to parse the files produced from the ANNIE Central Card electronics. The design and format of those files is described at this [github page](https://github.com/lappd-daq/acdc-daq).
+This tool is made to parse the files produced from the ANNIE Central Card electronics. The design and format of those files is described at this [github page](https://github.com/lappd-daq/acdc-daq). It supports using multiple boards, where events may or may not contain all boards. 
 
-There are three items added into an `ANNIEEvent` boost store:
 
-**Pedestal Data**
-`map<int, vector<Waveform<double>>>` 
-* key: some integer representing boards and channels (soon to be replaced with Geometry class).
-* value: vector of length one with a Waveform whose samples represent the raw pedestal data in PSEC ADC counts
-* store->("rawPedData")
 
-**ACC Data**
-`map<int, vector<Waveform<double>>>` 
-* key: some integer representing boards and channels (soon to be replaced with Geometry class).
-* value: vector of length one with a Waveform whose samples represent the pedestal subtracted data in PSEC ADC counts
-* store->"RawLAPPDData"
-
-**Meta Data**
-`map<int, map<string, double>>`
-* key: some integer representing boards and channels (soon to be replaced with Geometry class).
-* value: a map between strings and double with all the keywords listed in the data.meta file and their corresponding values
-* store->Header->"metaData"
 
 ## Options
 The following need to be defined at configuration level
 ```
-filepath <the base folder of the input files>
-filename <the base name of the three files>
-print <true/false> # Verbosity level
+store_name <string name of the store, say ANNIEEvent, this is also where raw waveforms will be stored>
+geometry_name <name of geometry object stored in the store_name above>
+lappd_data_filepath <path to the raw data>
+lappd_data_filename <base name of the three files output from ACDC, e.g. mydata (no extension)>
 ```
 
-an example of this would be
+
+## Stores
+The following items are accessed and saved from the store
 ```
-filepath ./fakedata
-filename test
-print false
-```
-This would read the three following files
-```
-fakedata/test.ped
-fakedata/test.acdc
-fakedata/test.meta
+# Geometry class of the data being analysed. (accessed)
+This is used to determine which detectors are LAPPDs, which channel keys are associated with those LAPPDs, and which channel keys map to which channel numbers and ACDC board numbers. Thus, it is critical for the user to set up a map between boards and channels during the geometry building phase. In writing this tool, I followed the example of the LoadGeometry tool.  
+
+# AllLAPPDChannels, map<unsigned long, Channel>* (created and saved)
+This is a map that contains LAPPD channel objects indexed by unique geometry channel key
+
+
+#LAPPDWaveforms, map<unsigned long, Waveform<double>>* (created and saved)
+This is the raw data created by parsing the data files. 
+
+
 ```


### PR DESCRIPTION
This PR contains just the LAPPDParseACC tool that has been rewritten to handle multiple board data parsing. The tool assumes that you have defined LAPPD detectors (and therefore channel keys ) into a Geometry class that has been saved in a store. It looks at those detector objects and associates ACDC channel numbers it finds in raw data files with Geometry channel keys to form the LAPPDWaveforms map<unsigned long, Waveform> . Therefore, it is critical to configure which LAPPDs have which ACDC channel numbers during the geometry building phase.

In writing this tool, I used LoadGeometry as a reference. I created my own geometry class LoadFTBFGeometry (not included in this PR) to test and confirm that the parser works with 4 board data from the test-beam. 