### PR TITLE
MRDDataDecoder Update

### DIFF
--- a/DataModel/TriggerData.cpp
+++ b/DataModel/TriggerData.cpp
@@ -55,8 +55,7 @@ zmq::message_t ms2(&SequenceID,sizeof SequenceID, bencleanup2);
   //zmq::message_t ms9(&(TriggerMasks.at(0)), sizeof(uint32_t)*TriggerMasks.size(), bencleanup2);
 
   //zmq::message_t ms10(&(TriggerCounters.at(0)), sizeof(uint32_t)*TriggerCounters.size(), bencleanup2);
-zmq::message_t ms10(&(TimeStampData.at(0)), sizeof(uint32_t)*TimeStampD\│cp
-ata.size(), bencleanup2);   
+  zmq::message_t ms10(&(TimeStampData.at(0)), sizeof(uint32_t)*TimeStampData.size(), bencleanup2);   
   //  std::cout<<"d0.12"<<std::endl;
 
   //  std::cout<<"data.size = "<<Data.size()<<std::endl;

--- a/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.h
+++ b/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.h
@@ -35,7 +35,7 @@ class ANNIEEventBuilder: public Tool {
   void BuildANNIEEventRunInfo(int RunNum, int SubRunNum, int RunType, uint64_t RunStartTime);  //Loads run level information, as well as the entry number
   void BuildANNIEEventTank(uint64_t CounterTime, std::map<std::vector<int>, std::vector<uint16_t>> WaveMap);
   void BuildANNIEEventMRD(std::vector<std::pair<unsigned long,int>> MRDHits, 
-        unsigned long MRDTimeStamp, std::string MRDTriggerType);
+        unsigned long MRDTimeStamp, std::string MRDTriggerType, int beam_tdc, int cosmic_tdc);
   void CalculateSlidWindows(std::vector<uint64_t> FirstTimestampSet,
         std::vector<uint64_t> SecondTimestampSet, int shift, double& tmean, double& tvar);
   void CardIDToElectronicsSpace(int CardID, int &CrateNum, int &SlotNum);
