### PR TITLE
fix to the TrackCombiner tool, updates to MrdDistributions and MrdEfficiency

### DIFF
--- a/DataModel/Particle.h
+++ b/DataModel/Particle.h
@@ -136,13 +136,13 @@ class MCParticle : public Particle {
 	public:
 	
 	MCParticle() : Particle(0, 0., 0., Position(), Position(), 0., 0., Direction(), 0.,
-				tracktype::UNCONTAINED), ParticleID(0), ParentPdg(0), StartsInFiducialVolume(false), TrackAngleX(0), TrackAngleY(0), TrackAngleFromBeam(0), EntersTank(false), TankEntryPoint(Position()), ExitsTank(false), TankExitPoint(Position()), TrackLengthInTank(0), EntersMrd(false), MrdEntryPoint(Position()), ExitsMrd(false), MrdExitPoint(Position()), PenetratesMrd(false), TrackLengthInMrd(0), MrdPenetration(0), MrdLayersPenetrated(0), MrdEnergyLoss(0), Flag(0) {serialise=true;}
+				tracktype::UNCONTAINED), ParticleID(0), ParentPdg(0), StartsInFiducialVolume(false), TrackAngleX(0), TrackAngleY(0), TrackAngleFromBeam(0), EntersTank(false), TankEntryPoint(Position()), ExitsTank(false), TankExitPoint(Position()), TrackLengthInTank(0), EntersMrd(false), MrdEntryPoint(Position()), ExitsMrd(false), MrdExitPoint(Position()), PenetratesMrd(false), TrackLengthInMrd(0), MrdPenetration(0), MrdLayersPenetrated(0), MrdEnergyLoss(0), Flag(0), MCTriggerNum(0) {serialise=true;}
 	
 	MCParticle(int pdg, double sttE, double stpE, Position sttpos, Position stppos, 
 	  double sttt, double stpt, Direction startdir, double len, tracktype tracktypein,
-	  int partid, int parentpdg, int flagid) 
+	  int partid, int parentpdg, int flagid, int triggernum)
 	: Particle(pdg, sttE, stpE, sttpos, stppos, sttt, stpt, startdir, len, tracktypein), 
