### PR TITLE
Calib fit rebase

### DIFF
--- a/UserTools/PhaseIIADCCalibrator/PhaseIIADCCalibrator.cpp
+++ b/UserTools/PhaseIIADCCalibrator/PhaseIIADCCalibrator.cpp
@@ -1,5 +1,17 @@
 #include <string>
 
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TApplication.h"
+#include "TCanvas.h"
+#include "TGraph.h"
+#include "TH1.h"
+#include "TF1.h"
+#include "TFitResult.h"
+
+#include <thread>
+#include <chrono>
+
 // ToolAnalysis includes
 #include "PhaseIIADCCalibrator.h"
 
@@ -12,6 +24,43 @@ bool PhaseIIADCCalibrator::Initialise(std::string config_filename, DataModel& da
 
   // Assign a transient data pointer
   m_data = &data;
+  
+  // get config variables
+  m_variables.Get("drawBaselineRootFit",draw_baseline_fit);
+  m_variables.Get("BaselineFitStartSample",baseline_start_sample);
+  get_ok = m_variables.Get("BaselineFitOrder",baseline_fit_order);
+  if(not get_ok) baseline_fit_order = 1; // default to linear fit
+  get_ok = m_variables.Get("RedoFitWithoutOutliers",redo_fit_without_outliers);
+  if(not get_ok) redo_fit_without_outliers = false; // whether to redo the fit after removing outliers
+  get_ok = m_variables.Get("RefitThresholdMillivolts", refit_threshold); // but only if wfrm range exceeds this
+  if(not get_ok) refit_threshold = 50; // something suitable: TODO tune me.
+  use_ze3ra_algorithm = true; // default
+  get_ok = m_variables.Get("UseZe3raAlgorithm", use_ze3ra_algorithm);
+  use_root_algorithm = false; // default
+  get_ok = m_variables.Get("UseRootFitAlgorithm",use_root_algorithm);
+  if((!use_ze3ra_algorithm)&&(!use_root_algorithm)) use_ze3ra_algorithm=true;
+  
+  // get or make the ROOT TApplication to show the fit, debug only
+  if(draw_baseline_fit){
+    int myargc=0;
+    intptr_t tapp_ptr=0;
+    get_ok = m_data->CStore.Get("RootTApplication",tapp_ptr);
+    if(not get_ok){
+      Log("PhaseIIADCCalibrator Tool: making global TApplication",v_debug,verbosity);
+      rootTApp = new TApplication("rootTApp",&myargc,0);
+      tapp_ptr = reinterpret_cast<intptr_t>(rootTApp);
+      m_data->CStore.Set("RootTApplication",tapp_ptr);
+    } else {
+      Log("PhaseIIADCCalibrator Tool: Retrieving global TApplication",v_debug,verbosity);
+      rootTApp = reinterpret_cast<TApplication*>(tapp_ptr);
+    }
+    // register ourself as a user
+    int tapplicationusers;
+    get_ok = m_data->CStore.Get("RootTApplicationUsers",tapplicationusers);
+    if(not get_ok) tapplicationusers=1;
+    else tapplicationusers++;
+    m_data->CStore.Set("RootTApplicationUsers",tapplicationusers);
+  }
 
   //Set defaults in case config file has no entries
   p_critical = 0.01;
@@ -85,8 +134,11 @@ bool PhaseIIADCCalibrator::Execute() {
     Log("Making calibrated waveforms for ADC channel " +
       std::to_string(channel_key), 3, verbosity);
 
-    calibrated_waveform_map[channel_key] = make_calibrated_waveforms(
-      raw_waveforms);
+    if(use_ze3ra_algorithm){
+      calibrated_waveform_map[channel_key] = make_calibrated_waveforms_ze3ra(raw_waveforms);
+    } else if(use_root_algorithm){
+      calibrated_waveform_map[channel_key] = make_calibrated_waveforms_rootfit(raw_waveforms);
+    }
 
     if(make_led_waveforms){
       Log("Also making LED window waveforms for ADC channel " +
@@ -101,8 +153,11 @@ bool PhaseIIADCCalibrator::Execute() {
       std::vector<Waveform<unsigned short>> LEDWaveforms;
       this->make_raw_led_waveforms(channel_key,raw_waveforms,LEDWaveforms);
       raw_led_waveform_map.emplace(channel_key,LEDWaveforms);
-      calibrated_led_waveform_map[channel_key] = make_calibrated_waveforms(
-        LEDWaveforms);
+      if(use_ze3ra_algorithm){
+        calibrated_led_waveform_map[channel_key] = make_calibrated_waveforms_ze3ra(LEDWaveforms);
+      } else if(use_root_algorithm){
+        calibrated_led_waveform_map[channel_key] = make_calibrated_waveforms_rootfit(LEDWaveforms);
+      }
     }
   }
 
@@ -237,8 +292,9 @@ void PhaseIIADCCalibrator::ze3ra_baseline(
 
 }
 
+// version based on the ze3bra algorithm; assumes a DC offset is sufficient
 std::vector< CalibratedADCWaveform<double> >
-PhaseIIADCCalibrator::make_calibrated_waveforms(
+PhaseIIADCCalibrator::make_calibrated_waveforms_ze3ra(
   const std::vector< Waveform<unsigned short> >& raw_waveforms)
 {
 
@@ -347,4 +403,204 @@ std::map<unsigned long, std::vector<std::vector<int>>> PhaseIIADCCalibrator::loa
         1, verbosity);
   }
   return chanwindowmap;
+}
+
+// version based on a polynomial fit done via ROOT
+std::vector< CalibratedADCWaveform<double> >
+PhaseIIADCCalibrator::make_calibrated_waveforms_rootfit(
+  const std::vector< Waveform<unsigned short> >& raw_waveforms){
+  
+  // Apparently the input waveforms given to us represent all the minibuffers for one channel,
+  // obtained in one particular ADC readout. But I don't expect that matters much to us.
+  
+  // create a TGraph if we don't have one
+  if(gROOT->FindObject("calibrated_waveform_tgraph")==nullptr){
+    // we need to know how many points the tgraph will hold
+    num_waveform_points = raw_waveforms.front().Samples().size();
+    calibrated_waveform_tgraph = new TGraph(num_waveform_points);
+    // honestly i have no idea how to stop ROOT interfering with object deletion after drawing
+    // see https://root.cern.ch/root/htmldoc/guides/users-guide/ObjectOwnership.html
+    // and https://root.cern.ch/root/roottalk/roottalk01/2060.html
+    calibrated_waveform_tgraph->SetName("calibrated_waveform_tgraph");
+    gROOT->Add(calibrated_waveform_tgraph); // make gROOT know about it
+    //calibrated_waveform_tgraph->GetHistogram()->SetName("calibrated_waveform_tgraph_histo"); better to use this?
+  }
+  
+  // create a TF1 if we don't have one
+  if(calibrated_waveform_fit==nullptr){
+    // take waveform range to fit either from minibuffer length or user if less and >0
+    if((num_baseline_samples<=0) || (num_baseline_samples>(num_waveform_points-baseline_start_sample)))
+        num_baseline_samples = num_waveform_points;
+    if(baseline_start_sample<0) baseline_start_sample = 0;
+    calibrated_waveform_fit = new TF1("calibrated_waveform_fit",TString::Format("pol%d",baseline_fit_order),
+      baseline_start_sample,num_baseline_samples);
+  }
+  
+  // Loop over raw waveforms
+  std::vector< CalibratedADCWaveform<double> > calibrated_waveforms;
+  for (const auto& raw_waveform : raw_waveforms){
+    
+    // retrieve the raw samples
+    const std::vector<unsigned short>& raw_data = raw_waveform.Samples();
+    
+    // update our TGraph's datapoints with the new datapoints
+    for(int samplei=0; samplei<raw_data.size(); ++samplei){
+      calibrated_waveform_tgraph->SetPoint(samplei,samplei,raw_data.at(samplei));
+    }
+    
+    
+    // fit the graph
+    TFitResultPtr fit_result = calibrated_waveform_tgraph->Fit(calibrated_waveform_fit,"RCFS");
+    // R to use range of TF1
+    // F option uses minuit fitter for polN... better?
+    // C skips calculation of chi2 to save time
+    // S prevents conversion of the TFitResultPtr to a plain integer, which can only be used to check status
+    // in this case we need to check the status of the fit manually: just by converting the pointer
+    
+    if(draw_baseline_fit){
+      Log("PhaseIIADCCalibrator Tool: Drawing initial baseline fit",v_message,verbosity);
+      if(gROOT->FindObject("baselineFitCanvas")==nullptr){
+        baselineFitCanvas = new TCanvas("baselineFitCanvas");
+      } else {
+        baselineFitCanvas->cd();
+      }
+      calibrated_waveform_tgraph->Draw("AP");
+      calibrated_waveform_tgraph->GetHistogram()->SetDirectory(0); // canvas should not take ownership
+      baselineFitCanvas->Modified();
+      baselineFitCanvas->Update();
+      gSystem->ProcessEvents();
+      while(gROOT->FindObject("baselineFitCanvas")!=nullptr){
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+    }
+    
+    Int_t fit_succeeded = fit_result;
+    double baseline=0;
+    if(not fit_succeeded){
+      Log("PhaseIIADCCalibrator Tool: polynomial fit of baseline failed!",v_warning,verbosity);
+    } else {
+      baseline = fit_result->Value(0); // DC offset. FIXME this doesn't fully capture the correction applied
+    }
+    
+    // convert samples from ADC count to volts, and subtract the baseline fit if fit succeeded
+    std::vector<double> cal_data;
+    // keep track of the max and min
+    double cal_data_min=std::numeric_limits<double>::min();
+    double cal_data_max=std::numeric_limits<double>::max();
+    // loop over samples
+    for(uint samplei=0; samplei<raw_data.size(); ++samplei){
+      const unsigned short& sample = raw_data.at(samplei);
+      double baseline_val = (fit_succeeded) ? calibrated_waveform_fit->Eval(samplei) : 0;
+      double cal_val = (static_cast<double>(sample) - baseline_val)*ADC_TO_VOLT;
+      cal_data.push_back(cal_val);
+      
+      if(cal_val<cal_data_min) cal_data_min = cal_val;
+      if(cal_val>cal_data_max) cal_data_max = cal_val;
+    }
+    
+    // do we need to calculate sigma_baseline? Does anyone use it? TODO
+    double sigma_baseline = 0;
+    
+    // if we're worried about our baseline fit being skewed by the presence of large pulses,
+    // remove outliers and do the baseline fit again. We can skip this step if the range is sufficiently
+    // small that we know there aren't any pulses to skew the data
+    double cal_data_range = cal_data_max - cal_data_min;
+    if((redo_fit_without_outliers) && (cal_data_range>refit_threshold) && (fit_succeeded)){
+      // first make a note of the current fit parameters
+      std::vector<double> fitpars(baseline_fit_order+1);
+      for(uint orderi=0; orderi<(baseline_fit_order+1); ++orderi){
+        fitpars.at(orderi) = fit_result->Value(orderi);
+        //calibrated_waveform_fit->SetParameter(orderi,0); // clear initial vals...? maybe not necessary?
+      }
+      
+      // find and remove outliers
+      std::vector<double> non_outlier_points(cal_data);
+      // We'll use interquartile range as a definition of data excluding outliers.
+      // First we need to find the interquartile range. Do it the lazy way: with ROOT.
+      if(gROOT->FindObject("raw_datapoint_hist")==nullptr){
+        raw_datapoint_hist = new TH1D("raw_datapoint_hist","Raw Data Histogram",200,cal_data_min,cal_data_max);
+      } else {
+        raw_datapoint_hist->Reset(); raw_datapoint_hist->SetBins(200, cal_data_min, cal_data_max);
+      }
+      for(double& cal_sample : cal_data){ raw_datapoint_hist->Fill(cal_sample); }
+      // get the quantile thresholds. We'll take the interquartile range,
+      // although we could take arbitrary thresholds
+      std::vector<double> threshold_probabilities{0.25,0.75};
+      std::vector<double> threshold_values(threshold_probabilities.size());
+      // get the quantile thresholds. Note GetQuantiles asks for it's input arrays backwards...
+      raw_datapoint_hist->GetQuantiles(threshold_probabilities.size(),
+          threshold_values.data(),threshold_probabilities.data());
+      
+      // since we know it:
+      sigma_baseline = raw_datapoint_hist->GetStdDev();
+      
+      // now we can remove any outliers
+      auto newend = std::remove_if(non_outlier_points.begin(), non_outlier_points.end(),
+         [&threshold_values](double& dataval){
+           return ( (dataval<threshold_values.front()) || (dataval>threshold_values.back()) );
+         }
+      );
+      non_outlier_points.erase(newend, non_outlier_points.end());
+      
+      // update the contents of the TGraph
+      for(uint samplei=0; samplei<non_outlier_points.size(); ++samplei){
+        calibrated_waveform_tgraph->SetPoint(samplei,samplei,non_outlier_points.at(samplei));
+      }
+      
+      if(draw_baseline_fit){
+        Log("PhaseIIADCCalibrator Tool: Drawing outlier-subtracted baseline fit",v_message,verbosity);
+        if(gROOT->FindObject("baselineFitCanvas")==nullptr){
+          baselineFitCanvas = new TCanvas("baselineFitCanvas");
+        } else {
+          baselineFitCanvas->cd();
+        }
+        calibrated_waveform_tgraph->Draw("AP");
+        calibrated_waveform_tgraph->GetHistogram()->SetDirectory(0); // canvas should not take ownership
+        baselineFitCanvas->Modified();
+        baselineFitCanvas->Update();
+        gSystem->ProcessEvents();
+        while(gROOT->FindObject("baselineFitCanvas")!=nullptr){
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+      }
+      
+      // note that this time we have fewer datapoints than before,
+      // so we will need to restrict the range of our fit
+      calibrated_waveform_fit->SetRange(0, non_outlier_points.size());
+      calibrated_waveform_fit->SetMinimum(0);
+      calibrated_waveform_fit->SetMaximum(non_outlier_points.size());
+      
+      // now redo the fit as we did before but with the remaining data
+      fit_result = calibrated_waveform_tgraph->Fit(calibrated_waveform_fit,"RCFS");
+      fit_succeeded = fit_result;
+      if(not fit_succeeded){
+        Log("PhaseIIADCCalibrator Tool: polynomial re-fit of baseline failed!",v_warning,verbosity);
+      } else {
+        // get the new fit parameters and add them to the previous ones.
+        for(uint orderi=0; orderi<(baseline_fit_order+1); ++orderi){
+          double new_parameter_val = fit_result->Value(orderi) + fitpars.at(orderi);
+          calibrated_waveform_fit->SetParameter(orderi, new_parameter_val);
+        }
+        baseline = calibrated_waveform_fit->GetParameter(0); // DC offset. FIXME doesn't fully capture correction
+        
+        // update our calibrated values
+        for(uint samplei=0; samplei<raw_data.size(); ++samplei){
+          const unsigned short& sample = raw_data.at(samplei);
+          double baseline_val = calibrated_waveform_fit->Eval(samplei);
+          double cal_val = (static_cast<double>(sample) - baseline_val)*ADC_TO_VOLT;
+          cal_data.push_back(cal_val);
+        }
+      }
+      
+      // revert our fit range for the next one before we forget
+      calibrated_waveform_fit->SetRange(baseline_start_sample,num_baseline_samples);
+      calibrated_waveform_fit->SetMinimum(baseline_start_sample);
+      calibrated_waveform_fit->SetMaximum(num_baseline_samples);
+    }
+    
+    // construct the calibrated waveform
+    calibrated_waveforms.emplace_back(raw_waveform.GetStartTime(), cal_data, baseline, sigma_baseline);
+  }
+  
+  return calibrated_waveforms;
 }

--- a/UserTools/PhaseIIADCCalibrator/PhaseIIADCCalibrator.h
+++ b/UserTools/PhaseIIADCCalibrator/PhaseIIADCCalibrator.h
@@ -16,6 +16,12 @@
 #include "ANNIEconstants.h"
 #include <boost/algorithm/string.hpp>
 
+class TApplication;
+class TCanvas;
+class TGraph;
+class TF1;
+class TH1D;
+
 class PhaseIIADCCalibrator : public Tool {
 
   public:
@@ -34,8 +40,16 @@ class PhaseIIADCCalibrator : public Tool {
     void ze3ra_baseline(const Waveform<unsigned short> raw_data,
       double& baseline, double& sigma_baseline, size_t num_baseline_samples);
 
-    std::vector< CalibratedADCWaveform<double> > make_calibrated_waveforms(
+    std::vector< CalibratedADCWaveform<double> > make_calibrated_waveforms_ze3ra(
       const std::vector< Waveform<unsigned short> >& raw_waveforms);
+    
+    /// @brief Fit a polynomial to the baseline of each waveform.
+    std::vector< CalibratedADCWaveform<double> > make_calibrated_waveforms_rootfit(
+      const std::vector<Waveform<short unsigned int> >& raw_waveforms);
+    
+    bool use_ze3ra_algorithm;
+    bool use_root_algorithm;
+    
  
     void make_raw_led_waveforms(unsigned long channel_key,
       const std::vector< Waveform<unsigned short> > raw_waveforms,
@@ -60,4 +74,27 @@ class PhaseIIADCCalibrator : public Tool {
     size_t num_sub_waveforms;
     bool make_led_waveforms;
     std::string adc_window_db; 
+    
+    size_t num_waveform_points;
+    size_t baseline_start_sample;
+    
+    int baseline_fit_order;
+    bool redo_fit_without_outliers;
+    int refit_threshold; // mV range of the initial baseline subtracted waveform must be > this to trigger refit
+    
+    // ROOT stuff for drawing the fit of the baseline
+    bool draw_baseline_fit=false;
+    TApplication* rootTApp=nullptr;
+    TCanvas* baselineFitCanvas=nullptr;
+    TGraph* calibrated_waveform_tgraph=nullptr;
+    TF1* calibrated_waveform_fit=nullptr;
+    TH1D* raw_datapoint_hist=nullptr;
+    
+    // verbosity levels: if 'verbosity' < this level, the message type will be logged.
+    int v_error=0;
+    int v_warning=1;
+    int v_message=2;
+    int v_debug=3;
+    std::string logmessage;
+    int get_ok;
 };

--- a/UserTools/PhaseIIADCCalibrator/PhaseIIADCCalibrator.h
+++ b/UserTools/PhaseIIADCCalibrator/PhaseIIADCCalibrator.h
@@ -16,6 +16,8 @@
 #include "ANNIEconstants.h"
 #include <boost/algorithm/string.hpp>
 
+#include <sstream>
+
 class TApplication;
 class TCanvas;
 class TGraph;
@@ -80,7 +82,7 @@ class PhaseIIADCCalibrator : public Tool {
     
     int baseline_fit_order;
     bool redo_fit_without_outliers;
-    int refit_threshold; // mV range of the initial baseline subtracted waveform must be > this to trigger refit
+    double refit_threshold; // V range of the initial baseline subtracted waveform must be > this to trigger refit
     
     // ROOT stuff for drawing the fit of the baseline
     bool draw_baseline_fit=false;
@@ -89,6 +91,7 @@ class PhaseIIADCCalibrator : public Tool {
     TGraph* calibrated_waveform_tgraph=nullptr;
     TF1* calibrated_waveform_fit=nullptr;
     TH1D* raw_datapoint_hist=nullptr;
+    int drawcount=0;
     
     // verbosity levels: if 'verbosity' < this level, the message type will be logged.
     int v_error=0;


### PR DESCRIPTION
Rebase on updated Application.
This PR adds a second option for removing baseline from waveforms in the PhaseIIADCCalibrator tool. It uses a simple linear fit using ROOT, which accounts for variation in baseline across pulses, in contrast to the current ze3ra method, which assumes the baseline is constant. 