@@ -59,6 +59,8 @@ class ANNIEEventBuilder: public Tool {
   //####### MAPS THAT ARE LOADED FROM OR CONTAIN INFO FROM THE CSTORE (FROM MRD/PMT DECODING) #########
   std::map<uint64_t, std::vector<std::pair<unsigned long, int> > > MRDEvents;  //Key: {MTCTime}, value: "WaveMap" with key (CardID,ChannelID), value FinishedWaveform
   std::map<uint64_t, std::string>  TriggerTypeMap;  //Key: {MTCTime}, value: string noting what type of trigger occured for the event 
+  std::map<uint64_t, int> MRDBeamLoopbackMap;  //Key: {MTCTime}, value: beam loopback TDC
+  std::map<uint64_t, int> MRDCosmicLoopbackMap;  //Key: {MTCTime}, value: cosmic loopback TDC
   std::map<uint64_t, std::map<std::vector<int>, std::vector<uint16_t> > >* InProgressTankEvents;  //Key: {MTCTime}, value: map of in-progress PMT trigger decoding from WaveBank
   std::map<uint64_t, std::map<std::vector<int>, std::vector<uint16_t> > > FinishedTankEvents;  //Key: {MTCTime}, value: map of fully-built waveforms from WaveBank
   Store RunInfoPostgress;   //Has Run number, subrun number, etc...

--- a/UserTools/MRDDataDecoder/MRDDataDecoder.cpp
+++ b/UserTools/MRDDataDecoder/MRDDataDecoder.cpp
@@ -43,7 +43,7 @@ bool MRDDataDecoder::Execute(){
     return true;
   }
 
-  
+
   /////////////////// getting MRD Data ////////////////////
   Log("MRDDataDecoder Tool: Accessing MRDData from CStore",v_message,verbosity); 
   m_data->CStore.Get("MRDData",mrddata);
@@ -52,6 +52,13 @@ bool MRDDataDecoder::Execute(){
   unsigned long timestamp = mrddata->TimeStamp;    //in ms since 1970/1/1
   std::vector<std::pair<unsigned long, int>> ChankeyTimePairs;
   MRDEvents.emplace(timestamp,ChankeyTimePairs);
+  
+  bool cosmic_loopback = false;
+  bool beam_loopback = false;
+  int cosmic_tdc = -1;
+  int beam_tdc = -1;
+  std::vector<int> CrateSlotChannel_Beam{7,11,15};
+  std::vector<int> CrateSlotChannel_Cosmic{7,11,14};
     
   //For each entry, loop over all crates and get data
   for (unsigned int i_data = 0; i_data < mrddata->Crate.size(); i_data++){
@@ -61,14 +68,20 @@ bool MRDDataDecoder::Execute(){
     int hittimevalue = mrddata->Value.at(i_data);
     std::vector<int> CrateSlotChannel{crate,slot,channel};
     unsigned long chankey = MRDCrateSpaceToChannelNumMap[CrateSlotChannel];
-    if (chankey !=0){
+    if (CrateSlotChannel != CrateSlotChannel_Beam && CrateSlotChannel != CrateSlotChannel_Cosmic){
       std::pair <unsigned long,int> keytimepair(chankey,hittimevalue);  //chankey will be 0 when looking at loopback channels that don't have an entry in the mapping-->skip
       MRDEvents[timestamp].push_back(keytimepair);
     }
-    if (crate == 7 && slot == 11 && channel == 14) mrdTriggertype = "Cosmic";   //FIXME: don't hard-code the trigger channels?
-    if (crate == 7 && slot == 11 && channel == 15) mrdTriggertype = "Beam";     //FIXME: don't hard-code the trigger channels?
+    if (crate == 7 && slot == 11 && channel == 14) {cosmic_loopback=true; cosmic_tdc = hittimevalue;}   //FIXME: don't hard-code the trigger channels?
+    if (crate == 7 && slot == 11 && channel == 15) {beam_loopback=true; beam_tdc = hittimevalue;}     //FIXME: don't hard-code the trigger channels?
   }
   
+  if (beam_loopback) mrdTriggertype = "Beam";
+  if (cosmic_loopback) mrdTriggertype = "Cosmic";      //prefer cosmic loopback over beam loopback (cosmic event will always also have a beam loopback entry)
+
+  CosmicLoopbackMap.emplace(timestamp,cosmic_tdc);
+  BeamLoopbackMap.emplace(timestamp,beam_tdc);
+
   //Entry processing done.  Label the trigger type and increment index
   TriggerTypeMap.emplace(timestamp,mrdTriggertype);
 
@@ -84,6 +97,14 @@ bool MRDDataDecoder::Execute(){
   m_data->CStore.Get("MRDEventTriggerTypes",CStoreTriggerTypeMap);
   CStoreTriggerTypeMap.insert(TriggerTypeMap.begin(),TriggerTypeMap.end());
   m_data->CStore.Set("MRDEventTriggerTypes",CStoreTriggerTypeMap);
+ 
+  m_data->CStore.Get("MRDBeamLoopback",CStoreBeamLoopbackMap);
+  CStoreBeamLoopbackMap.insert(BeamLoopbackMap.begin(),BeamLoopbackMap.end());
+  m_data->CStore.Set("MRDBeamLoopback",CStoreBeamLoopbackMap);
+ 
+  m_data->CStore.Get("MRDCosmicLoopback",CStoreCosmicLoopbackMap);
+  CStoreCosmicLoopbackMap.insert(CosmicLoopbackMap.begin(),CosmicLoopbackMap.end());
+  m_data->CStore.Set("MRDCosmicLoopback",CStoreCosmicLoopbackMap);
   
   m_data->CStore.Set("NewMRDDataAvailable",true);
 
@@ -96,6 +117,8 @@ bool MRDDataDecoder::Execute(){
   std::cout << "MRD EVENT CSTORE ENTRIES SET SUCCESSFULLY.  Clearing MRDEvents map from this file." << std::endl;
   MRDEvents.clear();
   TriggerTypeMap.clear();
+  BeamLoopbackMap.clear();
+  CosmicLoopbackMap.clear();
 
   ////////////// END EXECUTE LOOP ///////////////
   return true;
@@ -103,6 +126,6 @@ bool MRDDataDecoder::Execute(){
 
 
 bool MRDDataDecoder::Finalise(){
-  std::cout << "MRDDataDecoder tool exitting" << std::endl;
+  Log("MRDDataDecoder tool exitting",v_message,verbosity);
   return true;
 }

--- a/UserTools/MRDDataDecoder/MRDDataDecoder.h
+++ b/UserTools/MRDDataDecoder/MRDDataDecoder.h
@@ -44,6 +44,10 @@ class MRDDataDecoder: public Tool {
   //Maps that store completed waveforms from cards
   std::map<uint64_t, std::vector<std::pair<unsigned long, int> > > MRDEvents;  //Key: {MTCTime}, value: "WaveMap" with key (CardID,ChannelID), value FinishedWaveform
   std::map<uint64_t, std::vector<std::pair<unsigned long, int> > > CStoreMRDEvents;  //Key: {MTCTime}, value: "WaveMap" with key (CardID,ChannelID), value FinishedWaveform
+  std::map<uint64_t, int> BeamLoopbackMap;  //KEY: {MTCTime}, value: Beam loopback TDC value
+  std::map<uint64_t, int> CosmicLoopbackMap;  //KEY: {MTCTime}, value: Cosmic loopback TDC value
+  std::map<uint64_t, int> CStoreBeamLoopbackMap;  //KEY: {MTCTime}, value: Beam loopback TDC value
+  std::map<uint64_t, int> CStoreCosmicLoopbackMap;  //KEY: {MTCTime}, value: Cosmic loopback TDC value
   std::map<uint64_t, std::string>  TriggerTypeMap;  //Key: {MTCTime}, value: string noting what type of trigger occured for the event 
   std::map<uint64_t, std::string>  CStoreTriggerTypeMap;  //Key: {MTCTime}, value: string noting what type of trigger occured for the event 
 

--- a/UserTools/MonitorReceive/README.md
+++ b/UserTools/MonitorReceive/README.md
@@ -2,20 +2,21 @@
 
 MonitorReceive
 
-This is used to collect remote monitoring data
+The MonitorReceive tool is used to continuously collect remote monitoring data.
 
 ## Data
 
-Describe any data formats MonitorReceive creates, destroys, changes, or analyzes. E.G.
+MonitorReceive is continuously running and checks whether new data files have been produced. If so, it then provides the raw data to the Monitoring tools as follows: The tool initializes the raw data file as the BoostStore `indata` with the current raw data file, obtains the two sub-BoostStores `PMTData` and `MRDData` from `indata` and stores the `PMTData` and `MRDData` BoostStores in respective common BoostStores:
 
-**RawLAPPDData** `map<Geometry, vector<Waveform<double>>>`
-* Takes this data from the `ANNIEEvent` store and finds the number of peaks
+* `m_data->Stores["PMTData"]->Set("FileData",PMTData,false)`
+* `m_data->Stores["CCData"]->Set("FileData",MRDData,false)`
+
+The keywords for the BoostStores is "FileData" in both cases. The monitoring files can then obtain the BoostStores from there and process the data.
 
 ## Configuration
 
-Describe any configuration variables for MonitorReceive.
+The MonitorReceive tool will note the path where to store the monitoring plots in the CStore, so that the subsequent Monitoring tools can obtain the path and use it. The user can configure this path via the configuration variable `OutPath`.
 
 ```
-param1 value1
-param2 value2
+OutPath ./monitoringplots/
 ```

--- a/configfiles/DataDecoderMRD/LoadRawDataConfig
+++ b/configfiles/DataDecoderMRD/LoadRawDataConfig
@@ -1,5 +1,5 @@
 verbosity 5
 BuildType MRD
 Mode FileList
-InputFile /annie/app/users/pershint/Processing/ToolAnalysis/configfiles/DataDecoderMRD/my_files.txt
-DummyRunInfo 0
+InputFile ./configfiles/DataDecoderMRD/my_files.txt
+DummyRunInfo 1

--- a/configfiles/DataDecoderMRD/MRDDataDecoderConfig
+++ b/configfiles/DataDecoderMRD/MRDDataDecoderConfig
@@ -1,1 +1,1 @@
-verbosity 5
+verbosity 0

--- a/configfiles/DataDecoderMRD/my_files.txt
+++ b/configfiles/DataDecoderMRD/my_files.txt
@@ -1,1 +1,11 @@
-/annie/app/users/mnieslon/MyToolAnalysis3/MRDTest28commonstopp0
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p0
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p1
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p10
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p2
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p3
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p4
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p5
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p6
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p7
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p8
+/pnfs/annie/persistent/users/mnieslon/data/rawdata/beam/RAWDataR1604S0p9


### PR DESCRIPTION
The `MRDDataDecoder` tool was updated to fix a bug that prevented the veto channel with channelkey 0 to be decoded. Furthermore, the TDC values of beam and cosmic loopback channels are now transmitted to the `ANNIEEventBuilder` and stored in the ANNIEEvent BoostStore.

A typo in one line of `DataModel/TriggerData.cpp` was fixed that prevented proper compiling. 