### PR TITLE
add package osg-wn-client needed by images to run on the OSG

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -47,6 +47,7 @@ RUN yum install -y \
     emacs \
     curl \
     curl-devel \
+    osg-wn-client \
     && yum clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
as in the title. Currently trying to run grid jobs with the docker image hangs, and suggestions are this is likely to be due to the above missing package. 
Alas, it's not possible to test without pushing the updated image to dockerhub and then trying to submit more jobs, so fingers crossed!