-	  ParticleID(partid), ParentPdg(parentpdg), StartsInFiducialVolume(false), TrackAngleX(0), TrackAngleY(0), TrackAngleFromBeam(0), EntersTank(false), TankEntryPoint(Position()), ExitsTank(false), TankExitPoint(Position()), TrackLengthInTank(0), EntersMrd(false), MrdEntryPoint(Position()), ExitsMrd(false), MrdExitPoint(Position()), PenetratesMrd(false), TrackLengthInMrd(0), MrdPenetration(0), MrdLayersPenetrated(0), MrdEnergyLoss(0), Flag(flagid)
+	  ParticleID(partid), ParentPdg(parentpdg), StartsInFiducialVolume(false), TrackAngleX(0), TrackAngleY(0), TrackAngleFromBeam(0), EntersTank(false), TankEntryPoint(Position()), ExitsTank(false), TankExitPoint(Position()), TrackLengthInTank(0), EntersMrd(false), MrdEntryPoint(Position()), ExitsMrd(false), MrdExitPoint(Position()), PenetratesMrd(false), TrackLengthInMrd(0), MrdPenetration(0), MrdLayersPenetrated(0), MrdEnergyLoss(0), Flag(flagid), MCTriggerNum(triggernum)
 	  {
 		serialise=true;
 		// override Hit tracktype
@@ -160,6 +160,7 @@ class MCParticle : public Particle {
 	inline int GetParticleID(){return ParticleID;}
 	inline int GetParentPdg(){return ParentPdg;}
 	inline int GetFlag(){return Flag;}
+	inline int GetMCTriggerNum(){return MCTriggerNum;}
 	
 	inline bool GetStartsInFiducialVolume(){return StartsInFiducialVolume;}
 	
@@ -187,6 +188,7 @@ class MCParticle : public Particle {
 	inline void SetParticleID(int partidin){ParticleID=partidin;}
 	inline void SetParentPdg(int parentpdgin){ParentPdg=parentpdgin;}
 	inline void SetFlag(int flagidin){Flag=flagidin;}
+	inline void SetMCTriggerNum(int triggernumin){MCTriggerNum=triggernumin;}
 	
 	inline void SetStartsInFiducialVolume(bool iStartsInFiducialVolume){StartsInFiducialVolume = iStartsInFiducialVolume;}
 	
@@ -239,6 +241,7 @@ class MCParticle : public Particle {
 		std::cout<<"StartStopType : "; PrintStartStopType(StartStopType);
 		std::cout<<"ParticleID : "<<ParticleID<<std::endl;
 		std::cout<<"ParentPdg : "<<ParentPdg<<std::endl;
+		std::cout<<"MCTriggerNum : "<<MCTriggerNum<<std::endl;
 		std::cout<<"Parent Particle Name : "<<PdgToString(ParentPdg)<<std::endl;
 		
 		std::cout <<"StartsInFiducialVolume = "<<StartsInFiducialVolume <<std::endl;
@@ -268,6 +271,7 @@ class MCParticle : public Particle {
 	int ParticleID;
 	int ParentPdg;
 	int Flag;
+	int MCTriggerNum; // trigger window in which the particle was created
 	
 	bool StartsInFiducialVolume;
 	

--- a/UserTools/FindMrdTracks/FindMrdTracks.cpp
+++ b/UserTools/FindMrdTracks/FindMrdTracks.cpp
@@ -27,7 +27,7 @@ bool FindMrdTracks::Initialise(std::string configfile, DataModel &data){
 	outputdir = "./MRDPlots/";
 	triggertype = "Cosmic";
 	outputfile = "mrdtrackfile";
-
+	
 	// get configuration variables for this tool
 	m_variables.Get("verbosity",verbosity);
 	m_variables.Get("IsData",isData);
@@ -37,14 +37,14 @@ bool FindMrdTracks::Initialise(std::string configfile, DataModel &data){
 	m_variables.Get("WriteTracksToFile",writefile);
 	m_variables.Get("SelectTriggerType",triggertype_selection);
 	m_variables.Get("TriggerType",triggertype);
-
+	
 	if (triggertype == "NoLoopback") triggertype = "No Loopback";
 	std::cout <<"User Trigger type: "<<triggertype<<std::endl;
 	if (isData) {
 		Log("FindMrdTracks tool: Selected DrawTruthTracks in configfile for a data file! Setting DrawTruthTracks to false",v_error,verbosity);	
 		DrawTruthTracks = false;		//if looking at data, no possiblity to draw truth tracks
 	}
-
+	
 	// create a store for holding MRD tracks to pass to downstream Tools
 	// will be a single entry BoostStore containing a vector of single entry BoostStores
 	m_data->Stores["MRDTracks"] = new BoostStore(true,0);
@@ -64,11 +64,10 @@ bool FindMrdTracks::Initialise(std::string configfile, DataModel &data){
 	// put the pointer in the CStore, so it can be retrieved by MrdTrackPlotter tool Init
 	intptr_t subevptr = reinterpret_cast<intptr_t>(SubEventArray);
 	m_data->CStore.Set("MrdSubEventTClonesArray",subevptr);
-	m_data->CStore.Get("mrdpmtid_to_channelkey",mrdpmtid_to_channelkey);
+	m_data->CStore.Get("mrd_tubeid_to_channelkey",mrd_tubeid_to_channelkey);
 	// pass this to TrackCombiner
 	m_data->CStore.Set("DrawMrdTruthTracks",DrawTruthTracks);
 	
-
 	return true;
 }
 
@@ -99,30 +98,30 @@ bool FindMrdTracks::Execute(){
 	if (not get_ok){
 		Log("FindMrdTracks: Did not find MRDTriggerType in ANNIEEvent. Please check the settings in MRDDataDecoder+BuildANNIEEvent/LoadWCSim?",v_error,verbosity);
 	}
-        Log("FindMrdTracks tool: MRDTriggertype is "+MRDTriggertype+" (from ANNIEEvent store)",v_debug,verbosity);
-
+	Log("FindMrdTracks tool: MRDTriggertype is "+MRDTriggertype+" (from ANNIEEvent store)",v_debug,verbosity);
+	
 	// Get time cluster objects from CStore
-	// MRDTime Clusters object should be created by previous tool in ToolChain (TimeClustering) 
+	// MRDTime Clusters object should be created by previous tool in ToolChain (TimeClustering)
 	get_ok = m_data->CStore.Get("MrdTimeClusters",MrdTimeClusters);
-        if (not get_ok) {
-                Log("FindMrdTracks: Did not find MrdTimeClusters in CStore. Did you run the tool TimeClustering beforehand?",v_error,verbosity);
-                return true;  //it can happen that an event does not have a TDCData object if MRD is not hit
-        }
+	if (not get_ok) {
+		Log("FindMrdTracks: Did not find MrdTimeClusters in CStore. Did you run the tool TimeClustering beforehand?",v_error,verbosity);
+		return true;  //it can happen that an event does not have a TDCData object if MRD is not hit
+	}
 	int NumMrdTimeClusters;
-        get_ok = m_data->CStore.Get("NumMrdTimeClusters",NumMrdTimeClusters);
-        if (not get_ok){
-                Log("FindMrdTracks: Did not find NumMrdTimeClusters in CStore. Did you run the tool TimeClustering beforehand?",v_error,verbosity);
-                return false;
-        }
-        Log("FindMrdTracks tool: Got MrdTimeClusters of size "+std::to_string(MrdTimeClusters.size())+", with "+std::to_string(NumMrdTimeClusters)+" MrdTimeClusters.",v_message,verbosity);	
-
+	get_ok = m_data->CStore.Get("NumMrdTimeClusters",NumMrdTimeClusters);
+	if (not get_ok){
+		Log("FindMrdTracks: Did not find NumMrdTimeClusters in CStore. Did you run the tool TimeClustering beforehand?",v_error,verbosity);
+		return false;
+	}
+	Log("FindMrdTracks tool: Got MrdTimeClusters of size "+std::to_string(MrdTimeClusters.size())+", with "+std::to_string(NumMrdTimeClusters)+" MrdTimeClusters.",v_message,verbosity);
+	
 	// FIXME align types until we update MRDTrackClass/MRDSubEventClass
 	currentfilestring=MCFile;
 	runnum=(int)RunNumber;
 	subrunnum=(int)SubrunNumber;
 	eventnum=(int)EventNumber;
 	triggernum=(int)MCTriggernum;
-
+	
 	// TODO: add MCEventNum to MRDTrackClass/MRDSubEventClass
 	//
 	// Setup the vector to store the information which subevent had a track (for downstream plotting tools)
@@ -135,43 +134,43 @@ bool FindMrdTracks::Execute(){
 		
 	}
 	
-
+	
 	//verbose check whether the obtained MRD data seems sensible, MRDTimeClusters contains the indices of events belonging to that subevent
-	for (unsigned int i_cluster = 0; i_cluster < MrdTimeClusters.size(); i_cluster++){
-		if (verbosity >= v_debug) std::cout << "FindMrdTracks tool: Cluster " << i_cluster+1 << ", MrdTimeClusters.at(i_cluster).size() = " << MrdTimeClusters.at(i_cluster).size() << std::endl;
-		for (unsigned int i_entry = 0; i_entry < MrdTimeClusters.at(i_cluster).size(); i_entry++){
-			if (verbosity >= v_debug) std::cout <<MrdTimeClusters.at(i_cluster).at(i_entry)<<", ";
+	if(verbosity >= v_debug){
+		for (unsigned int i_cluster = 0; i_cluster < MrdTimeClusters.size(); i_cluster++){
+			std::cout << "FindMrdTracks tool: Cluster " << i_cluster+1 << ", MrdTimeClusters.at(i_cluster).size() = " << MrdTimeClusters.at(i_cluster).size() << std::endl;
+			for (unsigned int i_entry = 0; i_entry < MrdTimeClusters.at(i_cluster).size(); i_entry++){
+				std::cout <<MrdTimeClusters.at(i_cluster).at(i_entry)<<", ";
+			}
+			std::cout << std::endl;
 		}
-		if (verbosity >= v_debug) std::cout << std::endl;
 	}
-
+	
 	// get the time and pmts digits from the CStore and put them into separate vectors used by the track finder, clear those containers
 	mrddigittimesthisevent.clear();
 	mrddigitpmtsthisevent.clear();
-	mrddigitchargesthisevent.clear();	
-
-
+	mrddigitchargesthisevent.clear();
+	
 	///////////////////////////
 	// now do the track finding
 	
 	Log("FindMrdTracks tool: Searching for MRD tracks in event "+std::to_string(eventnum),v_message,verbosity);
-
+	
 /*
 if your class contains pointers, use TrackArray.Clear("C"). You MUST then provide a Clear() method in your class that properly performs clearing and memory freeing. (or "implements the reset procedure for pointer objects")
  see https://root.cern.ch/doc/master/classTClonesArray.html#a025645e1e80ea79b43a08536c763cae2
 */
 	int mrdeventcounter=0;
-
+	
 	//select only specific trigger types if prompted to do so
 	//this is useful if one wants to look at e.g. only beam events for the analysis or only at cosmic events for the MRD paddle calibration
 	
 	if ((triggertype_selection && MRDTriggertype == triggertype) || !triggertype_selection ){
-
-
+		
 		// no clusters found
 		if (MrdTimeClusters.size() == 0){
 			nummrdsubeventsthisevent=0;
-			nummrdtracksthisevent=0;	
+			nummrdtracksthisevent=0;
 			if(writefile){
 				nummrdsubeventsthiseventb->Fill();
 				nummrdtracksthiseventb->Fill();
@@ -190,15 +189,15 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 			// skip remainder
 			// ======================================================================================
 		}
-
+		
 		m_data->CStore.Get("MrdDigitTimes",mrddigittimesthisevent);
 		m_data->CStore.Get("MrdDigitPmts",mrddigitpmtsthisevent);
-		m_data->CStore.Get("MrdDigitCharges",mrddigitchargesthisevent);	
+		m_data->CStore.Get("MrdDigitCharges",mrddigitchargesthisevent);
 		double eventendtime = *std::max_element(mrddigittimesthisevent.begin(),mrddigittimesthisevent.end());
-
+		
 		// LOOP THROUGH MRD SUBEVENTS
 		// ===========================
-			
+		
 		std::vector<int> digitidsinasubevent;
 		std::vector<int> tubeidsinasubevent;
 		std::vector<double> digitqsinasubevent;
@@ -206,32 +205,32 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 		std::vector<int> digitnumtruephots;
 		std::vector<int> particleidsinasubevent;
 		std::vector<double> photontimesinasubevent;
-
+		
 		Log("FindMrdTracks tool: "+std::to_string(MrdTimeClusters.size())+" subevents this event!",v_message,verbosity);
-	
+		
 		// Now we need to sort the digits into the subevents they belong to:
 		// Loop over subevents
-
+		
 		int mrdtrackcounter=0;   // not all the subevents will have a track
 		
 		for(unsigned int thiscluster=0; thiscluster<MrdTimeClusters.size(); thiscluster++){
-
+			
 			std::vector<int> single_mrdcluster = MrdTimeClusters.at(thiscluster);
 			int numdigits = single_mrdcluster.size();
-
+			
 			for(int thisdigit=0;thisdigit<numdigits;thisdigit++){
 				int digit_value = single_mrdcluster.at(thisdigit); // digit value is index of digit in TDC hits
 				// TimeClustering tool builds clusters from both MRD and Veto hits,
 				// but we cannot have veto PMTs in the MrdTrackLib reco algorithms
 				// (they would be out of bounds in the expected maps...)
 				// so convert back to channelkey, get the Detector, and check whether it's MRD or Veto
-				int wcsimid = mrddigitpmtsthisevent.at(digit_value);
-				if(mrdpmtid_to_channelkey.count(wcsimid)==0){
+				int wcsimid = mrddigitpmtsthisevent.at(digit_value)+1;
+				if(mrd_tubeid_to_channelkey.count(wcsimid)==0){
 					Log("FindMrdTracks tool: Error! WCSimID "+to_string(wcsimid)
-						+" was not in the mrdpmtid_to_channelkey map!",v_error,verbosity);
+						+" was not in the mrd_tubeid_to_channelkey map!",v_error,verbosity);
 					continue;
 				} else {
-					unsigned long chankey = mrdpmtid_to_channelkey.at(wcsimid);
+					unsigned long chankey = mrd_tubeid_to_channelkey.at(wcsimid);
 					Detector* thedetector = geo->ChannelToDetector(chankey);
 					if(thedetector==nullptr){
 						Log("FindMrdTracks Tool: Null detector in TDCData!",v_error,verbosity);
@@ -243,19 +242,19 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 				tubeidsinasubevent.push_back(mrddigitpmtsthisevent.at(digit_value));
 				digittimesinasubevent.push_back(mrddigittimesthisevent.at(digit_value));
 				digitqsinasubevent.push_back(mrddigitchargesthisevent.at(digit_value));
-
+				
 			}
-
+			
 			digitnumtruephots.assign(digittimesinasubevent.size(),0);      // FIXME replacement of above
 			photontimesinasubevent.assign(digittimesinasubevent.size(),0); // FIXME replacement of above
-			particleidsinasubevent.assign(digittimesinasubevent.size(),0); // FIXME replacement of above		
-
+			particleidsinasubevent.assign(digittimesinasubevent.size(),0); // FIXME replacement of above
+			
 			// Just initialize MCTruth variables, as before
 			std::vector<std::pair<TVector3,TVector3>> truetrackvertices;
 			std::vector<Int_t> truetrackpdgs;
-
+			
 			// In case we want to overlay the truth track in MC, also load the MCParticle information
-
+			
 			if (DrawTruthTracks){
 				int numtracks = MCParticles->size();
 				// a vector to record the subevent number for each track, to know if we've allocated it yet.
@@ -263,7 +262,7 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 				std::vector<float> cluster_starttimes;
 				m_data->CStore.Get("ClusterStartTimes",cluster_starttimes);
 				float endtime = (thiscluster<(MrdTimeClusters.size()-1)) ?  cluster_starttimes.at(thiscluster+1) : (eventendtime+1.);
-		
+				
 				for(int truetracki=0; truetracki<numtracks; truetracki++){
 					MCParticle nextrack = MCParticles->at(truetracki);
 					if((subtrackthisevent.at(truetracki)<0)&&(nextrack.GetStartTime()<endtime)
@@ -281,11 +280,11 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 			
 			Log("FindMrdTracks tool: Constructing subevent "+std::to_string(mrdeventcounter)+" with "+std::to_string(digitidsinasubevent.size())+" digits",v_message,verbosity);
 			cMRDSubEvent* currentsubevent = new((*SubEventArray)[mrdeventcounter]) cMRDSubEvent(mrdeventcounter, currentfilestring, runnum, eventnum, triggernum, digitidsinasubevent, tubeidsinasubevent, digitqsinasubevent, digittimesinasubevent, digitnumtruephots, photontimesinasubevent, particleidsinasubevent, truetrackvertices, truetrackpdgs);
-			if (currentsubevent->GetTracks()->size() > 0) track_subevs.push_back(mrdeventcounter);	//annotate the current subevent number to have a track
+			if (currentsubevent->GetTracks()->size() > 0) track_subevs.push_back(mrdeventcounter); //annotate the current subevent number to have a track
 			mrdeventcounter++;
 			mrdtrackcounter+=currentsubevent->GetTracks()->size();
 			Log("FindMrdTracksData: Subevent "+std::to_string(thiscluster)+" found "+std::to_string(currentsubevent->GetTracks()->size())+" tracks",v_message,verbosity);
-
+			
 			digitidsinasubevent.clear();
 			tubeidsinasubevent.clear();
 			digitqsinasubevent.clear();
@@ -293,9 +292,9 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 			particleidsinasubevent.clear();
 			photontimesinasubevent.clear();
 			digitnumtruephots.clear();
-
+		
 		}
-
+		
 		nummrdsubeventsthisevent=mrdeventcounter;
 		nummrdtracksthisevent=mrdtrackcounter;
 		
@@ -304,12 +303,12 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 			nummrdtracksthiseventb->Fill();
 			subeventsinthiseventb->Fill();
 		}
-			
+		
 	} else {
 		//did not pass the triggertype selection cut
- 	
+		
 		nummrdsubeventsthisevent=0;
-                nummrdtracksthisevent=0;
+		nummrdtracksthisevent=0;
 		if(writefile){
 			nummrdsubeventsthiseventb->Fill();
 			nummrdtracksthiseventb->Fill();
@@ -319,18 +318,18 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 			mrdtree->Write("",TObject::kOverwrite);
 			gROOT->cd();
 		}
-
+		
 		Log("FindMrdTracks tool: Trigger type selection cuts were not passed; returning",v_message,verbosity);
 		return true;
-
+		
 		// XXX Note for other tools: we've written files and updated BoostStore SubEvent/Track counts to 0.
 		// XXX Other tools should check these before processing the MrdTracks BoostStore or MrdSubEventTClonesArray
 		// XXX since those are not necessarily cleared!
 		// skip remainder
 		// =====================================================================================
-
+	
 	}
-
+	
 	//if(eventnum==735){ assert(false); }
 	//if(nummrdtracksthisevent) std::this_thread::sleep_for (std::chrono::seconds(5));
 	
@@ -473,6 +472,9 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 //			thisTrackAsBoostStore->Set("DigiNumPhots",atrack->GetDigiNumPhots());
 //			thisTrackAsBoostStore->Set("DigiPhotTs",atrack->GetDigiPhotTs());
 //			thisTrackAsBoostStore->Set("DigiPhotParents",atrack->GetDigiPhotParents());
+			
+			// differentiate tracks found with this algorithm from those found by the TrackCombiner tool
+			thisTrackAsBoostStore->Set("LongTrack",1);
 		}
 	}
 	std::cout <<"Setting MRDTracks"<<std::endl;
@@ -486,20 +488,19 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 	std::cout <<"Setting subevptr in CStore"<<std::endl;
 	intptr_t subevptr = reinterpret_cast<intptr_t>(SubEventArray);
 	m_data->CStore.Set("MrdSubEventTClonesArray",subevptr);
-
+	
 	// Set the information which subevent had a track
 	m_data->CStore.Set("TracksSubEvs",track_subevs);
 	
 	//The following is just for debugging purposes
 	//std::cout <<"FindMrdTracks tool: List of objects (End of Execute): "<<std::endl;
-        //gObjectTable->Print();
-
+	//gObjectTable->Print();
+	
 	return true;
 }
 
 bool FindMrdTracks::Finalise(){
-
-
+	
 	// close output file
 	if(mrdtrackfile){
 		mrdtrackfile->Close();

--- a/UserTools/FindMrdTracks/FindMrdTracks.h
+++ b/UserTools/FindMrdTracks/FindMrdTracks.h
@@ -38,11 +38,11 @@ private:
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	std::string outputdir="";
 	bool writefile=false;
-        std::string outputfile;
+	std::string outputfile;
 	bool triggertype_selection;
 	std::string triggertype;
 	bool isData;
-
+	
 	// Variables retrieved from ANNIEEVENT
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	std::string MCFile;      //-> currentfilestring
@@ -53,17 +53,16 @@ private:
 	uint64_t MCEventNum;    // not yet in MRDTrackClass 
 	Geometry* geo=nullptr;  // for num MRD PMTs
 	int numvetopmts=0;      // current method for separating veto / mrd pmts in TDCData
-	std::string file_chankeymap;	
-
-
+	std::string file_chankeymap;
+	
 	// From the CStore, for converting WCSim TubeId to channelkey
-	std::map<int,unsigned long> mrdpmtid_to_channelkey;
+	std::map<int,unsigned long> mrd_tubeid_to_channelkey;
 	
 	// Store information regarding MRD Time clusters
 	std::vector<std::vector<int>> MrdTimeClusters;
-        std::string MRDTriggertype;
+	std::string MRDTriggertype;
 	
-
+	
 	// MRD TRACK RECONSTRUCTION
 	// ~~~~~~~~~~~~~~~~~~~~~~~~
 	// variables for file writing

--- a/UserTools/LoadRATPAC/LoadRATPAC.cpp
+++ b/UserTools/LoadRATPAC/LoadRATPAC.cpp
@@ -239,7 +239,7 @@ bool LoadRATPAC::Execute(){
             (startpoint.Y())/1000., (startpoint.Z())/1000.), Position((endpoint.X())/1000.,
             (endpoint.Y())/1000., (endpoint.Z())/1000.), starttime,
             endtime, partdir,
-            tracklength/1000., startstoptype, particleid, parentid, -9999);
+            tracklength/1000., startstoptype, particleid, parentid, -9999,0);
     MCParticles->push_back(thisparticle);
   }
 

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -212,8 +212,8 @@ bool LoadWCSim::Initialise(std::string configfile, DataModel &data){
 	trackid_to_mcparticleindex = new std::map<int,int>;
 	
 	//anniegeom->GetChannel(0); // trigger InitChannelMap
-
-	m_data->CStore.Set("UserEvent",false);			//enables the ability for other tools to select a specific event number
+	
+	m_data->CStore.Set("UserEvent",false);   //enables the ability for other tools to select a specific event number
 	triggers_event = 0;
 	
 	return true;
@@ -224,13 +224,13 @@ bool LoadWCSim::Execute(){
 	
 	// probably not necessary, clears the map for this entry. We're going to re-Set the event entry anyway...
 	//m_data->Stores.at("ANNIEEvent")->Clear();
-
+	
 	//check if another tool has specified a specific evnumber to load (currently e.g. the EventDisplay has the ability to do that)
 	bool user_event;
 	m_data->CStore.Get("UserEvent",user_event);
 	if (user_event){
 		m_data->CStore.Set("UserEvent",false);
-		MCTriggernum = 0;			//look at first trigger for user-specified event numbers
+		MCTriggernum = 0;   //look at first trigger for user-specified event numbers
 		int user_evnum; 
 		uint16_t currentTriggernum;
 		bool check_further_triggers=false;
@@ -246,7 +246,7 @@ bool LoadWCSim::Execute(){
 				//there is a further trigger in the previous event, load the entry
 				MCEventNum = user_evnum - 1;
 				MCTriggernum=currentTriggernum;
-			}		
+			}
 		}
 		// Pre-load entry so we can stop the loop if it this was the last one in the chain
 		if(MCEventNum>=MaxEntries && MaxEntries>0){
@@ -278,7 +278,7 @@ bool LoadWCSim::Execute(){
 	
 	MCHits->clear();
 	TDCData->clear();
-
+	
 	triggers_event = WCSimEntry->wcsimrootevent->GetNumberOfEvents();
 	
 	//for(int MCTriggernum=0; MCTriggernum<WCSimEntry->wcsimrootevent->GetNumberOfEvents(); MCTriggernum++){
@@ -310,12 +310,6 @@ bool LoadWCSim::Execute(){
 		if(MCTriggernum==0){
 			MCParticles->clear();
 			trackid_to_mcparticleindex->clear();
-			ParticleId_to_TankTubeIds->clear();
-			ParticleId_to_MrdTubeIds->clear();
-			ParticleId_to_VetoTubeIds->clear();
-			ParticleId_to_TankCharge->clear();
-			ParticleId_to_MrdCharge->clear();
-			ParticleId_to_VetoCharge->clear();
 			primarymuonindex=-1;
 			
 			std::string geniefilename = firsttrigt->GetHeader()->GetGenieFileName().Data();
@@ -327,7 +321,7 @@ bool LoadWCSim::Execute(){
 			for(int trigi=0; trigi<WCSimEntry->wcsimrootevent->GetNumberOfEvents(); trigi++){
 				
 				WCSimRootTrigger* atrigtt = WCSimEntry->wcsimrootevent->GetTrigger(trigi);
-				if(verbosity>1) cout<<"getting "<<atrigtt->GetNtrack()<<" tracks"<<endl;
+				if(verbosity>1) cout<<"getting "<<atrigtt->GetNtrack()<<" tracks from trigger "<<trigi<<endl;
 				for(int tracki=0; tracki<atrigtt->GetNtrack(); tracki++){
 					if(verbosity>2) cout<<"getting track "<<tracki<<endl;
 					WCSimRootTrack* nextrack = (WCSimRootTrack*)atrigtt->GetTracks()->At(tracki);
@@ -373,7 +367,8 @@ bool LoadWCSim::Execute(){
 						startstoptype,
 						nextrack->GetId(),
 						nextrack->GetParenttype(),
-						nextrack->GetFlag());
+						nextrack->GetFlag(),
+						trigi);
 					// not currently in constructor call, but we now have it in latest WCSim files
 					// XXX this will fall over with older WCSim files, whose WCSimLib doesn't have this method!
 					thisparticle.SetTankExitPoint(Position(nextrack->GetTankExitPoint(0)/ 100.,
@@ -611,19 +606,26 @@ bool LoadWCSim::Execute(){
 		if(verbosity>2) cout<<"setting triggerdata time to "<<EventTimeNs<<"ns"<<endl;
 		TriggerData->front().SetTime(EventTimeNs);
 		
-		// copy over additional information about tracks and which tank/mrd/veto PMTs they hit
-		if(MCTriggernum==0){
-			// populate the maps of additional MC Truth information
-			// ParticleId_to_TankTubeIds is a std::map<ParticleId,std::map<ChannelKey,TotalCharge>>
-			// where TotalCharge is the total charge from that particle on that tube
-			// (in the event that the particle generated several hits on the tube)
-			// ParticleId_to_TankCharge is a std::map<ParticleId,TotalCharge> 
-			// where TotalCharge is summed over all digits, on all pmts, which contained
-			// light from that particle
-			MakeParticleToPmtMap(atrigt, firsttrigt, ParticleId_to_TankTubeIds, ParticleId_to_TankCharge, pmt_tubeid_to_channelkey);
-			MakeParticleToPmtMap(atrigm, firsttrigm, ParticleId_to_MrdTubeIds, ParticleId_to_MrdCharge, mrd_tubeid_to_channelkey);
-			MakeParticleToPmtMap(atrigv, firsttrigv, ParticleId_to_VetoTubeIds, ParticleId_to_VetoCharge, facc_tubeid_to_channelkey);
-		}
+		// update the information about tracks and which tank/mrd/veto PMTs they hit
+		// this needs updating with each MC trigger, as digits are grouped into MC trigger
+		// so these maps will then only contain the digits respective particles create
+		// in the active trigger
+		// 
+		// ParticleId_to_TankTubeIds is a std::map<ParticleId,std::map<ChannelKey,TotalCharge>>
+		// where TotalCharge is the total charge from that particle on that tube
+		// (in the event that the particle generated several hits on the tube)
+		// ParticleId_to_TankCharge is a std::map<ParticleId,TotalCharge> 
+		// where TotalCharge is summed over all digits, on all pmts, which contained
+		// light from that particle
+		ParticleId_to_TankTubeIds->clear();
+		ParticleId_to_MrdTubeIds->clear();
+		ParticleId_to_VetoTubeIds->clear();
+		ParticleId_to_TankCharge->clear();
+		ParticleId_to_MrdCharge->clear();
+		ParticleId_to_VetoCharge->clear();
+		MakeParticleToPmtMap(atrigt, firsttrigt, ParticleId_to_TankTubeIds, ParticleId_to_TankCharge, pmt_tubeid_to_channelkey);
+		MakeParticleToPmtMap(atrigm, firsttrigm, ParticleId_to_MrdTubeIds, ParticleId_to_MrdCharge, mrd_tubeid_to_channelkey);
+		MakeParticleToPmtMap(atrigv, firsttrigv, ParticleId_to_VetoTubeIds, ParticleId_to_VetoCharge, facc_tubeid_to_channelkey);
 		
 	//}
 	
@@ -675,7 +677,6 @@ bool LoadWCSim::Execute(){
 	m_data->Stores.at("ANNIEEvent")->Set("ParticleId_to_VetoCharge", ParticleId_to_VetoCharge, false);
 	m_data->Stores.at("ANNIEEvent")->Set("TrackId_to_MCParticleIndex",trackid_to_mcparticleindex,false);
 	m_data->Stores.at("ANNIEEvent")->Set("MRDTriggerType",Triggertype);
-
 	m_data->Stores.at("ANNIEEvent")->Set("PrimaryMuonIndex",primarymuonindex);
 	
 	//Things that need to be set by later tools:
@@ -713,7 +714,7 @@ bool LoadWCSim::Execute(){
 			}
 		}
 	}
-
+	
 	//gObjectTable->Print();
 	return true;
 }
@@ -928,7 +929,6 @@ Geometry* LoadWCSim::ConstructToolChainGeometry(){
 					  detectorstatus::ON,
 					  0.);
 		
-
 		// construct the channel associated with this PMT
 		unsigned long uniquechannelkey = anniegeom->ConsumeNextFreeChannelKey();
 		pmt_tubeid_to_channelkey.emplace(apmt.GetTubeNo(), uniquechannelkey);
@@ -1228,6 +1228,23 @@ void LoadWCSim::MakeParticleToPmtMap(WCSimRootTrigger* thistrig, WCSimRootTrigge
 			if(ParticleId_to_TubeIds->at(thephotonsparenttrackid).count(channelkey)==0){
 				// in the map for this particle record that this tube was hit
 				ParticleId_to_TubeIds->at(thephotonsparenttrackid).emplace(channelkey,digihit->GetQ());
+//				
+//				double particletime = -1;
+//				int particletrigger = -1;
+//				if(trackid_to_mcparticleindex->count(thephotonsparenttrackid)){
+//					int particleindex = trackid_to_mcparticleindex->at(thephotonsparenttrackid);
+//					MCParticle theparticle = MCParticles->at(particleindex);
+//					particletime = theparticle.GetStartTime();
+//					particletrigger = theparticle.GetMCTriggerNum();
+//				}
+//				double hittime = digihit->GetT();
+//				double triggertime = thistrig->GetHeader()->GetDate();
+//				std::cout<<"Particle "<<thephotonsparenttrackid<<" created at "<<particletime
+//						 <<" in trigger "<<particletrigger
+//						 <<" produced hit on MRD PMT "<<channelkey<<" at time "<<hittime
+//						 <<" relative to trigger time at "<<triggertime
+//						 <<std::endl;
+//				
 			} else {
 				// add another hit on this tube from this particle
 				ParticleId_to_TubeIds->at(thephotonsparenttrackid).at(channelkey)+=digihit->GetQ();

--- a/UserTools/LoadWCSim/LoadWCSim.h
+++ b/UserTools/LoadWCSim/LoadWCSim.h
@@ -128,7 +128,7 @@ class LoadWCSim: public Tool {
 	std::map<unsigned long,std::vector<MCHit>>* MCHits;
 	std::vector<TriggerClass>* TriggerData;
 	BeamStatusClass* BeamStatus;
-
+	
 	int primarymuonindex;
 	
 	// additional info
@@ -139,7 +139,7 @@ class LoadWCSim: public Tool {
 	std::map<int,double>* ParticleId_to_TankCharge = nullptr;
 	std::map<int,double>* ParticleId_to_MrdCharge = nullptr;
 	std::map<int,double>* ParticleId_to_VetoCharge = nullptr;
-	std::string Triggertype;	
+	std::string Triggertype;
 	
 	// verbosity levels: if 'verbosity' < this level, the message type will be logged.
 	int v_error=0;

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.h
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.h
@@ -29,7 +29,7 @@ class LoadWCSimLAPPD: public Tool {
 	
 	private:
 	// config file variables
-	int verbose=1;
+	int verbosity=1;
 	std::string MCFile;
 	double Rinnerstruct;    // cm octagonal inner structure radius
 	
@@ -56,7 +56,7 @@ class LoadWCSimLAPPD: public Tool {
 	std::vector<MCLAPPDHit> unassignedhits;  // lappd hits not yet assigned to a trigger
 	
 	bool DEBUG_DRAW_LAPPD_HITS;
-	TApplication* lappdRootDrawApp;
+	TApplication* rootTApp;
 	TCanvas* lappdRootCanvas;
 	TPolyMarker3D* lappdhitshist;
 	TH1D *digixpos, *digiypos, *digizpos, *digits;
@@ -69,6 +69,14 @@ class LoadWCSimLAPPD: public Tool {
 	// pre-trigger-selection (so no WCSim trigger association is included)
 	std::map<unsigned long,std::vector<MCLAPPDHit>>* MCLAPPDHits;
 	std::map<int,int>* TrackId_to_MCParticleIndex=nullptr; // maps WCSim trackId to index in MCParticles
+	
+	// verbosity levels: if 'verbosity' < this level, the message type will be logged.
+	int v_error=0;
+	int v_warning=1;
+	int v_message=2;
+	int v_debug=3;
+	std::string logmessage;
+	int get_ok;
 	
 };
 

--- a/UserTools/MrdPaddlePlot/MrdPaddlePlot.cpp
+++ b/UserTools/MrdPaddlePlot/MrdPaddlePlot.cpp
@@ -29,7 +29,7 @@ bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 	
 	useTApplication = true;
 	plotOnlyTracks = false;
-
+	
 	// get configuration variables for this tool
 	m_variables.Get("verbosity",verbosity);
 	m_variables.Get("gdmlpath",gdmlpath);
@@ -45,9 +45,9 @@ bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 	m_variables.Get("useTApplication",useTApplication);
 	m_variables.Get("OutputROOTFile",output_rootfile);
 	m_variables.Get("PlotOnlyTracks",plotOnlyTracks);
-
-	if (drawGdmlOverlay) useTApplication=true;	// need TApplication to display GDML plots
-
+	
+	if (drawGdmlOverlay) useTApplication=true;   // need TApplication to display GDML plots
+	
 	// for gdml overlay
 	double buildingoffsetx, buildingoffsety, buildingoffsetz;
 	m_variables.Get("buildingoffsetx",buildingoffsetx);
@@ -87,7 +87,7 @@ bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 		mrdvis_file = new TFile(ss_rootfilename.str().c_str(),"RECREATE");
 		gROOT->cd();
 	}
-
+	
 	if(drawStatistics){
 		if (saverootfile) mrdvis_file->cd();
 		hnumhclusters = new TH1D("hnumhclusters","Num track clusters in H view",10,0,10);
@@ -124,7 +124,7 @@ bool MrdPaddlePlot::Initialise(std::string configfile, DataModel &data){
 //		// we also need to specify a marker style so we can distinguish them TODO add legend
 //		markercolours.emplace("mctruth_start_vertices",kBlue);
 //		// repeat for as many point types as we need
-
+	
 	}
 #endif
 	
@@ -169,10 +169,10 @@ bool MrdPaddlePlot::Execute(){
 	// check which subevents had a track
 	std::vector<int> track_subevs;
 	m_data->CStore.Get("TracksSubEvs",track_subevs);
-
+	
 	if(verbosity>2) cout<<"Event "<<EventNumber<<" had "<<numtracksinev<<" tracks in "<<numsubevs<<" subevents"<<endl;
-
-	std::cout <<"MrdPaddlePlot: Check at start of execute: plotDirectory = "<<plotDirectory<<std::endl;
+	
+	//std::cout <<"MrdPaddlePlot: Check at start of execute: plotDirectory = "<<plotDirectory<<std::endl;
 	
 	// ##############################################################################
 	// Track drawing and Histogram Filling code
@@ -415,7 +415,10 @@ bool MrdPaddlePlot::Execute(){
 		//gSystem->ProcessEvents();
 		//gPad->WaitPrimitive();
 		// only need to sleep when using the interactive process
-		if (useTApplication) std::this_thread::sleep_for (std::chrono::seconds(2));
+		if (useTApplication){
+			//gPad->WaitPrimitive();
+			std::this_thread::sleep_for (std::chrono::seconds(2));
+		}
 		
 		if(drawGdmlOverlay){
 			// TODO, we should definitely move this somewhere else
@@ -565,10 +568,10 @@ bool MrdPaddlePlot::Execute(){
 	if(numtracksinev!=numtracksrunningtot){
 		cerr<<"number of tracks in event does not correspond to sum of tracks in subevents!"<<endl;
 	}
-
-        //only for debugging
-        //std::cout <<"MRDPaddlePlot tool: List of objects (End of Execute): "<<std::endl;
-        //gObjectTable->Print();
+	
+	//only for debugging
+	//std::cout <<"MRDPaddlePlot tool: List of objects (End of Execute): "<<std::endl;
+	//gObjectTable->Print();
 	
 	return true;
 }
@@ -633,9 +636,8 @@ bool MrdPaddlePlot::Finalise(){
 			hpaddleids->Write();
 			gROOT->cd();
 		}
-
-		delete mrdTrackCanv;
-                mrdTrackCanv=nullptr;
+		
+		delete mrdTrackCanv; mrdTrackCanv=nullptr;
 	}
 	
 	// cleanup

--- a/UserTools/TimeClustering/TimeClustering.cpp
+++ b/UserTools/TimeClustering/TimeClustering.cpp
@@ -2,8 +2,8 @@
 #include "TimeClustering.h"
 
 // for sleeping
-#include <thread>          // std::this_thread::sleep_for
-#include <chrono>          // std::chrono::seconds
+#include <thread>  // std::this_thread::sleep_for
+#include <chrono>  // std::chrono::seconds
 
 // for ROOT debug plot
 #include "TROOT.h"
@@ -27,8 +27,8 @@ bool TimeClustering::Initialise(std::string configfile, DataModel &data){
 	/////////////////////////////////////////////////////////////////
 	
 	LaunchTApplication = false;
-	MakeSingleEventPlots = false; 		//very verbose, mostly for debugging
-
+	MakeSingleEventPlots = false;      //very verbose, mostly for debugging
+	
 	m_variables.Get("verbosity",verbosity);
 	m_variables.Get("IsData",isData);
 	m_variables.Get("MinDigitsForTrack",minimumdigits);
@@ -39,10 +39,9 @@ bool TimeClustering::Initialise(std::string configfile, DataModel &data){
 	m_variables.Get("LaunchTApplication",LaunchTApplication);
 	m_variables.Get("OutputROOTFile",output_rootfile);
 	m_variables.Get("MapChankey_WCSimID",file_chankeymap);
-
-
-	if (!MakeMrdDigitTimePlot) LaunchTApplication = false;	//no use launching TApplication when histograms are not produced
-
+	
+	if (!MakeMrdDigitTimePlot) LaunchTApplication = false;  //no use launching TApplication when histograms are not produced
+	
 	if(LaunchTApplication){
 		canvwidth = 900;
 		canvheight = 600;
@@ -52,7 +51,7 @@ bool TimeClustering::Initialise(std::string configfile, DataModel &data){
 		// There may only be one TApplication, so if another tool has already made one
 		// register ourself as a user. Otherwise, make one and put a pointer in the CStore for other Tools
 		// create the ROOT application to show histograms
-
+		
 		int myargc=0;
 		//char *myargv[] = {(const char*)"Ahh shark!"};
 		intptr_t tapp_ptr=0;
@@ -72,33 +71,33 @@ bool TimeClustering::Initialise(std::string configfile, DataModel &data){
 		else tapplicationusers++;
 		m_data->CStore.Set("RootTApplicationUsers",tapplicationusers);
 	}
-
+	
 	// setup objects to save clustered hit times to a *.root file
 	if (MakeMrdDigitTimePlot){
-                std::stringstream ss_rootfilename;
-                ss_rootfilename << output_rootfile << ".root";
+		std::stringstream ss_rootfilename;
+		ss_rootfilename << output_rootfile << ".root";
 		Log("TimeClustering tool: Create ROOT-file "+ss_rootfilename.str(),v_message,verbosity);
 		//save the cluster time information for different trigger types in different histograms
-                mrddigitts_file = new TFile(ss_rootfilename.str().c_str(),"RECREATE");
-                mrddigitts_cosmic_cluster = new TH1D("mrddigitts_cosmic_cluster","MRD Cosmic Times Clustered",1000,0,4000);
-                mrddigitts_beam_cluster = new TH1D("mrddigitts_beam_cluster","MRD Beam Times Clustered",1000,0,4000);
-                mrddigitts_noloopback_cluster = new TH1D("mrddigitts_noloopback_cluster","MRD No Loopback Times Clustered",1000,0,4000);
-                mrddigitts_cluster = new TH1D("mrddigitts_cluster","MRD Times Clustered",1000,0,4000);
-                mrddigitts_cosmic = new TH1D("mrddigitts_cosmic","MRD Cosmic Times",1000,0,4000);
-                mrddigitts_beam = new TH1D("mrddigitts_beam","MRD Beam Times",1000,0,4000);
-                mrddigitts_noloopback = new TH1D("mrddigitts_noloopback","MRD No Loopback Times",1000,0,4000);
-                mrddigitts = new TH1D("mrddigitts","MRD Times",1000,0,4000);
+		mrddigitts_file = new TFile(ss_rootfilename.str().c_str(),"RECREATE");
+		mrddigitts_cosmic_cluster = new TH1D("mrddigitts_cosmic_cluster","MRD Cosmic Times Clustered",1000,0,4000);
+		mrddigitts_beam_cluster = new TH1D("mrddigitts_beam_cluster","MRD Beam Times Clustered",1000,0,4000);
+		mrddigitts_noloopback_cluster = new TH1D("mrddigitts_noloopback_cluster","MRD No Loopback Times Clustered",1000,0,4000);
+		mrddigitts_cluster = new TH1D("mrddigitts_cluster","MRD Times Clustered",1000,0,4000);
+		mrddigitts_cosmic = new TH1D("mrddigitts_cosmic","MRD Cosmic Times",1000,0,4000);
+		mrddigitts_beam = new TH1D("mrddigitts_beam","MRD Beam Times",1000,0,4000);
+		mrddigitts_noloopback = new TH1D("mrddigitts_noloopback","MRD No Loopback Times",1000,0,4000);
+		mrddigitts = new TH1D("mrddigitts","MRD Times",1000,0,4000);
 		mrddigitts_vertical = new TH1D("mrddigitts_vertical","MRD Times (Vertical Layers)",1000,0,4000);
 		mrddigitts_horizontal = new TH1D("mrddigitts_horizontal","MRD Times (Horizontal Layers)",1000,0,4000); 
-	
+		
 		if (MakeSingleEventPlots){
 			mrddigitts_single = new TH1D("mrddigitts_single","MRD Single Times",1000,0,4000);
 			mrddigitts_cluster_single = new TH1D("mrddigitts_cluster_single","MRD Single Times",1000,0,4000);
 		}
-       		gROOT->cd();
+		gROOT->cd();
 	}
-
-        // Setup mapping from Channelkeys to WCSim IDs (important for track fitting with old MRD classes in FindMrdTracks)
+	
+	// Setup mapping from Channelkeys to WCSim IDs (important for track fitting with old MRD classes in FindMrdTracks)
 	if (isData){
 		ifstream file_mapping(file_chankeymap);
 		unsigned long temp_chankey;
@@ -112,11 +111,11 @@ bool TimeClustering::Initialise(std::string configfile, DataModel &data){
 			Log("FindMrdTracks tool: Emplaced temp_chankey "+std::to_string(temp_chankey)+" with temp_wcsimid "+std::to_string(temp_wcsimid)+"into channelkey_to_mrdpmtid object!",v_debug,verbosity);
 		}
 		file_mapping.close();
-	 	m_data->CStore.Set("channelkey_to_mrdpmtid",channelkey_to_mrdpmtid);
-	 	m_data->CStore.Set("mrdpmtid_to_channelkey",mrdpmtid_to_channelkey);
-       	}
+		m_data->CStore.Set("channelkey_to_mrdpmtid",channelkey_to_mrdpmtid);
+		m_data->CStore.Set("mrdpmtid_to_channelkey",mrdpmtid_to_channelkey);
+		}
 	else {
-		get_ok = m_data->CStore.Get("channelkey_to_mrdpmtid",channelkey_to_mrdpmtid);	//for MC, simply get the sample obtained from the LoadWCSim tool
+		get_ok = m_data->CStore.Get("channelkey_to_mrdpmtid",channelkey_to_mrdpmtid);  //for MC, simply get the sample obtained from the LoadWCSim tool
 		if(not get_ok){
 			Log("TimeClustering Tool: Error! No channelkey_to_mrdpmtid in CStore!",v_error,verbosity);
 			return false;
@@ -127,10 +126,10 @@ bool TimeClustering::Initialise(std::string configfile, DataModel &data){
 			return false;
 		}
 	}
-
+	
 	// Get Detectors map to divide in horizontal and vertical layers
 	m_data->Stores["ANNIEEvent"]->Header->Get("AnnieGeometry",geom);
-
+	
 	return true;
 }
 
@@ -144,18 +143,18 @@ bool TimeClustering::Execute(){
 	m_data->CStore.Set("NumMrdTimeClusters",0);
 	int mrdeventcounter=0;
 	
-        //Get Trigger type to decide which events are cosmic/beam/etc
-        std::string MRDTriggertype;
-        m_data->Stores.at("ANNIEEvent")->Get("MRDTriggerType",MRDTriggertype);
+	//Get Trigger type to decide which events are cosmic/beam/etc
+	std::string MRDTriggertype;
+	m_data->Stores.at("ANNIEEvent")->Get("MRDTriggerType",MRDTriggertype);
 	Log("TimeClustering tool: MRDTriggertype is "+MRDTriggertype+" (from ANNIEEvent store)",v_debug,verbosity);
 	m_data->Stores.at("ANNIEEvent")->Get("EventNumber",evnum);
-
+	
 	// extract the digits from the annieevent and put them into separate vectors used by the track finder
 	mrddigitpmtsthisevent.clear();
 	mrddigitchankeysthisevent.clear();
 	mrddigittimesthisevent.clear();
 	mrddigitchargesthisevent.clear();
-
+	
 	if (MakeMrdDigitTimePlot && MakeSingleEventPlots){
 		mrddigitts_single->Reset();
 		mrddigitts_cluster_single->Reset();
@@ -165,8 +164,8 @@ bool TimeClustering::Execute(){
 		mrddigitts_single->SetName(ss_single.str().c_str());
 		mrddigitts_cluster_single->SetName(ss_cluster_single.str().c_str());
 	}
-
-	if (isData){	
+	
+	if (isData){
 		std::cout <<"TimeClustering tool: Data file: Getting TDCData object"<<std::endl;
 		get_ok = m_data->Stores.at("ANNIEEvent")->Get("TDCData",TDCData);  // a std::map<unsigned long,vector<Hit>>
 		if(not get_ok){
@@ -174,7 +173,7 @@ bool TimeClustering::Execute(){
 			return false;
 		}
 	} else {
-		std::cout <<"TimeClustering tool: MC file: Getting TDCData object"<<std::endl;	
+		std::cout <<"TimeClustering tool: MC file: Getting TDCData object"<<std::endl;
 		get_ok = m_data->Stores.at("ANNIEEvent")->Get("TDCData",TDCData_MC);  // a std::map<unsigned long,vector<MCHit>>
 		if(not get_ok){
 			Log("TimeClustering Tool: No TDC data in ANNIEEvent!",v_error,verbosity);
@@ -197,7 +196,7 @@ bool TimeClustering::Execute(){
 	
 	if (isData) Log("TimeClustering Tool: Retrieving digit info from "+to_string(TDCData->size())+" hit pmts",v_debug,verbosity);
 	else Log("TimeClustering Tool: Retrieving digit info from "+to_string(TDCData_MC->size())+" hit pmts",v_debug,verbosity);
-
+	
 	// just dump all the hit times in this event into a vector. Allows us to sort hit times and search for clusters.
 	if (isData){
 		for(auto&& anmrdpmt : (*TDCData)){
@@ -220,7 +219,7 @@ bool TimeClustering::Execute(){
 						mrddigitts->Fill(hitsonthismrdpmt.GetTime());
 						if (MRDTriggertype == "Cosmic") mrddigitts_cosmic->Fill(hitsonthismrdpmt.GetTime());
 						else if (MRDTriggertype == "Beam") mrddigitts_beam->Fill(hitsonthismrdpmt.GetTime());
-						else if (MRDTriggertype == "No Loopback") mrddigitts_noloopback->Fill(hitsonthismrdpmt.GetTime());       //this triggertype should not occur if everything is running smoothly, but it can serve as a good cross-check in any case
+						else if (MRDTriggertype == "No Loopback") mrddigitts_noloopback->Fill(hitsonthismrdpmt.GetTime());    //this triggertype should not occur if everything is running smoothly, but it can serve as a good cross-check in any case
 						Detector* thistube = geom->ChannelToDetector(chankey);
 						unsigned long detkey = thistube->GetDetectorID();
 						Paddle *mrdpaddle = (Paddle*) geom->GetDetectorPaddle(detkey);
@@ -242,33 +241,46 @@ bool TimeClustering::Execute(){
 //				Log("TimeClustering Tool: Null detector in TDCData_MC!",v_error,verbosity);
 //				continue;
 //			}
-//			if(thedetector->GetDetectorElement()!="MRD") continue; // this is a veto hit, not an MRD hit
-//			if(channelkey_to_mrdpmtid.count(chankey)==0){
+//			if((thedetector->GetDetectorElement()!="MRD") &&
+//			   (thedetector->GetDetectorElement()!="Veto") ){
+//				Log("TDC hit on channel that is neither MRD nor Veto! Type: " + thedetector->GetDetectorElement(),v_debug,verbosity);
+//			}
+//			if( (channelkey_to_mrdpmtid.count(chankey) ==0) &&
+//				(channelkey_to_faccpmtid.count(chankey)==0)){
 //				Log("TimeClustering Tool: MRD PMT with ID not in channelkey_to_mrdpmtid map!",v_error,verbosity);
-//				if(verbosity>2){
+//				if(true||verbosity>2){
 //					std::cerr<<"We have: "<<channelkey_to_mrdpmtid.size()
-//							 <<" known mappings and they are: {"<<std::endl;
+//							 <<" known MRD mappings and they are: {"<<std::endl;
 //					for(auto&& apair : channelkey_to_mrdpmtid){
+//						std::cout<<apair.first<<" : "<<apair.second<<std::endl;
+//					}
+//					std::cout<<"}"<<std::endl;
+//					std::cerr<<"We have: "<<channelkey_to_faccpmtid.size()
+//							 <<" known FACC mappings and they are: {"<<std::endl;
+//					for(auto&& apair : channelkey_to_faccpmtid){
 //						std::cout<<apair.first<<" : "<<apair.second<<std::endl;
 //					}
 //					std::cout<<"}"<<std::endl;
 //				}
 //				continue;
 //			}
+//			int wcsimtubeid = -1;
+//			wcsimtubeid = (channelkey_to_mrdpmtid.count(chankey)) ? channelkey_to_mrdpmtid.at(chankey) :
+//																	channelkey_to_faccpmtid.at(chankey);
 //			if(wcsimtubeid==0){
 //				Log("TimeClustering Tool: channel with wcsimpmtid 0! IDs should number from 1!",v_error, verbosity);
 //				continue;
 //			}
+			// checking channelkey_to_mrdpmtid (as opposed to channelkey_to_faccpmtid)
+			// will filter out MRD PMTs only
+			int pmtidwcsim=-1;
+			if (channelkey_to_mrdpmtid.count(chankey)){
+				pmtidwcsim = channelkey_to_mrdpmtid.at(chankey)-1;
+			} else if(channelkey_to_faccpmtid.count(chankey)){
+				pmtidwcsim = channelkey_to_faccpmtid.at(chankey)-1;
+			}
 			for(auto&& hitsonthismrdpmt : anmrdpmt.second){
-				// checking channelkey_to_mrdpmtid (as opposed to channelkey_to_faccpmtid)
-				// will filter out MRD PMTs only
-				int pmtidwcsim=-1;
-				if (channelkey_to_mrdpmtid.find(chankey) != channelkey_to_mrdpmtid.end()){
-					pmtidwcsim = channelkey_to_mrdpmtid.at(chankey)-1;
-				} else if(channelkey_to_faccpmtid.count(chankey)){
-					pmtidwcsim = channelkey_to_faccpmtid.at(chankey)-1;
-				}
-				if(pmtidwcsim>0){
+				if(pmtidwcsim>=0){
 					mrddigitpmtsthisevent.push_back(pmtidwcsim);
 					mrddigittimesthisevent.push_back(hitsonthismrdpmt.GetTime());
 					mrddigitchargesthisevent.push_back(hitsonthismrdpmt.GetCharge());
@@ -278,7 +290,7 @@ bool TimeClustering::Execute(){
 						mrddigitts->Fill(hitsonthismrdpmt.GetTime());
 						if (MRDTriggertype == "Cosmic") mrddigitts_cosmic->Fill(hitsonthismrdpmt.GetTime());
 						else if (MRDTriggertype == "Beam") mrddigitts_beam->Fill(hitsonthismrdpmt.GetTime());
-						else if (MRDTriggertype == "No Loopback") mrddigitts_noloopback->Fill(hitsonthismrdpmt.GetTime());       //this triggertype should not occur if everything is running smoothly, but it can serve as a good cross-check in any case
+						else if (MRDTriggertype == "No Loopback") mrddigitts_noloopback->Fill(hitsonthismrdpmt.GetTime());   //this triggertype should not occur if everything is running smoothly, but it can serve as a good cross-check in any case
 						Detector* thistube = geom->ChannelToDetector(chankey);
 						unsigned long detkey = thistube->GetDetectorID();
 						Paddle *mrdpaddle = (Paddle*) geom->GetDetectorPaddle(detkey);
@@ -287,7 +299,7 @@ bool TimeClustering::Execute(){
 						else mrddigitts_vertical->Fill(hitsonthismrdpmt.GetTime());
 					}
 				} else {
-					Log("TimeClustering tool: Did not find channelkey "+std::to_string(chankey)+" in chankey_to_mrdpmtid map.",v_warning,verbosity);
+					Log("TimeClustering tool: Did not find channelkey "+std::to_string(chankey)+" in chankey_to_mrdpmtid or channelkey_to_faccpmtid maps.",v_warning,verbosity);
 				}
 			}
 		}
@@ -321,7 +333,7 @@ bool TimeClustering::Execute(){
 	// JUST ONE SUBEVENT
 	// =================
 		Log("TimeClustering Tool: All hits this event within one subevent.",v_debug,verbosity);
-		std::vector<int> digitidsinasubevent(numdigits);                     // a vector of indices of the digits in this subevent
+		std::vector<int> digitidsinasubevent(numdigits);    // a vector of indices of the digits in this subevent
 		std::iota(digitidsinasubevent.begin(),digitidsinasubevent.end(),1);  // fill with 1-N, as all digits are are in this subevent
 		MrdTimeClusters.push_back(digitidsinasubevent);
 		if (MakeMrdDigitTimePlot){
@@ -360,7 +372,7 @@ bool TimeClustering::Execute(){
 		
 		//write subeventhittimesv to CStore for subsequent tools (e.g. FindMrdTracks)
 		m_data->CStore.Set("ClusterStartTimes",subeventhittimesv);
-
+		
 		// DEBUG CHECK
 		// -----------
 		// debug check of the timing splitting: draw a histogram of the times
@@ -370,7 +382,7 @@ bool TimeClustering::Execute(){
 			timeClusterCanvas = new TCanvas("timeClusterCanvas","timeClusterCanvas",canvwidth,canvheight);
 			timeClusterCanvas->SetWindowSize(canvwidth,canvheight);
 			timeClusterCanvas->cd();
-			if (MakeSingleEventPlots) mrddigitts_single->Draw();		//the other histograms are simply written to file, otherwise swamped with unnecessary information during execution
+			if (MakeSingleEventPlots) mrddigitts_single->Draw();  //the other histograms are simply written to file, otherwise swamped with unnecessary information during execution
 			timeClusterCanvas->Modified();
 			timeClusterCanvas->Update();
 			gSystem->ProcessEvents();
@@ -416,8 +428,8 @@ bool TimeClustering::Execute(){
 					digitchargesinasubevent.push_back(mrddigitchargesthisevent.at(thisdigit));
 					if (MakeMrdDigitTimePlot){
 						mrddigitts_file->cd();
-						if (MakeSingleEventPlots) mrddigitts_single->Fill(mrddigittimesthisevent.at(thisdigit));			
-					}			
+						if (MakeSingleEventPlots) mrddigitts_single->Fill(mrddigittimesthisevent.at(thisdigit));
+					}
 				}
 			}
 			
@@ -435,8 +447,8 @@ bool TimeClustering::Execute(){
 						mrddigitts_cluster->Fill(digittimesinasubevent.at(i_time));
 						if (MakeSingleEventPlots) mrddigitts_cluster_single->Fill(digittimesinasubevent.at(i_time));
 						if (MRDTriggertype == "Cosmic") mrddigitts_cosmic_cluster->Fill(digittimesinasubevent.at(i_time));
-                                		else if (MRDTriggertype == "Beam") mrddigitts_beam_cluster->Fill(digittimesinasubevent.at(i_time));
-                                		else if (MRDTriggertype == "No Loopback") mrddigitts_noloopback_cluster->Fill(digittimesinasubevent.at(i_time));						
+						else if (MRDTriggertype == "Beam") mrddigitts_beam_cluster->Fill(digittimesinasubevent.at(i_time));
+						else if (MRDTriggertype == "No Loopback") mrddigitts_noloopback_cluster->Fill(digittimesinasubevent.at(i_time));
 					}
 				}
 			}
@@ -460,18 +472,18 @@ bool TimeClustering::Execute(){
 	// verbose check about what is contained in MrdTimeClusters object
 	for (unsigned int i_cluster=0; i_cluster < MrdTimeClusters.size(); i_cluster++){
 		if (verbosity >= v_debug) std::cout << "TimeClustering tool: Cluster " << i_cluster+1 << ", MrdTimeClusters.at(i_cluster).size() = " << MrdTimeClusters.at(i_cluster).size() << std::endl;
-                for (unsigned int i_entry = 0; i_entry < MrdTimeClusters.at(i_cluster).size(); i_entry++){
-                        if (verbosity >= v_debug) std::cout <<MrdTimeClusters.at(i_cluster).at(i_entry)<<", ";
-                }
-                if (verbosity >= v_debug) std::cout << std::endl;	
+			for (unsigned int i_entry = 0; i_entry < MrdTimeClusters.at(i_cluster).size(); i_entry++){
+				if (verbosity >= v_debug) std::cout <<MrdTimeClusters.at(i_cluster).at(i_entry)<<", ";
+			}
+			if (verbosity >= v_debug) std::cout << std::endl;
 	}
-
+	
 	for (unsigned int i=0; i< mrddigittimesthisevent.size(); i++){
 		if (verbosity > v_debug) std::cout <<"mrddigitpmts, entry "<<i<<", time: "<<mrddigittimesthisevent.at(i)<<", pmt: "<<mrddigitpmtsthisevent.at(i)<<", charge: "<<mrddigitchargesthisevent.at(i)<<std::endl;
 }
 
 	if (MakeMrdDigitTimePlot){
-
+	
 		mrddigitts_file->cd();
 		if (MakeSingleEventPlots){
 			mrddigitts_cluster_single->Write();
@@ -479,7 +491,7 @@ bool TimeClustering::Execute(){
 		}
 		gROOT->cd();
 	}
-
+	
 	// pass the found clusters to the ANNIEEvent
 	m_data->CStore.Set("MrdTimeClusters",MrdTimeClusters);
 	m_data->CStore.Set("NumMrdTimeClusters",mrdeventcounter);
@@ -487,11 +499,11 @@ bool TimeClustering::Execute(){
 	m_data->CStore.Set("MrdDigitPmts",mrddigitpmtsthisevent);
 	m_data->CStore.Set("MrdDigitChankeys",mrddigitchankeysthisevent);
 	m_data->CStore.Set("MrdDigitCharges",mrddigitchargesthisevent);
-
+	
 	//only for debugging
 	//std::cout <<"TimeClustering tool: List of objects (End of Execute): "<<std::endl;
 	//gObjectTable->Print();
-
+	
 	return true;
 }
 
@@ -502,23 +514,22 @@ bool TimeClustering::Finalise(){
 	
 	if (MakeMrdDigitTimePlot){
 		mrddigitts_file->cd();
-        	mrddigitts_cosmic_cluster->Write();
-        	mrddigitts_beam_cluster->Write();
-        	mrddigitts_noloopback_cluster->Write();
-        	mrddigitts_cluster->Write();
-        	mrddigitts_cosmic->Write();
-        	mrddigitts_beam->Write();
-        	mrddigitts_noloopback->Write();
-        	mrddigitts->Write();
+			mrddigitts_cosmic_cluster->Write();
+			mrddigitts_beam_cluster->Write();
+			mrddigitts_noloopback_cluster->Write();
+			mrddigitts_cluster->Write();
+			mrddigitts_cosmic->Write();
+			mrddigitts_beam->Write();
+			mrddigitts_noloopback->Write();
+			mrddigitts->Write();
 		mrddigitts_horizontal->Write();
 		mrddigitts_vertical->Write();
-        	mrddigitts_file->Close();
-        	delete mrddigitts_file;     //histograms get deleted by deleting associated TFile
+			mrddigitts_file->Close();
+			delete mrddigitts_file;     //histograms get deleted by deleting associated TFile
 		mrddigitts_file=0;
 		gROOT->cd();
 	}
-
-
+	
 	if (LaunchTApplication){
 		// see if we're the last user of the TApplication and release it if so,
 		// otherwise de-register us as a user since we're done

--- a/UserTools/TimeClustering/TimeClustering.h
+++ b/UserTools/TimeClustering/TimeClustering.h
@@ -38,20 +38,20 @@ class TimeClustering: public Tool {
 	bool MakeMrdDigitTimePlot=false;
 	bool MakeSingleEventPlots;
 	bool LaunchTApplication;
-	bool isData;	
+	bool isData;
 	std::string output_rootfile;
 	std::string file_chankeymap;
 	int evnum;
-
+	
 	//ANNIEEvent data
 	std::map<unsigned long,vector<Hit>>* TDCData;
 	std::map<unsigned long,vector<MCHit>>* TDCData_MC;
-	Geometry *geom = nullptr;	
-
+	Geometry *geom = nullptr;
+	
 	// From the CStore, for converting WCSim TubeId t channelkey
-        std::map<unsigned long,int> channelkey_to_mrdpmtid;
-        std::map<unsigned long,int> channelkey_to_faccpmtid;
-
+	std::map<unsigned long,int> channelkey_to_mrdpmtid;
+	std::map<unsigned long,int> channelkey_to_faccpmtid;
+	
 	// Cluster properties
 	std::vector<double> mrddigittimesthisevent;
 	std::vector<int> mrddigitpmtsthisevent;
@@ -61,21 +61,21 @@ class TimeClustering: public Tool {
 	std::vector<std::vector<double>> MrdTimeClusters_Times;
 	std::vector<std::vector<double>> MrdTimeClusters_Charges;
 	
-        // Histograms storing information about the MRD cluster times
+	// Histograms storing information about the MRD cluster times
 	TH1D* mrddigitts_cosmic_cluster = nullptr;
-        TH1D* mrddigitts_beam_cluster = nullptr;
-        TH1D* mrddigitts_noloopback_cluster = nullptr;
-        TH1D* mrddigitts_cluster = nullptr;
-        TH1D* mrddigitts_cosmic = nullptr;
-        TH1D* mrddigitts_beam = nullptr;
-        TH1D* mrddigitts_noloopback = nullptr;
-        TH1D* mrddigitts = nullptr;
+	TH1D* mrddigitts_beam_cluster = nullptr;
+	TH1D* mrddigitts_noloopback_cluster = nullptr;
+	TH1D* mrddigitts_cluster = nullptr;
+	TH1D* mrddigitts_cosmic = nullptr;
+	TH1D* mrddigitts_beam = nullptr;
+	TH1D* mrddigitts_noloopback = nullptr;
+	TH1D* mrddigitts = nullptr;
 	TH1D *mrddigitts_cluster_single = nullptr;
 	TH1D *mrddigitts_single = nullptr;
 	TH1D *mrddigitts_horizontal = nullptr;
 	TH1D *mrddigitts_vertical = nullptr;
-        TFile* mrddigitts_file = nullptr;
-
+	TFile* mrddigitts_file = nullptr;
+	
 	//TApplication-related variables
 	TCanvas* timeClusterCanvas=nullptr;
 	TApplication* rootTApp=nullptr;

--- a/UserTools/TrackCombiner/TrackCombiner.cpp
+++ b/UserTools/TrackCombiner/TrackCombiner.cpp
@@ -895,7 +895,7 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 						theclusters->back().AddDigit(0, wcsimtubeid-1, earliest_hit_time);
 					}
 				}
-			
+				
 				// if this isn't the first cluster, make a cell between it and the previous one
 				int nclusters = theclusters->size();
 				if(nclusters>1){
@@ -1024,6 +1024,9 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 								atrack->GetMrdEntryPoint().Z() / 100.);
 		thisTrackAsBoostStore->Set("TankExitPoint",TankExitPoint);
 		thisTrackAsBoostStore->Set("MrdEntryPoint",MrdEntryPoint);
+		
+		// differentiate tracks found with this algorithm from those found by the FindMrdTracks tool
+		thisTrackAsBoostStore->Set("LongTrack",0);
 		
 		// if it's the first loop and we found a matching pair, grab the pointer to return
 		if((stub_i==0)&&(found_matching_stub)){

--- a/configfiles/FindMrdTracks/MC/FindMrdTracksConfig
+++ b/configfiles/FindMrdTracks/MC/FindMrdTracksConfig
@@ -1,12 +1,12 @@
 # FindMrdTracks Config File
 # all variables retrieved with m_variables.Get() must be defined here!
 
-verbosity 5
+verbosity 1
 IsData 0
 OutputDirectory .
-OutputFile 25_04_19_wcsim_0.0.0
-DrawTruthTracks 0 # whether to add MC Truth track info for drawing in MrdPaddlePlot Tool
-                  ## note you need to run that tool to actually view the tracks!
-WriteTracksToFile 1	# should the track information be written to a ROOT-file?
-SelectTriggerType 0	#should the loaded data be filtered by trigger type?
-TriggerType Cosmic	#options: Cosmic, Beam, No Loopback
+OutputFile mrdtrackfile  # the output file built will be '<OutputDirectory>/<OutputFile>.<Run>.<Subrun>.root'
+DrawTruthTracks 0        # whether to add MC Truth track info for drawing in MrdPaddlePlot Tool
+                         ## note you need to run that tool to actually view the tracks!
+WriteTracksToFile 1      # should the track information be written to a ROOT-file?
+SelectTriggerType 0      # should the loaded data be filtered by trigger type?
+TriggerType Cosmic       # options: Cosmic, Beam, No Loopback

--- a/configfiles/FindMrdTracks/MC/LoadWCSimConfig
+++ b/configfiles/FindMrdTracks/MC/LoadWCSimConfig
@@ -16,8 +16,8 @@ FileStartOffset 0
 WCSimVersion 3               ## should reflect the WCSim version of the files being loaded
 HistoricTriggeroffset 0      ## time offset of digits relative to the trigger
 UseDigitSmearedTime 1        ## whether to use smeared digit time (T), or true time of first photon (F)
-LappdNumStrips 56            ## num channels to construct from each LAPPD
+LappdNumStrips 60            ## num channels to construct from each LAPPD
 LappdStripLength 100         ## relative x position of each LAPPD strip, for dual-sided readout [mm]
 LappdStripSeparation 10      ## stripline separation, for calculating relative y position of each LAPPD strip [mm]
-TriggerType Beam           ## options: Beam / Cosmic / No Loopback
+TriggerType Beam             ## options: Beam / Cosmic / No Loopback
 

--- a/configfiles/FindMrdTracks/MC/PlotMrdTracksConfig
+++ b/configfiles/FindMrdTracks/MC/PlotMrdTracksConfig
@@ -17,10 +17,10 @@ drawPaddlePlot 1        # draw the top/side view paddle plot of tracks
 drawGdmlOverlay 0       # draw a 3D representation of the ANNIE detector overlaid with MRD tracks
 drawStatistics 0        # histograms plotting some debug statistics about the track reconstruction
 saveimages 0            # save the paddle plots as images.
-saverootfile 1		# save the paddle plots within a rootfile
+saverootfile 1          # save the paddle plots within a rootfile
 #plotDirectory /annie/app/users/moflaher/ToolAnalysis/ToolAnalysis/MrdPlots  # where to save plot images
 plotDirectory ./MrdPaddlePlots
 printTClonesTracks 0    # verbose printout of track information from TClonesArray
-useTApplication 0	# launch a TApplication to directly show the plots (slow on cluster)
-OutputROOTFile MRDPaddlePlots_test	#which root file name should we save to?
-DrawOnlyTracks 1	# should subevents only be drawn if a track was found?
+useTApplication 0       # launch a TApplication to directly show the plots (slow on cluster)
+OutputROOTFile MRDPaddlePlots_test   #which root file name should we save to?
+DrawOnlyTracks 1        # should subevents only be drawn if a track was found?

--- a/configfiles/FindMrdTracks/MC/TimeClusteringConfig
+++ b/configfiles/FindMrdTracks/MC/TimeClusteringConfig
@@ -1,13 +1,14 @@
 #TimeClustering config file
 
-verbosity 2
+verbosity 1
 MinDigitsForTrack 4
-MaxMrdSubEventDuration 30
-MinSubeventTimeSep 30
+MaxMrdSubEventDuration 30     # if ALL hits are within this duration, they'll all be considered as one subevent
+                              # Purely for efficiency, this is NOT a limit on the time span of digits in a subevent!
+MinSubeventTimeSep 30         # a gap of this length will delimit subevents
 MakeMrdDigitTimePlot 0
 LaunchTApplication 0
 IsData 0
 #OutputROOTFile TimeClustering_MRDTest28_cluster30ns
-OutputROOTFile 25_04_19_wcsim_0.0.0
+OutputROOTFile mrdhittimeclusters  # output file will be '<OutputROOTFile>.root'
 MapChankey_WCSimID ./configfiles/MrdPaddleEfficiency/MRD_Chankey_WCSimID.dat
 

--- a/configfiles/FindMrdTracks/MC/ToolChainConfig
+++ b/configfiles/FindMrdTracks/MC/ToolChainConfig
@@ -15,7 +15,7 @@ service_publish_sec -1
 service_kick_sec -1
 
 ##### Tools To Add #####
-Tools_File configfiles/FindMrdTracks/ToolsConfig
+Tools_File configfiles/FindMrdTracks/MC/ToolsConfig
 
 ##### Run Type #####
 Inline -1 ## number of Execute steps in program, -1 infinite loop that is ended by user 

--- a/configfiles/FindMrdTracks/MC/ToolsConfig
+++ b/configfiles/FindMrdTracks/MC/ToolsConfig
@@ -16,7 +16,7 @@ myFindMrdTracks FindMrdTracks ./configfiles/FindMrdTracks/MC/FindMrdTracksConfig
 # find short tracks
 myTrackCombiner TrackCombiner ./configfiles/FindMrdTracks/MC/TrackCombinerConfig
 # plot tracks found
-myMrdTrackPlotter MrdPaddlePlot ./configfiles/FindMrdTracks/MC/PlotMrdTracksConfig
+myMrdPaddlePlot MrdPaddlePlot ./configfiles/FindMrdTracks/MC/PlotMrdTracksConfig
 myMrdEfficiency MrdEfficiency ./configfiles/FindMrdTracks/MC/MrdEfficiencyConfig
 myMrdDistributions MrdDistributions ./configfiles/FindMrdTracks/MC/MrdDistributionsConfig
 myGracefulStop GracefulStop ./configfiles/FindMrdTracks/MC/GracefulStopConfig


### PR DESCRIPTION
* Add `MCTriggernum` to MCParticle class, to specify during which trigger the particle was created.
* Fix FindMrdTracks `mrdpmtid_to_channelkey` to `mrd_tubeid_to_channelkey`, which is used in matching found MRD tracks to their corresponding MC truth particle.
* In `LoadWCSim` make calls to `MakeParticleToPmtMap` on every toolchain iteration, rather than only for `MCTriggerNum==0`; this means the digit-to-parent-particle maps will only contain the digits each particle produced _in this trigger_.
* Rename `verbose` to `verbosity` in LoadWCSimLAPPD for consistency.
* Add the usual TApplication boilerplate to LoadWCSimLAPPD, so that only one TApplication gets made even if multiple Tools are using it.
* Fix a `if(pmtidwcsim>0){` with `if(pmtidwcsim>=0){` in TimeClustering tool, which would have been skipping adding hits for the first MRD paddle. 
* Assorted improvements to the MrdDistributions tool.

And a whole lotta whitespace fixes.