### PR TITLE
Warnings fixes

### DIFF
--- a/DataModel/CardData.h
+++ b/DataModel/CardData.h
@@ -23,7 +23,7 @@ class CardData : public SerialisableObject{
  
   ~CardData();
 
-  bool Print(){};
+  bool Print(){return true;};
 
   void  Send(zmq::socket_t *socket, int flag=0);
   bool Receive(zmq::socket_t *socket);

--- a/DataModel/Hit.h
+++ b/DataModel/Hit.h
@@ -70,9 +70,9 @@ class MCHit : public Hit {
 		std::cout<<"Charge : "<<Charge<<endl;
 		if(Parents.size()){
 			std::cout<<"Parent MCPartice indices: {";
-			for(int parenti=0; parenti<Parents.size(); ++parenti){
+			for(int parenti=0; parenti<(int)Parents.size(); ++parenti){
 				std::cout<<Parents.at(parenti);
-				if((parenti+1)<Parents.size()) std::cout<<", ";
+				if((parenti+1)<(int)Parents.size()) std::cout<<", ";
 			}
 			std::cout<<"}"<<endl;
 		} else {

--- a/DataModel/LAPPDHit.h
+++ b/DataModel/LAPPDHit.h
@@ -72,9 +72,9 @@ class MCLAPPDHit : public LAPPDHit{
 		cout<<"Charge : "<<Charge<<endl;
 		if(Parents.size()){
 			cout<<"Parent MCPartice indices: {";
-			for(int parenti=0; parenti<Parents.size(); ++parenti){
+			for(int parenti=0; parenti<(int)Parents.size(); ++parenti){
 				cout<<Parents.at(parenti);
-				if((parenti+1)<Parents.size()) cout<<", ";
+				if((parenti+1)<(int)Parents.size()) cout<<", ";
 			}
 			cout<<"}"<<endl;
 		} else {

--- a/DataModel/NnlsSolution.h
+++ b/DataModel/NnlsSolution.h
@@ -40,7 +40,7 @@ public:
 		if(filled) cout << "Number of components: " << component_times.size() << endl;
 		if(verbose){
 			cout<<"Times and scales:" << endl;
-			for(int i = 0; i < component_times.size(); i++){
+			for(int i = 0; i < (int) component_times.size(); i++){
 				cout << component_times.at(i) << ", " << component_scales.at(i) << endl;
 			}
 		}

--- a/DataModel/TriggerData.h
+++ b/DataModel/TriggerData.h
@@ -34,7 +34,7 @@ class TriggerData : public SerialisableObject{
   int FIFOOverflow;
   int DriverOverflow;
   ~TriggerData();
-  bool Print(){};
+  bool Print(){return true;};
   
   void  Send(zmq::socket_t *socket, int flag=0);
   bool Receive(zmq::socket_t *socket);        

--- a/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.cpp
+++ b/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.cpp
@@ -281,7 +281,7 @@ bool ANNIEEventBuilder::Execute(){
         myMRDMaps.MRDBeamLoopbackMap.erase(MRDTimeStamp);
         myMRDMaps.MRDCosmicLoopbackMap.erase(MRDTimeStamp);
       }
-      for(int i=0; i<BuiltTankTimes.size(); i++){
+      for(int i=0; i<(int)BuiltTankTimes.size(); i++){
         BeamTankMRDPairs.erase(BuiltTankTimes.at(i));
       }
     }
@@ -599,7 +599,7 @@ std::map<uint64_t,std::map<std::string,uint64_t>> ANNIEEventBuilder::PairCTCCosm
   
 
   //Delete CTCTimestamps that have a PMT or MRD pair from CTC timestamp tracker
-  for(int j=0;j<BuiltCTCs.size();j++){
+  for(int j=0;j<(int)BuiltCTCs.size();j++){
     if(verbosity>4) std::cout << "REMOVING CTC TIME OF " << BuiltCTCs.at(j) << "FROM CTCTIMESTAMPS VECTOR" << std::endl;
     myTimeStream.CTCTimestamps.erase(std::remove(myTimeStream.CTCTimestamps.begin(),
         myTimeStream.CTCTimestamps.end(),BuiltCTCs.at(j)), 
@@ -614,7 +614,7 @@ std::map<uint64_t,std::map<std::string,uint64_t>> ANNIEEventBuilder::PairCTCCosm
 
 void ANNIEEventBuilder::RemoveCosmics(){
   std::vector<uint64_t> MRDStampsToDelete;
-  for (int i=0;i<(myTimeStream.BeamMRDTimestamps.size()); i++) {
+  for (int i=0;i<(int)(myTimeStream.BeamMRDTimestamps.size()); i++) {
     std::string MRDTriggerType = myMRDMaps.MRDTriggerTypeMap[myTimeStream.BeamMRDTimestamps.at(i)];
     if(verbosity>4) std::cout << "THIS MRD TRIGGER TYPE IS: " << MRDTriggerType << std::endl;
     if(MRDTriggerType == "Cosmic"){
@@ -625,7 +625,7 @@ void ANNIEEventBuilder::RemoveCosmics(){
       }
     }
   }
-  for (int j=0; j<MRDStampsToDelete.size(); j++){
+  for (int j=0; j<(int)MRDStampsToDelete.size(); j++){
     myTimeStream.BeamMRDTimestamps.erase(std::remove(myTimeStream.BeamMRDTimestamps.begin(),
         myTimeStream.BeamMRDTimestamps.end(),MRDStampsToDelete.at(j)), 
         myTimeStream.BeamMRDTimestamps.end());
@@ -762,7 +762,7 @@ std::map<uint64_t,std::map<std::string,uint64_t>> ANNIEEventBuilder::MergeStream
   }
 
   //Delete myTimeStream.CTCTimestamps that have a PMT or MRD pair from CTC timestamp tracker
-  for(int j=0;j<BuiltCTCs.size();j++){
+  for(int j=0;j<(int)BuiltCTCs.size();j++){
     if(verbosity>4) std::cout << "REMOVING CTC TIME OF " << BuiltCTCs.at(j) << "FROM CTCTIMESTAMPS VECTOR" << std::endl;
     myTimeStream.CTCTimestamps.erase(std::remove(myTimeStream.CTCTimestamps.begin(),
         myTimeStream.CTCTimestamps.end(),BuiltCTCs.at(j)), 

--- a/UserTools/AmBeRunStatistics/AmBeRunStatistics.cpp
+++ b/UserTools/AmBeRunStatistics/AmBeRunStatistics.cpp
@@ -87,7 +87,7 @@ bool AmBeRunStatistics::Execute(){
     h_SiPM2_PeakTime->Fill(SiPM2_MaxPulse.peak_time());
   }
 
-  double deltat, charge_ratio;
+  double deltat=0., charge_ratio=0.;
   if(SiPM1_NumPulses>0  && SiPM1_NumPulses>0){ 
     h_S1S2_Amplitudes->Fill(SiPM1_MaxPulse.amplitude(),SiPM2_MaxPulse.amplitude());
     deltat = SiPM1_MaxPulse.peak_time() - SiPM2_MaxPulse.peak_time();
@@ -139,9 +139,9 @@ bool AmBeRunStatistics::Execute(){
   h_S1S2_ChargeratioCleanPromptTrig->Fill(charge_ratio);
   h_S1S2_DeltatCleanPromptTrig->Fill(deltat);
 
-  double cluster_charge;
-  double cluster_time;
-  double cluster_PE;
+  double cluster_charge=0;
+  double cluster_time=0;
+  double cluster_PE=0;
   if(verbosity>3) std::cout << "AmBeRunStatistics Tool: looping through clusters to get cluster info now" << std::endl;
   if(verbosity>3) std::cout << "AmBeRunStatistics Tool: number of clusters: " << m_all_clusters->size() << std::endl;
   for (std::pair<double,std::vector<Hit>>&& cluster_pair : *m_all_clusters) {
@@ -149,7 +149,7 @@ bool AmBeRunStatistics::Execute(){
     cluster_time = cluster_pair.first;
     cluster_PE = 0;
     std::vector<Hit> cluster_hits = cluster_pair.second;
-    for (int i = 0; i<cluster_hits.size(); i++){
+    for (int i = 0; i < (int) cluster_hits.size(); i++){
       int hit_ID = cluster_hits.at(i).GetTubeId();
       std::map<int, double>::iterator it = ChannelKeyToSPEMap.find(hit_ID);
       if(it != ChannelKeyToSPEMap.end()){ //Charge to SPE conversion is available

--- a/UserTools/BeamClusterPlots/BeamClusterPlots.cpp
+++ b/UserTools/BeamClusterPlots/BeamClusterPlots.cpp
@@ -88,7 +88,7 @@ bool BeamClusterPlots::Execute(){
     double cluster_PE = 0;
     double num_hits = 0;
     std::vector<Hit> cluster_hits = cluster_pair.second;
-    for (int i = 0; i<cluster_hits.size(); i++){
+    for (int i = 0; i<(int)cluster_hits.size(); i++){
       int hit_ID = cluster_hits.at(i).GetTubeId();
       std::map<int, double>::iterator it = ChannelKeyToSPEMap.find(hit_ID);
       if(it != ChannelKeyToSPEMap.end()){ //Charge to SPE conversion is available
@@ -140,13 +140,13 @@ bool BeamClusterPlots::Execute(){
   //Then, make multiplicity histograms
   if(max_prompt_clusterPE>PromptPEMin){
     hist_prompt_delayed_multiplicity->Fill(delayed_cluster_times.size()); 
-    for(int j = 0; j< delayed_cluster_times.size(); j++){
+    for(int j = 0; j< (int) delayed_cluster_times.size(); j++){
       hist_prompt_delayed_deltat->Fill(delayed_cluster_times.at(j) - max_prompt_clustertime);
     }
 
     hist_prompt_neutron_multiplicity->Fill(delayed_ncandidate_times.size()); 
     hist_prompt_neutron_multiplicityvstankE->Fill(delayed_ncandidate_times.size(),max_prompt_clusterPE/PEPerMeV); 
-    for(int j = 0; j< delayed_ncandidate_times.size(); j++){
+    for(int j = 0; j< (int) delayed_ncandidate_times.size(); j++){
       hist_prompt_neutron_deltat->Fill(delayed_ncandidate_times.at(j) - max_prompt_clustertime);
     }
   }

--- a/UserTools/CNNImage/CNNImage.cpp
+++ b/UserTools/CNNImage/CNNImage.cpp
@@ -113,7 +113,7 @@ bool CNNImage::Execute(){
   bool bool_nhits=false;
 
   if (verbosity > 1) std::cout <<"Loop through MCParticles..."<<std::endl;
-  for(int particlei=0; particlei<mcparticles->size(); particlei++){
+  for(int particlei=0; particlei<(int)mcparticles->size(); particlei++){
     MCParticle aparticle = mcparticles->at(particlei);
     if (verbosity > 1) std::cout <<"particle "<<particlei<<std::endl;
     if (verbosity > 1) std::cout <<"Parent ID: "<<aparticle.GetParentPdg()<<std::endl;
@@ -179,7 +179,7 @@ bool CNNImage::Execute(){
   max_time_pmts = 0;
   min_time_pmts = 999.;
   total_charge_pmts = 0;
-  for (int i_pmt=0;i_pmt<hitpmt_detkeys.size();i_pmt++){
+  for (int i_pmt=0;i_pmt<(int)hitpmt_detkeys.size();i_pmt++){
     unsigned long detkey = hitpmt_detkeys[i_pmt];
     if (charge[detkey]>maximum_pmts) maximum_pmts = charge[detkey];
     total_charge_pmts+=charge[detkey];

--- a/UserTools/CalcClassificationVars/CalcClassificationVars.cpp
+++ b/UserTools/CalcClassificationVars/CalcClassificationVars.cpp
@@ -473,7 +473,8 @@ void CalcClassificationVars::ClassificationVarsPMTLAPPD(){
 		double digitQ = thisdigit.GetCalCharge();
 		double digitT = thisdigit.GetCalTime();
 		double detDist, detTheta, detPhi;
-		double MCdetDist, MCdetTheta;
+		double MCdetDist=0.;
+		double MCdetTheta;
 		int digitID = thisdigit.GetDetectorID();
 			
 		if (isData){

--- a/UserTools/ClusterClassifiers/ClusterClassifiers.cpp
+++ b/UserTools/ClusterClassifiers/ClusterClassifiers.cpp
@@ -81,7 +81,7 @@ Position ClusterClassifiers::CalculateChargePoint(std::vector<Hit> cluster_hits)
   double tank_center_y = detector_center.Y();
   double tank_center_z = detector_center.Z();
 
-  for (int i = 0; i < cluster_hits.size(); i++){
+  for (int i = 0; i < (int) cluster_hits.size(); i++){
     Hit ahit = cluster_hits.at(i); 
     double hit_charge = ahit.GetCharge();
     int channel_key = ahit.GetTubeId();
@@ -108,7 +108,7 @@ double ClusterClassifiers::CalculateChargeBalance(std::vector<Hit> cluster_hits)
   double total_Q = 0;
   double total_QSquared = 0;
   std::map<int, double> CBMap;
-  for (int i = 0; i < cluster_hits.size(); i++){
+  for (int i = 0; i < (int)cluster_hits.size(); i++){
     Hit ahit = cluster_hits.at(i); 
     double hit_charge = ahit.GetCharge();
     int hit_ID = ahit.GetTubeId();
@@ -133,7 +133,7 @@ double ClusterClassifiers::CalculateChargeBalance(std::vector<Hit> cluster_hits)
 double ClusterClassifiers::CalculateMaxPE(std::vector<Hit> cluster_hits)
 {
   double max_PE = 0;
-  for (int i = 0; i < cluster_hits.size(); i++){
+  for (int i = 0; i < (int)cluster_hits.size(); i++){
     Hit ahit = cluster_hits.at(i); 
     double hit_charge = ahit.GetCharge();
     int channel_key = ahit.GetTubeId();

--- a/UserTools/DataSummary/DataSummary.cpp
+++ b/UserTools/DataSummary/DataSummary.cpp
@@ -300,10 +300,10 @@ bool DataSummary::LoadNextFile(){
 		return false;
 	}
 	ANNIEEvent->Get("RunNumber",RunNumber);
-	if(RunNumber!=run)
+	if((int)RunNumber!=run)
 		Log("DataSummary Tool: filename / entry mismatch for RunNumber!",v_error,verbosity);
 	ANNIEEvent->Get("SubrunNumber",SubrunNumber);
-	if(SubrunNumber!=subrun)
+	if((int)SubrunNumber!=subrun)
 		Log("DataSummary Tool: filename / entry mismatch for SubrunNumber!",v_error,verbosity);
 	// TODO... handle these errors? We should have an error log file.
 	PartNumber=part; // not stored so assume it's the same
@@ -530,7 +530,7 @@ bool DataSummary::AddTDiffPlots(){
 	tank_ctc_ts.reserve(tank_ctc_diff_vals.size()/(overlap_fraction*window_size));
 	int start_sample=0;
 	int step_size = window_size*overlap_fraction;
-	for(int i=0; i<tank_ctc_diff_vals.size(); ++i){
+	for(int i=0; i<(int)tank_ctc_diff_vals.size(); ++i){
 		ComputeMeanAndVariance(tank_ctc_diff_vals, mean_ctc_to_tank, var_ctc_to_tank, window_size, start_sample);
 		tank_ctc_means.push_back(mean_ctc_to_tank);
 		tank_ctc_vars.push_back(var_ctc_to_tank);

--- a/UserTools/DataSummary/DataSummary.cpp
+++ b/UserTools/DataSummary/DataSummary.cpp
@@ -223,6 +223,7 @@ bool DataSummary::LoadNextANNIEEventEntry(){
 		return ANNIEEvent->GetEntry(localentry);
 	} // else no more ANNIEEvents, but we didn't load a new file
 	  // because there are still Orphans to process
+	return false;
 }
 
 bool DataSummary::LoadNextOrphanStoreEntry(){
@@ -243,6 +244,7 @@ bool DataSummary::LoadNextOrphanStoreEntry(){
 		return OrphanStore->GetEntry(localorphan);
 	} // else no more orphans, but we didn't load a new file
 	  // because there are still ANNIEEvents to process
+	return false;
 }
 
 bool DataSummary::LoadNextFile(){
@@ -356,6 +358,7 @@ bool DataSummary::CreateOutputFile(){
 	outtree2->Branch("OrphanedEventType",&orphantype);
 	outtree2->Branch("OrphanTimestamp",&orphantimestamp);
 	outtree2->Branch("OrphanCause",&orphancause);
+	return true;
 }
 
 bool DataSummary::CreatePlots(){
@@ -379,7 +382,7 @@ bool DataSummary::CreatePlots(){
 	AddTDiffPlots();
 	//AddTDiffPlots(30,30,0.5,"CtcToMrdTDiff");
 	//AddTDiffPlots(30,30,0.5,"TankToMrdTDiff");
-	
+	return true;	
 }
 
 // just histograms of timestamps of a given type with a time axis
@@ -436,7 +439,7 @@ bool DataSummary::AddRatePlots(int nbins){
 	allsystems_rate->GetXaxis()->SetLabelSize(0.03);
 	noloopback_rate->GetXaxis()->SetLabelSize(0.03);
 	orphan_rate->GetXaxis()->SetLabelSize(0.03);
-	
+	return true;	
 }
 
 // TODO refactor to break up plot types and remove triplets of calls
@@ -547,5 +550,6 @@ bool DataSummary::AddTDiffPlots(){
 //	ComputeMeanAndVariance(ctc_to_tank_vals, mean_ctc_to_tank, var_ctc_to_tank, window_size);
 	
 	// 5. you could also make a normalized histogram at each step to make a colour band plot
+	return true;
 	
 }

--- a/UserTools/DigitBuilderDoE/DigitBuilderDoE.cpp
+++ b/UserTools/DigitBuilderDoE/DigitBuilderDoE.cpp
@@ -99,7 +99,7 @@ bool DigitBuilderDoE::Execute(){
   int DigitId;
   int digitType;
   std::cout << "TOTAL DIGIT ARRAY SIZE: " << DigitIdArray->size() << std::endl;
-  for (int i=0;i<DigitIdArray->size();i++){
+  for (int i=0;i<(int)DigitIdArray->size();i++){
     if(DigitWhichDet->at(i) == "PMT8inch" && DigitCharges->at(i)>5.0){
       if((fPhotodetectorConfiguration == "PMT_only") || (fPhotodetectorConfiguration == "All")){
         //Load up a PMT RecoDigit's goods

--- a/UserTools/DigitBuilderROOT/DigitBuilderROOT.cpp
+++ b/UserTools/DigitBuilderROOT/DigitBuilderROOT.cpp
@@ -103,7 +103,7 @@ bool DigitBuilderROOT::Execute(){
 
   Log("DigitBuilderROOT Tool: Looping through and loading all digits",v_debug,verbosity);
   //Loop through all Digits and load their information as RecoDigits
-  for(int j=0;j<fDigitType->size();j++){
+  for(int j=0;j<(int)fDigitType->size();j++){
     int region = -999;
     double calT = fDigitT->at(j);
     double calQ = fDigitQ->at(j);

--- a/UserTools/FindMrdTracks/FindMrdTracks.cpp
+++ b/UserTools/FindMrdTracks/FindMrdTracks.cpp
@@ -357,7 +357,7 @@ if your class contains pointers, use TrackArray.Clear("C"). You MUST then provid
 	Log("FindMrdTracks tool: Writing MRD tracks to MRDTracks BoostStore",v_debug,verbosity);
 	m_data->Stores["MRDTracks"]->Set("NumMrdSubEvents",nummrdsubeventsthisevent);
 	m_data->Stores["MRDTracks"]->Set("NumMrdTracks",nummrdtracksthisevent);
-	if(nummrdtracksthisevent>theMrdTracks->size()){
+	if(nummrdtracksthisevent>(int)theMrdTracks->size()){
 		Log("FindMrdTracks tool: Growing theMrdTracks vector to size "+std::to_string(nummrdtracksthisevent),v_debug,verbosity);
 		theMrdTracks->resize(nummrdtracksthisevent);
 	}

--- a/UserTools/HitResiduals/HitResiduals.cpp
+++ b/UserTools/HitResiduals/HitResiduals.cpp
@@ -65,7 +65,7 @@ bool HitResiduals::Execute(){
 	double muontime;
 	Position muonvertex;
 	if(MCParticles){
-		for(int particlei=0; particlei<MCParticles->size(); particlei++){
+		for(int particlei=0; particlei<(int)MCParticles->size(); particlei++){
 			MCParticle aparticle = MCParticles->at(particlei);
 			//if(v_debug<verbosity) aparticle.Print();     // print if we're being *really* verbose
 			if(aparticle.GetParentPdg()!=0) continue;      // not a primary particle

--- a/UserTools/LAPPDAnalysis/LAPPDAnalysis.cpp
+++ b/UserTools/LAPPDAnalysis/LAPPDAnalysis.cpp
@@ -37,7 +37,7 @@ bool LAPPDAnalysis::Execute(){
       vector<Waveform<double>> Vfwavs;
 
       //loop over all Waveforms
-      for(int i=0; i<Vwavs.size(); i++){
+      for(int i=0; i < (int) Vwavs.size(); i++){
 
           Waveform<double> bwav = Vwavs.at(i);
           Waveform<double> blswav = SubtractSine(bwav);

--- a/UserTools/LAPPDBaselineSubtract/LAPPDBaselineSubtract.cpp
+++ b/UserTools/LAPPDBaselineSubtract/LAPPDBaselineSubtract.cpp
@@ -42,7 +42,7 @@ bool LAPPDBaselineSubtract::Execute(){
     vector<Waveform<double>> Vfwavs;
 
     //loop over all Waveforms
-    for(int i=0; i<Vwavs.size(); i++){
+    for(int i=0; i<(int)Vwavs.size(); i++){
 
         Waveform<double> bwav = Vwavs.at(i);
         Waveform<double> blswav = SubtractSine(bwav);

--- a/UserTools/LAPPDFilter/LAPPDFilter.cpp
+++ b/UserTools/LAPPDFilter/LAPPDFilter.cpp
@@ -46,7 +46,7 @@ bool LAPPDFilter::Execute(){
     vector<Waveform<double>> Vfwavs;
 
     //loop over all Waveforms
-    for(int i=0; i<Vwavs.size(); i++){
+    for(int i=0; i<(int)Vwavs.size(); i++){
 
         Waveform<double> bwav = Vwavs.at(i);
         Waveform<double> filtwav = Waveform_FFT(bwav);

--- a/UserTools/LAPPDFindPeak/LAPPDFindPeak.cpp
+++ b/UserTools/LAPPDFindPeak/LAPPDFindPeak.cpp
@@ -47,7 +47,7 @@ bool LAPPDFindPeak::Execute(){
 
     //loop over all Waveforms
     std::vector<LAPPDPulse> thepulses;
-    for(int i=0; i<Vwavs.size(); i++){
+    for(int i=0; i < (int) Vwavs.size(); i++){
 
         Waveform<double> bwav = Vwavs.at(i);
         thepulses = FindPulses_TOT(bwav.GetSamples());

--- a/UserTools/LAPPDIntegratePulse/LAPPDIntegratePulse.cpp
+++ b/UserTools/LAPPDIntegratePulse/LAPPDIntegratePulse.cpp
@@ -44,7 +44,7 @@ bool LAPPDIntegratePulse::Execute(){
 
     //loop over all Waveforms
     vector<double> acharge;
-    for(int i=0; i<Vwavs.size(); i++){
+    for(int i=0; i<(int)Vwavs.size(); i++){
 
         Waveform<double> bwav = Vwavs.at(i);
 
@@ -84,7 +84,7 @@ double LAPPDIntegratePulse::CalcIntegral(Waveform<double> hwav, double lowR, dou
 
   double tQ=0.;
 
-  if( (lowb>=0) && (hib<hwav.GetSamples()->size()) ){
+  if( (lowb>=0) && (hib<(int)hwav.GetSamples()->size()) ){
     for(int i=lowb; i<hib; i++){
       tQ+=((-hwav.GetSample(i))*Deltat);
     }

--- a/UserTools/LAPPDParseACC/LAPPDParseACC.cpp
+++ b/UserTools/LAPPDParseACC/LAPPDParseACC.cpp
@@ -270,7 +270,7 @@ bool LAPPDParseACC::FindChannelKeyFromACDCFile(int acdc_board, int acdc_ch, unsi
     det_board = thech.GetSignalCard();
     det_ch = thech.GetSignalChannel();
     //this is the golden find, return if found. 
-    if(det_board == acdc_board and det_ch == acdc_ch)
+    if((int)det_board == acdc_board and (int)det_ch == acdc_ch)
     {
       //change the key pointer to match the found channel
       key = k;

--- a/UserTools/LAPPDSaveROOT/LAPPDSaveROOT.cpp
+++ b/UserTools/LAPPDSaveROOT/LAPPDSaveROOT.cpp
@@ -94,7 +94,7 @@ LAPPDTree->Branch("PulseNum",&PulseNum);
   m_data->Stores["ANNIEEvent"]->Get("HitPulses",LAPPDHitPulses);
   m_data->Stores["ANNIEEvent"]->Get("PulseNum",PulseNum);
   std::cout<<LAPPDHitPulses.size()<<endl;
-  for(int i=0; i<LAPPDHitPulses.size(); i++){
+  for(int i=0; i<(int)LAPPDHitPulses.size(); i++){
     LAPPDPulse tempPulse = LAPPDHitPulses.at(i);
     std::cout<<tempPulse.GetChannelID()<<endl;
     if(tempPulse.GetChannelID()==0)
@@ -180,7 +180,7 @@ LAPPDTree->Branch("PulseNum",&PulseNum);
     vector<double> Vqs = pq->second;
 
     // loop over the charges and store to a hist
-    for(int pqi=0; pqi<Vqs.size(); pqi++){
+    for(int pqi=0; pqi<(int)Vqs.size(); pqi++){
       double theq = Vqs.at(pqi);
       if(channelno>=0&&channelno<NChannel){
         if(channelno!=TrigChannel) hQ[channelno]->Fill(theq);
@@ -188,7 +188,7 @@ LAPPDTree->Branch("PulseNum",&PulseNum);
     }
 
     //loop over all pulses fill histos and fill tree with pulse information
-    for(int i=0; i<Vpulses.size(); i++){
+    for(int i=0; i<(int)Vpulses.size(); i++){
       LAPPDPulse thepulse = Vpulses.at(i);
       if(channelno!=TrigChannel){
 
@@ -208,7 +208,7 @@ LAPPDTree->Branch("PulseNum",&PulseNum);
 
     //loop over all Waveforms, make histrograms
     std::vector<LAPPDPulse> thepulses;
-    for(int i=0; i<Vwavs.size(); i++){
+    for(int i=0; i<(int)Vwavs.size(); i++){
 
         Waveform<double> bwav = Vwavs.at(i);
         Waveform<double> bfwav;

--- a/UserTools/LAPPDSim/LAPPDDisplay.cpp
+++ b/UserTools/LAPPDSim/LAPPDDisplay.cpp
@@ -154,7 +154,7 @@ void LAPPDDisplay::MCTruthDrawing(int eventNumber, unsigned long actualTubeNo, v
 
     //Find the minimal time to create the histograms in a decent range
 		double mintime = 1000000;
-		for (int k = 0; k < mchits.size(); k++)
+		for (int k = 0; k < (int) mchits.size(); k++)
 		{
 			LAPPDHit ahit = mchits.at(k);
 			double atime = ahit.GetTime();
@@ -175,7 +175,7 @@ void LAPPDDisplay::MCTruthDrawing(int eventNumber, unsigned long actualTubeNo, v
 		TH2D* LAPPDPara = new TH2D(charNamePara, charNamePara, 256, mintime-1, mintime + 25.6, 60, -0.12, 0.12);
 
     //loop over all MC hits
-    for (int i = 0; i < mchits.size(); i++)
+    for (int i = 0; i < (int) mchits.size(); i++)
 		{
       //Getting the hit information
 			LAPPDHit ahit = mchits.at(i);
@@ -312,7 +312,7 @@ void LAPPDDisplay::RecoDrawing(int eventCounter, unsigned long tubeNumber, std::
     TH1D* waveformRight = new TH1D(waveformRightChar, waveformRightChar, 256, 0, 25.6);
 
     //loop over the samples
-		for (int j = 0; j < samplesleft->size(); j++)
+		for (int j = 0; j < (int) samplesleft->size(); j++)
 		{
       //The samples range from 0 to 256, which equals 0 to 25.6 ns.
       //Therefore one needs the sample number divided with 10 to get ns.

--- a/UserTools/LAPPDSim/LAPPDSim.cpp
+++ b/UserTools/LAPPDSim/LAPPDSim.cpp
@@ -212,7 +212,7 @@ bool LAPPDSim::Execute()
 			response.Initialise(_tf);
 
 			//loop over the hits on each lappd
-			for (int j = 0; j < mchits.size(); j++)
+			for (int j = 0; j < (int) mchits.size(); j++)
 			{
 				LAPPDHit ahit = mchits.at(j);
 				//Time is in [ns], we need [ps] for the LAPPDrespnse class' methods.

--- a/UserTools/LAPPDSim/LAPPDresponse.cpp
+++ b/UserTools/LAPPDSim/LAPPDresponse.cpp
@@ -182,7 +182,7 @@ Waveform<double> LAPPDresponse::GetTrace(int CHnumber, double starttime, double 
 
     //if there are pulses on the strip, loop over the N pulses on that strip
 	std::vector<LAPPDPulse> tempoVector = LAPPDPulseCluster.at(CHnumber);   //SD
-    for(int k=0; k<tempoVector.size(); k++){           //SD
+    for(int k=0; k<(int)tempoVector.size(); k++){           //SD
       //  for(int k=0; k<4; k++){
 
 

--- a/UserTools/LAPPDcfd/LAPPDcfd.cpp
+++ b/UserTools/LAPPDcfd/LAPPDcfd.cpp
@@ -84,14 +84,14 @@ bool LAPPDcfd::Execute(){
     std::vector<LAPPDPulse> thepulses;
 
     //loop over all Waveforms
-    for(int i=0; i<Vwavs.size(); i++){
+    for(int i=0; i<(int)Vwavs.size(); i++){
 
         Waveform<double> bwav = Vwavs.at(i);
 
         //std::cout<<"reconstructed pulses: "<<std::endl;;
 
         // loop over all candidate pulses on each waveform, as determined by the LAPPDFindPeak Tool
-        for(int j=0; j<Vpulses.size(); j++){
+        for(int j=0; j<(int)Vpulses.size(); j++){
 
           // for each pulse on the Waveform find the time using CFD1 algorithm
           double cfdtime = CFD_Discriminator1(bwav.GetSamples(),Vpulses.at(j));

--- a/UserTools/LAPPDlasertestHitFinder/LAPPDlasertestHitFinder.cpp
+++ b/UserTools/LAPPDlasertestHitFinder/LAPPDlasertestHitFinder.cpp
@@ -59,7 +59,7 @@ double MaxAmp =-1.0;
     TempVector = LAPPDPulseCluster.at(i);
      std::cout<<"Temp Vector Size "<<TempVector.size()<<endl;
      //     std::cout<<"Temp Vector Channel "<<TempVector.at(i).GetChannelID()<<endl;
-    for (int j = 0; j < TempVector.size(); j++){
+    for (int j = 0; j < (int)TempVector.size(); j++){
       if (TempVector.at(j).GetTime()*1000. >= MinTimeWindow && TempVector.at(j).GetTime()*1000. <= MaxTimeWindow){
         if (TempVector.at(j).GetPeak() > MaxAmp){
           MaxAmp = TempVector.at(j).GetPeak();
@@ -92,7 +92,7 @@ LAPPDPulse OpposPulse;
 
     // is there a pulse in the time window, on the opposite side of the strip? (I hope so)
     LAPPDPulse OpposPulse;
-    for (int j = 0; j < negaVector.size(); j++){
+    for (int j = 0; j < (int)negaVector.size(); j++){
     //Find pulse inside this vector that has the same peak and thetime
       if (fabs(negaVector.at(j).GetTime()*1000. - MaxPulse.GetTime()*1000.) < PTRange && (fabs(negaVector.at(j).GetPeak() - MaxAmp) / MaxAmp) <= 0.1){
         OpposPulse = negaVector.at(j);
@@ -111,8 +111,8 @@ LAPPDPulse OpposPulse;
 
 
 //Perpendicular position
-  double SumAbove;
-  double SumBelow;
+  double SumAbove=0;
+  double SumBelow=0;
 
   if(!TwoSided){
   std::cout<<"Not twosided"<<endl;
@@ -122,7 +122,7 @@ LAPPDPulse OpposPulse;
 
       neighbourVector = LAPPDPulseCluster.at(i);
 
-      for (int j = 0; j < neighbourVector.size(); j++){
+      for (int j = 0; j < (int)neighbourVector.size(); j++){
         if (fabs(neighbourVector.at(j).GetTime()*1000. - MaxPulse.GetTime()*1000.) < PTRange){
 
 	   NeighboursPulses.push_back(neighbourVector.at(j));
@@ -134,7 +134,7 @@ LAPPDPulse OpposPulse;
     if(NeighboursPulses.size()>0){
   for (int i=0; i<3; i++){
     int j=0;
-    if(j<NeighboursPulses.size()){
+    if(j<(int)NeighboursPulses.size()){
       if(i!=MaxPulse.GetChannelID())
 	{
 	SumAbove +=  (stripID[i] * NeighboursPulses.at(j).GetPeak());
@@ -158,7 +158,7 @@ LAPPDPulse OpposPulse;
     {
       for(int i =0; i<3; i++){
 	if(i!=MaxPulse.GetChannelID() && i!=OpposPulse.GetChannelID()){
-	  for (int j = 0; j < LAPPDPulseCluster.at(i).size(); j++){
+	  for (int j = 0; j < (int)LAPPDPulseCluster.at(i).size(); j++){
 	    if (fabs(LAPPDPulseCluster.at(i).at(j).GetTime()*1000. - MaxPulse.GetTime()*1000.) < PTRange){
 	       NeighboursPulses.push_back(LAPPDPulseCluster.at(i).at(j));
 	     }

--- a/UserTools/LikelihoodFitterCheck/LikelihoodFitterCheck.cpp
+++ b/UserTools/LikelihoodFitterCheck/LikelihoodFitterCheck.cpp
@@ -52,7 +52,7 @@ bool LikelihoodFitterCheck::Execute(){
   m_data->Stores.at("ANNIEEvent")->Get("EventNumber",fEventNumber);
   
   // Only check this event
-  if(fShowEvent>0 && fEventNumber!=fShowEvent) return true; 
+  if(fShowEvent>0 && (int)fEventNumber!=fShowEvent) return true; 
   	
   logmessage = "Likelihood check for MC Entry Number " + to_string(fMCEventNum) 
                + " , MC Trigger Number" + to_string(fMCTriggerNum) 

--- a/UserTools/LoadANNIEEvent/LoadANNIEEvent.cpp
+++ b/UserTools/LoadANNIEEvent/LoadANNIEEvent.cpp
@@ -123,7 +123,7 @@ bool LoadANNIEEvent::Execute() {
      m_data->CStore.Set("UserEvent",false);
      int user_evnum;
      m_data->CStore.Get("LoadEvNr",user_evnum);
-     if (user_evnum < total_entries_in_file_ && user_evnum >=0) current_entry_ = user_evnum;
+     if (user_evnum < (int) total_entries_in_file_ && user_evnum >=0) current_entry_ = user_evnum;
    }
 
   Log("ANNIEEvent store has "+std::to_string(total_entries_in_file_)+" entries",v_debug,verbosity_);
@@ -131,7 +131,7 @@ bool LoadANNIEEvent::Execute() {
     " ANNIEEvent input file \"" + input_filenames_.at(current_file_)
     + '\"', 1, verbosity_);
  
-  if (current_entry_ != offset_evnum) m_data->Stores["ANNIEEvent"]->Delete();	//ensures that we can access pointers without problems
+  if ((int)current_entry_ != offset_evnum) m_data->Stores["ANNIEEvent"]->Delete();	//ensures that we can access pointers without problems
 
   m_data->Stores["ANNIEEvent"]->GetEntry(current_entry_);  
   ++current_entry_;

--- a/UserTools/LoadCCData/LoadCCData.cpp
+++ b/UserTools/LoadCCData/LoadCCData.cpp
@@ -326,7 +326,7 @@ bool LoadCCData::Execute(){
 		Log("LoadCCData Tool: Getting HeftyInfo times",v_debug,verbosity);
 		currentminibufts = eventheftyinfo.all_times();
 		int numminibuffers = eventheftyinfo.num_minibuffers();
-		if(currentminibufts.size()!=numminibuffers){
+		if((int)currentminibufts.size()!=numminibuffers){
 			Log("LoadCCData Tool: HeftyInfo mismatch between num minibuffers "
 				+ to_string(numminibuffers) + "and size of returned times vector "
 				+ to_string(currentminibufts.size()),v_error,verbosity);
@@ -434,7 +434,7 @@ bool LoadCCData::PerformMatching(std::vector<unsigned long long> currentminibuft
 	// scan the TDC data and return all hits matching the current minibuffers
 	
 	// loop over minibuffers in this Execute() iteration
-	for(int minibufi=0; minibufi<currentminibufts.size(); minibufi++){
+	for(int minibufi=0; minibufi<(int)currentminibufts.size(); minibufi++){
 		// get this minibuffer's timestamp
 		uint64_t theminibufferTS = currentminibufts.at(minibufi);
 		if(theminibufferTS==0){
@@ -445,7 +445,7 @@ bool LoadCCData::PerformMatching(std::vector<unsigned long long> currentminibuft
 		// minibuffer of the current readout, we need to use the timestamp of the
 		// first minibuffer from the next readout
 		uint64_t thenextminibufferTS;
-		if((minibufi+1)<currentminibufts.size()){
+		if((minibufi+1)<(int)currentminibufts.size()){
 			thenextminibufferTS = currentminibufts.at(minibufi+1);
 			if(thenextminibufferTS==0){
 				//Log("LoadCCData Tool: Event Next Minibuffer Time Is 0!",v_warning,verbosity); // don't report twice
@@ -459,7 +459,7 @@ bool LoadCCData::PerformMatching(std::vector<unsigned long long> currentminibuft
 		if(thenextminibufferTS<theminibufferTS){
 			// get the next next minibuffer, to see where it lies
 			uint64_t nextnextminibufferTS;
-			if((minibufi+2)<currentminibufts.size()){
+			if((minibufi+2)<(int)currentminibufts.size()){
 				nextnextminibufferTS = currentminibufts.at(minibufi+2);
 			} else if(thenextminibufferTS!=nextreadoutfirstminibufstart){
 				nextnextminibufferTS=nextreadoutfirstminibufstart;
@@ -469,7 +469,7 @@ bool LoadCCData::PerformMatching(std::vector<unsigned long long> currentminibuft
 			
 			if(thenextminibufferTS!=0){  // zero timestamps are reported separately
 				logmessage="LoadCCData Tool: Non-monotonic increase of ADC timestamps!";
-				if((minibufi+1)<currentminibufts.size()){
+				if((minibufi+1)<(int)currentminibufts.size()){
 					logmessage+= " Minibuffer "+to_string(minibufi+1);
 				} else {
 					logmessage+= " First minibuffer from next readout";
@@ -554,7 +554,7 @@ bool LoadCCData::PerformMatching(std::vector<unsigned long long> currentminibuft
 			int64_t time_to_next_mb = thenextminibufferTS - MRDEventTime.GetNs();
 			
 			if(abs(time_to_this_mb) < abs(time_to_next_mb)){
-				if(abs(time_to_this_mb)<maxtimediff){
+				if(abs(time_to_this_mb)<(int)maxtimediff){
 					// it's a match!
 					
 					if(not (verbosity<v_debug)){
@@ -598,7 +598,7 @@ bool LoadCCData::PerformMatching(std::vector<unsigned long long> currentminibuft
 					Log("LoadCCData Tool: Looping over "+to_string(numhitsthisevent)+" TDC hits",v_debug,verbosity);
 					
 					int usedhiti=0; // since trigger hits are skipped
-					for(int hiti=0; hiti<numhitsthisevent; hiti++){
+					for(int hiti=0; hiti<(int)numhitsthisevent; hiti++){
 						
 						// Get the MRD PMT ID plugged into this TDC Card + Channel
 						uint32_t tubeid;
@@ -688,8 +688,8 @@ bool LoadCCData::PerformMatching(std::vector<unsigned long long> currentminibuft
 						// add them to the debug file, so we can see what we skipped
 						UInt_t numhitsthisevent = MRDData->OutNumber;
 						int usedhiti=0; // since trigger hits are skipped
-						for(int hiti=0; hiti<numhitsthisevent; hiti++){
-							uint32_t tubeid;
+						for(int hiti=0; hiti<(int)numhitsthisevent; hiti++){
+							uint32_t tubeid=std::numeric_limits<uint32_t>::max();
 							if (map_version == "v1") tubeid = TubeIdFromSlotChannel(MRDData->Slot->at(hiti),MRDData->Channel->at(hiti),1);
                                                 	else if (map_version == "v2") tubeid = TubeIdFromSlotChannel(MRDData->Slot->at(hiti),MRDData->Channel->at(hiti),2);
 							if(tubeid==std::numeric_limits<uint32_t>::max()){ continue; }
@@ -832,7 +832,7 @@ std::vector<uint64_t> LoadCCData::ConvertTimeStamps(unsigned long long LastSync,
 					Data, TriggerCounts, Rates);
 	std::vector<uint64_t> alltimestamps;
 	// loop over all the minibuffers in the readout and retrieve their timestamps
-	for(int minibufi=0; minibufi<TriggerCounts.size(); minibufi++){
+	for(int minibufi=0; minibufi<(int)TriggerCounts.size(); minibufi++){
 		unsigned long long thetimestamp = tempcard.trigger_time(minibufi);
 		alltimestamps.push_back(thetimestamp);
 	}
@@ -843,7 +843,7 @@ uint32_t LoadCCData::TubeIdFromSlotChannel(unsigned int slot, unsigned int chann
 	// map TDC Slot + Channel into a MRD PMT Tube ID
 	uint32_t tubeid=-1;
 	uint16_t slotchan = static_cast<uint16_t>(slot*100)+static_cast<uint16_t>(channel);
-	if (slotchan !=1831 && slotchan != 1731) //std::cout <<"LoadCCData: slotchan = "<<slotchan<<std::endl;
+	if ((int)slotchan !=1831 && (int)slotchan != 1731) //std::cout <<"LoadCCData: slotchan = "<<slotchan<<std::endl;
 	if (version == 1){
 		if(slotchantopmtidv1.count(slotchan)){
 			std::string stringPMTID = "1"+slotchantopmtidv1.at(slotchan);

--- a/UserTools/LoadGenieEvent/LoadGenieEvent.cpp
+++ b/UserTools/LoadGenieEvent/LoadGenieEvent.cpp
@@ -874,7 +874,7 @@ std::map<int,std::string>* LoadGenieEvent::GenerateMediumMap(){
 	mediummap.emplace(26,"M1018 Steel");
 	mediummap.emplace(28,"Decay Pipe Vacuum");
 	mediummap.emplace(31,"CT852");
-
+	return &mediummap;
 }
 
 #endif // LOADED_GENIE==1

--- a/UserTools/LoadRATPAC/LoadRATPAC.cpp
+++ b/UserTools/LoadRATPAC/LoadRATPAC.cpp
@@ -115,7 +115,7 @@ bool LoadRATPAC::Execute(){
 
   if(verbosity) std::cout<<"LoadRATPAC tool: Begin the PMT loop"<<std::endl;
   //PMT loop
-  for( size_t iPMT = 0; iPMT < ds->GetMC()->GetMCPMTCount(); iPMT++ ){
+  for( int iPMT = 0; iPMT < ds->GetMC()->GetMCPMTCount(); iPMT++ ){
     if(verbosity>2) std::cout<<"getting PMT "<<iPMT<<std::endl;
     RAT::DS::MCPMT *aPMT = ds->GetMC()->GetMCPMT(iPMT);
     int tubeid = aPMT->GetID();
@@ -140,7 +140,7 @@ bool LoadRATPAC::Execute(){
 
   //LAPPD loop
   if(verbosity) std::cout<<"LoadRATPAC tool: Begin the LAPPD loop"<<std::endl;
-  for( size_t iLAPPD = 0; iLAPPD < ds->GetMC()->GetMCLAPPDCount(); iLAPPD++ ){
+  for( int iLAPPD = 0; iLAPPD < ds->GetMC()->GetMCLAPPDCount(); iLAPPD++ ){
     if(verbosity>2) std::cout<<"getting LAPPD "<<iLAPPD<<std::endl;
     RAT::DS::MCLAPPD *aLAPPD = ds->GetMC()->GetMCLAPPD(iLAPPD);
     int lappdid = aLAPPD->GetID();

--- a/UserTools/LoadRawData/LoadRawData.cpp
+++ b/UserTools/LoadRawData/LoadRawData.cpp
@@ -311,10 +311,11 @@ std::vector<std::string> LoadRawData::OrganizeRunParts(std::string FileList)
       //for(int i = 0;i<splitline.size(); i ++){
         //std::string filename = splitline.at(i);
         std::string filename = line;
-	    int rawfilerun, rawfilesubrun, rawfilepart;
+	int rawfilerun=-1;
+        int rawfilesubrun, rawfilepart;
         int numargs = 0;
-	    try{
-	    	std::reverse(line.begin(),line.end());
+	try{
+	    std::reverse(line.begin(),line.end());
             //Part number is the first character now.
             size_t pplace = line.find("p");
             std::string part = line.substr(0,pplace);
@@ -352,11 +353,11 @@ std::vector<std::string> LoadRawData::OrganizeRunParts(std::string FileList)
     if(verbosity>v_debug) std::cout << "MRDDataDecoder Tool: Organizing filenames: " << std::endl;
     //Now, organize files based on the part number array
     std::vector < std::pair<int,std::string>> SortingVector;
-    for (int i = 0; i < UnorganizedFileList.size(); i++){
+    for (int i = 0; i < (int) UnorganizedFileList.size(); i++){
       SortingVector.push_back( std::make_pair(RunCodes.at(i),UnorganizedFileList.at(i)));
     }
     std::sort(SortingVector.begin(),SortingVector.end());
-    for (int j = 0; j<SortingVector.size();j ++) {
+    for (int j = 0; j < (int) SortingVector.size();j ++) {
       OrganizedFiles.push_back(SortingVector.at(j).second);
     }
   } else {

--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -249,7 +249,7 @@ bool LoadWCSim::Execute(){
 			}
 		}
 		// Pre-load entry so we can stop the loop if it this was the last one in the chain
-		if(MCEventNum>=MaxEntries && MaxEntries>0){
+		if((int)MCEventNum>=MaxEntries && MaxEntries>0){
 			std::cout<<"LoadWCSim Tool: Reached max entries specified in config file, terminating ToolChain"<<endl;
 			m_data->vars.Set("StopLoop",1);
 		} else {
@@ -734,7 +734,7 @@ bool LoadWCSim::Execute(){
 	
 	// Pre-load next entry so we can stop the loop if it this was the last one in the chain
 	if(newentry){  // if next loop is processing the next trigger in the same entry, no need to re-load it
-		if(MCEventNum>=MaxEntries && MaxEntries>0){
+		if((int)MCEventNum>=MaxEntries && MaxEntries>0){
 			cout<<"LoadWCSim Tool: Reached max entries specified in config file, terminating ToolChain"<<endl;
 			m_data->vars.Set("StopLoop",1);
 		} else {
@@ -1237,7 +1237,7 @@ void LoadWCSim::MakeParticleToPmtMap(WCSimRootTrigger* thistrig, WCSimRootTrigge
 		int tubeid = digihit->GetTubeId();
 		// loop over the photons in this digit
 		std::vector<int> truephotonindices = digihit->GetPhotonIds();
-		for(int truephoton=0; truephoton<truephotonindices.size(); truephoton++){
+		for(int truephoton=0; truephoton<(int)truephotonindices.size(); truephoton++){
 			int thephotonsid = truephotonindices.at(truephoton);
 			// get the index of the photon CherenkovHit object in the TClonesArray
 			if(WCSimVersion<2){
@@ -1298,7 +1298,7 @@ std::vector<int> LoadWCSim::GetHitParentIds(WCSimRootCherenkovDigiHit* digihit, 
 	
 	// loop over the photons in this digit
 	std::vector<int> truephotonindices = digihit->GetPhotonIds();
-	for(int truephoton=0; truephoton<truephotonindices.size(); truephoton++){
+	for(int truephoton=0; truephoton<(int)truephotonindices.size(); truephoton++){
 		int thephotonsid = truephotonindices.at(truephoton);
 		// get the indices of the digit's photon CherenkovHitTime objects
 		if(WCSimVersion<2){

--- a/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
+++ b/UserTools/LoadWCSimLAPPD/LoadWCSimLAPPD.cpp
@@ -170,7 +170,7 @@ bool LoadWCSimLAPPD::Execute(){
 		} else {
 			if(verbosity>2) cout<<"looping over "<<unassignedhits.size()
 							  <<" LAPPD hits that weren't in the first trigger window"<<endl;
-			for(int hiti=0; hiti<unassignedhits.size(); hiti++){
+			for(int hiti=0; hiti<(int)unassignedhits.size(); hiti++){
 				MCLAPPDHit nexthit = unassignedhits.at(hiti);
 				double digitst = nexthit.GetTime(); // ABSOLUTE
 				double relativedigitst=digitst-wcsimtriggertime; // relative to trigger time

--- a/UserTools/MCParticleProperties/MCParticleProperties.cpp
+++ b/UserTools/MCParticleProperties/MCParticleProperties.cpp
@@ -76,7 +76,7 @@ bool MCParticleProperties::Execute(){
 	// Loop over reconstructed tracks and calculate additional properties
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	Log("MCParticleProperties Tool: Looping over MCParticles",v_debug,verbosity);
-	for(int tracki=0; tracki<MCParticles->size(); tracki++){
+	for(int tracki=0; tracki<(int)MCParticles->size(); tracki++){
 		Log("MCParticleProperties Tool: Processing MCParticle "+to_string(tracki),v_debug,verbosity);
 		// Get the track details
 		MCParticle* nextparticle = &MCParticles->at(tracki);

--- a/UserTools/MonitorSimReceive/MonitorSimReceive.cpp
+++ b/UserTools/MonitorSimReceive/MonitorSimReceive.cpp
@@ -103,10 +103,10 @@ bool MonitorSimReceive::Execute(){
     } 
     else if (mode == "FileList"){
     std::string datapath;
-    if (i_loop<vec_filename.size()){
+    if (i_loop<(int)vec_filename.size()){
       datapath = vec_filename.at(i_loop);
       if (verbosity > 2) std::cout <<"Current file: "<<datapath<<std::endl;
-      if (i_loop == vec_filename.size()-1) m_data->vars.Set("StopLoop",true);
+      if (i_loop == (int)vec_filename.size()-1) m_data->vars.Set("StopLoop",true);
     } else {
       m_data->vars.Set("StopLoop",true);
       if (indata!=0){ indata->Close(); indata->Delete(); delete indata; indata = 0;}

--- a/UserTools/MonitorTankTime/MonitorTankTime.cpp
+++ b/UserTools/MonitorTankTime/MonitorTankTime.cpp
@@ -1190,7 +1190,7 @@ void MonitorTankTime::WriteToFile(){
   bool omit_entries = false;
   for (int i_entry = 0; i_entry < n_entries; i_entry++){
     t->GetEntry(i_entry);
-    if (t_start == t_file_start) {
+    if ((long)t_start == t_file_start) {
       Log("WARNING (MonitorTankTime): WriteToFile: Wanted to write data from file that is already written to DB. Omit entries",v_warning,verbosity);
       omit_entries = true;
     }

--- a/UserTools/MonitorTrigger/MonitorTrigger.cpp
+++ b/UserTools/MonitorTrigger/MonitorTrigger.cpp
@@ -493,7 +493,7 @@ void MonitorTrigger::WriteToFile(){
   bool omit_entries = false;
   for (int i_entry = 0; i_entry < n_entries; i_entry++){
     t->GetEntry(i_entry);
-    if (t_start == t_file_start) {
+    if ((long)t_start == t_file_start) {
       Log("WARNING (MonitorTrigger): WriteToFile: Wanted to write data from file that is already written to DB. Omit entries.",v_warning,verbosity);
       omit_entries = true;
     }

--- a/UserTools/MrdDiscriminatorScan/MrdDiscriminatorScan.cpp
+++ b/UserTools/MrdDiscriminatorScan/MrdDiscriminatorScan.cpp
@@ -409,7 +409,7 @@ bool MrdDiscriminatorScan::CountChannelHits(BoostStore* MRDData, std::map<int,st
 	Log(logmessage,v_debug,verbosity);
 	
 	// loop over the readouts
-	for (int readouti = 0; readouti <  total_number_entries; readouti++){
+	for (int readouti = 0; readouti <  (int) total_number_entries; readouti++){
 		
 		MRDData->GetEntry(readouti);       // MRDData is a multi-entry BoostStore: load the next event
 		MRDOut mrdReadout;                 // class defined in the DataModel to contain an MRD readout
@@ -424,7 +424,7 @@ bool MrdDiscriminatorScan::CountChannelHits(BoostStore* MRDData, std::map<int,st
 		ULong64_t timestamp = mrdReadout.TimeStamp;
 		TimeClass timestampclass(timestamp*1000*1000);                            // [ms] to [ns]
 		if(readouti==0) first_timestamp = timestampclass;                         // [ms] to [s]
-		if(readouti==(total_number_entries-1)) last_timestamp = timestampclass;   // [ms] to [s]
+		if(readouti==(int)(total_number_entries-1)) last_timestamp = timestampclass;   // [ms] to [s]
 		
 		// we don't actually care about the times of the hits, we just want to count how many there were
 		// so just for interest
@@ -434,7 +434,7 @@ bool MrdDiscriminatorScan::CountChannelHits(BoostStore* MRDData, std::map<int,st
 		}
 		
 		// loop over all hits in this readout
-		for (int hiti = 0; hiti < mrdReadout.Slot.size(); hiti++){
+		for (int hiti = 0; hiti < (int)mrdReadout.Slot.size(); hiti++){
 			
 			// get the channel info
 			int crate_num = mrdReadout.Crate.at(hiti);

--- a/UserTools/MrdDistributions/MrdDistributions.cpp
+++ b/UserTools/MrdDistributions/MrdDistributions.cpp
@@ -265,7 +265,7 @@ bool MrdDistributions::Execute(){
 		return false;
 	}
 	// sanity check
-	if(theMrdTracks->size()<numtracksinev){
+	if((int)theMrdTracks->size()<numtracksinev){
 		cerr<<"Too few entries in MRDTracks vector relative to NumMrdTracks!"<<endl;
 		// more is fine as we don't shrink for efficiency
 	}
@@ -588,7 +588,7 @@ bool MrdDistributions::Execute(){
 	// Loop over true tracks and record their properties
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	Log("MrdDistributions Tool: Looping over MCParticles",v_debug,verbosity);
-	for(int tracki=0; tracki<MCParticles->size(); tracki++){
+	for(int tracki=0; tracki<(int)MCParticles->size(); tracki++){
 		MCParticle* nextparticle = &MCParticles->at(tracki);
 		if(nextparticle->GetPdgCode()!=13)                continue; // only interested in muons
 		if(not (nextparticle->GetEntersMrd()))            continue; // only record tracks that entered the MRD

--- a/UserTools/MrdEfficiency/MrdEfficiency.cpp
+++ b/UserTools/MrdEfficiency/MrdEfficiency.cpp
@@ -210,7 +210,7 @@ bool MrdEfficiency::Execute(){
 	int primarymuonid = 0;
 	if(MCParticles){
 		Log("MrdEfficiency Tool: Num MCParticles = "+to_string(MCParticles->size()),v_message,verbosity);
-		for(int particlei=0; particlei<MCParticles->size(); particlei++){
+		for(int particlei=0; particlei<(int)MCParticles->size(); particlei++){
 			MCParticle aparticle = MCParticles->at(particlei);
 			if(aparticle.GetPdgCode()==13){
 				logmessage = "True muon found with parent type " + to_string(aparticle.GetParentPdg())
@@ -289,7 +289,7 @@ bool MrdEfficiency::Execute(){
 		m_data->Stores["MRDTracks"]->Print(false);
 		return false;
 	}
-	if(theMrdTracks->size()<numtracksinev){
+	if((int)theMrdTracks->size()<numtracksinev){
 		cerr<<"Too few entries in MRDTracks vector relative to NumMrdTracks!"<<endl;
 		// more is fine as we don't shrink for efficiency
 	}
@@ -318,7 +318,7 @@ bool MrdEfficiency::Execute(){
 	// Produce a matrix of figures of merit for how well each reco track matches each true particle
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	std::vector<std::vector<double> > matchmerits (paddlesInTrackReco.size(), std::vector<double>(paddlesInTrackTrue.size(),0));
-	for(int recotracki=0; recotracki<paddlesInTrackReco.size(); recotracki++){
+	for(int recotracki=0; recotracki<(int)paddlesInTrackReco.size(); recotracki++){
 		// get the next reco track
 		std::map<int,std::vector<int>>::iterator arecotrack = paddlesInTrackReco.begin();
 		std::advance(arecotrack,recotracki);
@@ -330,7 +330,7 @@ bool MrdEfficiency::Execute(){
 		Log(logmessage,v_debug,verbosity);
 		
 		// scan through the true tracks and calculate FOM against this reco track
-		for(int truetracki=0; truetracki<paddlesInTrackTrue.size(); truetracki++){
+		for(int truetracki=0; truetracki<(int)paddlesInTrackTrue.size(); truetracki++){
 			// get the next true track
 			std::map<int,std::vector<int>>::iterator atruetrack = paddlesInTrackTrue.begin();
 			std::advance(atruetrack,truetracki);
@@ -346,7 +346,7 @@ bool MrdEfficiency::Execute(){
 			int num_extra_reco_paddles = 0;
 			
 			// scan over the reconstructed paddles
-			for(int arecopaddlei=0; arecopaddlei<reco_tracks_paddles.size(); arecopaddlei++){
+			for(int arecopaddlei=0; arecopaddlei<(int)reco_tracks_paddles.size(); arecopaddlei++){
 				int therecopaddleid = reco_tracks_paddles.at(arecopaddlei);
 				// see if this paddle is also in the true paddles
 				bool in_true = std::count(true_tracks_paddles.begin(),true_tracks_paddles.end(),therecopaddleid);
@@ -354,7 +354,7 @@ bool MrdEfficiency::Execute(){
 				else num_extra_reco_paddles++;
 			}
 			// scan over the true paddles
-			for(int atruepaddlei=0; atruepaddlei<true_tracks_paddles.size(); atruepaddlei++){
+			for(int atruepaddlei=0; atruepaddlei<(int)true_tracks_paddles.size(); atruepaddlei++){
 				int thetruepaddleid = true_tracks_paddles.at(atruepaddlei);
 				bool in_reco = std::count(reco_tracks_paddles.begin(),reco_tracks_paddles.end(),thetruepaddleid);
 				if(not in_reco) num_true_paddles_unmatched++;
@@ -388,7 +388,7 @@ bool MrdEfficiency::Execute(){
 	while(true){
 		double currentmax=0.;
 		int maxrow=-1, maxcolumn=-1;
-		for(int rowi=0; rowi<matchmerits.size(); rowi++){
+		for(int rowi=0; rowi<(int)matchmerits.size(); rowi++){
 			std::vector<double> therow = matchmerits.at(rowi);
 			std::vector<double>::iterator thisrowsmaxit = std::max_element(therow.begin(), therow.end());
 			if((thisrowsmaxit!=therow.end())&&((*thisrowsmaxit)>currentmax)){

--- a/UserTools/MrdPaddleEfficiencyPreparer/MrdPaddleEfficiencyPreparer.cpp
+++ b/UserTools/MrdPaddleEfficiencyPreparer/MrdPaddleEfficiencyPreparer.cpp
@@ -171,7 +171,7 @@ bool MrdPaddleEfficiencyPreparer::Execute(){
 					std::vector<Int_t> truetrackpdgs;
 					m_data->CStore.Get("TrueTrackVertices",truetrackvertices);
 					m_data->CStore.Get("TrueTrackPDGs",truetrackpdgs);
-					for (int i=0; i< truetrackvertices.size(); i++){
+					for (int i=0; i< (int) truetrackvertices.size(); i++){
 						if (i==0) continue; 	//first vertex is not saved correctly
 						Position startvertex = truetrackvertices.at(i).first;
 						Position stopvertex = truetrackvertices.at(i).second;
@@ -192,7 +192,7 @@ bool MrdPaddleEfficiencyPreparer::Execute(){
 
 				if (PMTsHit.size() < 50 ){
 
-					for (int i_layer = 0; i_layer < zLayers.size(); i_layer++){
+					for (int i_layer = 0; i_layer < (int) zLayers.size(); i_layer++){
 						
 						// Exclude first and layer from efficiency determination						
 						if (i_layer == 0 || i_layer == int(zLayers.size()) -1) continue;

--- a/UserTools/PMTDataDecoder/PMTDataDecoder.cpp
+++ b/UserTools/PMTDataDecoder/PMTDataDecoder.cpp
@@ -332,7 +332,7 @@ std::vector<DecodedFrame> PMTDataDecoder::DecodeFrames(std::vector<uint32_t> ban
 {
   Log("PMTDataDecoder Tool: Decoding frames now ",v_debug, verbosity);
   Log("PMTDataDecoder Tool: Bank size is "+to_string(bank.size()),v_debug, verbosity);
-  uint64_t tempword;
+  uint64_t tempword=0;
   std::vector<DecodedFrame> frames;  //What we will return
   std::vector<uint16_t> samples;
   samples.resize(40); //Well, if there's 480 bits per frame of samples max, this fits it
@@ -354,8 +354,8 @@ std::vector<DecodedFrame> PMTDataDecoder::DecodeFrames(std::vector<uint32_t> ban
         wordindex += 1;
       }
       //Logic to search for record headers
-      if((tempword&0xfff)==RECORD_HEADER_LABELPART1) haverecheader_part1 = true;
-      else if (haverecheader_part1 && ((tempword&0xfff)==RECORD_HEADER_LABELPART2)){
+      if((int)(tempword&0xfff)==RECORD_HEADER_LABELPART1) haverecheader_part1 = true;
+      else if (haverecheader_part1 && ((int)(tempword&0xfff)==RECORD_HEADER_LABELPART2)){
         if(verbosity>vv_debug) std::cout << "FOUND A RECORD HEADER. AT INDEX " << sampleindex << std::endl;
         thisframe.has_recordheader=true;
         thisframe.recordheader_starts.push_back(sampleindex-1);
@@ -513,7 +513,7 @@ void PMTDataDecoder::StoreFinishedWaveform(int CardID, int ChannelID)
   Log("PMTDataDecoder Tool: Finished Wave Length"+to_string(WaveBank.size()),v_debug, verbosity);
   Log("PMTDataDecoder Tool: Finished Wave Clock time (ns)"+to_string(FinishedWaveTrigTime),v_debug, verbosity);
 
-  if(FinishedWave.size()>ADCCountsToBuild){
+  if((int)FinishedWave.size()>ADCCountsToBuild){
     NewWavesBuilt = true;
     if(FinishedPMTWaves->count(FinishedWaveTrigTime) == 0) {
       std::map<std::vector<int>, std::vector<uint16_t> > WaveMap;

--- a/UserTools/PhaseIIADCCalibrator/PhaseIIADCCalibrator.cpp
+++ b/UserTools/PhaseIIADCCalibrator/PhaseIIADCCalibrator.cpp
@@ -453,7 +453,8 @@ PhaseIIADCCalibrator::make_calibrated_waveforms_ze3ra_multi(
   for (const auto& raw_waveform : raw_waveforms) {
     std::vector<uint16_t> baselines;
     std::vector<size_t> RepresentationRegion;
-    double first_baseline, first_sigma_baseline;
+    double first_baseline=0;
+    double first_sigma_baseline;
     double baseline, sigma_baseline;
     const size_t nsamples = raw_waveform.Samples().size();
     for(size_t starting_sample = 0; starting_sample < nsamples; starting_sample += baseline_rep_samples){
@@ -477,7 +478,7 @@ PhaseIIADCCalibrator::make_calibrated_waveforms_ze3ra_multi(
     std::vector<double> cal_data;
     const std::vector<unsigned short>& raw_data = raw_waveform.Samples();
     for (const auto& asample: raw_data){
-      for(int j = 0; j<RepresentationRegion.size(); j++){
+      for(int j = 0; j<(int)RepresentationRegion.size(); j++){
         if(asample < RepresentationRegion.at(j)){
           cal_data.push_back((static_cast<double>(asample) - baselines.at(j))
             * ADC_TO_VOLT);
@@ -559,7 +560,7 @@ PhaseIIADCCalibrator::make_calibrated_waveforms_rootfit(
     
     // update our TGraph's datapoints with the new datapoints
     Log("PhaseIIADCCalibrator Tool: Setting TGraph datapoints", v_debug, verbosity);
-    for(int samplei=0; samplei<raw_data.size(); ++samplei){
+    for(int samplei=0; samplei<(int)raw_data.size(); ++samplei){
       calibrated_waveform_tgraph->SetPoint(samplei,samplei,raw_data.at(samplei));
     }
     
@@ -581,11 +582,11 @@ PhaseIIADCCalibrator::make_calibrated_waveforms_rootfit(
     } else {
       Log("PhaseIIADCCalibrator Tool: polynomial fit of baseline succeeded, noting parameters",v_debug,verbosity);
       // make a note of the current fit parameters, in case we re-do the fit later
-      for(uint orderi=0; orderi<(baseline_fit_order+1); ++orderi){
+      for(int orderi=0; orderi<(baseline_fit_order+1); ++orderi){
         fitpars.at(orderi) = fit_result->Value(orderi);
       }
       logmessage="PhaseIIADCCalibrator Tool: Baseline fit success: fit function was: ";
-      for(uint orderi=0; orderi<(baseline_fit_order+1); ++orderi){
+      for(int orderi=0; orderi<(baseline_fit_order+1); ++orderi){
         logmessage+= to_string(fitpars.at(orderi))+"*x^"+to_string(orderi);
         if(orderi<baseline_fit_order) logmessage+=" + ";
       }
@@ -646,7 +647,7 @@ PhaseIIADCCalibrator::make_calibrated_waveforms_rootfit(
       
       // update our TGraph's datapoints with the new datapoints
       Log("PhaseIIADCCalibrator Tool: Setting TGraph datapoints", v_debug, verbosity);
-      for(int samplei=0; samplei<cal_data.size(); ++samplei){
+      for(int samplei=0; samplei<(int)cal_data.size(); ++samplei){
         calibrated_waveform_tgraph->SetPoint(samplei,samplei,cal_data.at(samplei));
       }
       
@@ -810,7 +811,7 @@ PhaseIIADCCalibrator::make_calibrated_waveforms_rootfit(
         Log("PhaseIIADCCalibrator Tool: polynomial re-fit of baseline failed!",v_warning,verbosity);
       } else {
         logmessage="PhaseIIADCCalibrator Tool: Baseline re-fit success: fit function was: ";
-        for(uint orderi=0; orderi<(baseline_fit_order+1); ++orderi){
+        for(int orderi=0; orderi<(baseline_fit_order+1); ++orderi){
           logmessage+= to_string(fit_result->Value(orderi))+"*x^"+to_string(orderi);
           if(orderi<baseline_fit_order) logmessage+=" + ";
         }
@@ -818,12 +819,12 @@ PhaseIIADCCalibrator::make_calibrated_waveforms_rootfit(
         
         Log("PhaseIIADCCalibrator Tool: Combining with previous fit for final fit parameters", v_debug, verbosity);
         // get the new fit parameters and add them to the previous ones.
-        for(uint orderi=0; orderi<(baseline_fit_order+1); ++orderi){
+        for(int orderi=0; orderi<(baseline_fit_order+1); ++orderi){
           double new_parameter_val = fit_result->Value(orderi) + fitpars.at(orderi);
           calibrated_waveform_fit->SetParameter(orderi, new_parameter_val);
         }
         logmessage="PhaseIIADCCalibrator Tool: Final fit function was: ";
-        for(uint orderi=0; orderi<(baseline_fit_order+1); ++orderi){
+        for(int orderi=0; orderi<(baseline_fit_order+1); ++orderi){
           logmessage+= to_string(fit_result->Value(orderi))+"*x^"+to_string(orderi);
           if(orderi<baseline_fit_order) logmessage+=" + ";
         }
@@ -898,8 +899,8 @@ void PhaseIIADCCalibrator::make_raw_led_waveforms(unsigned long channel_key,
   //Get the windows for this channel key
   std::vector<std::vector<int>> thispmt_adc_windows;
   thispmt_adc_windows = this->get_db_windows(channel_key);
-  for(int j=0; j<raw_waveforms.size(); j++){
-    for(int i = 0; i<thispmt_adc_windows.size();i++){
+  for(int j=0; j<(int)raw_waveforms.size(); j++){
+    for(int i = 0; i<(int)thispmt_adc_windows.size();i++){
       // Make a waveform out of this subwindow, plus the number of samples
       // used for background estimation
       std::vector<int> awindow = thispmt_adc_windows.at(i);
@@ -916,7 +917,7 @@ void PhaseIIADCCalibrator::make_raw_led_waveforms(unsigned long channel_key,
       std::vector<uint16_t> led_waveform;
       //FIXME: want start time of window, not of the full raw waveform
       uint64_t start_time = raw_waveforms.at(j).GetStartTime();
-      for (size_t s = windowmin; s < windowmax; ++s) {
+      for (int s = windowmin; s < windowmax; ++s) {
         led_waveform.push_back(raw_waveforms.at(j).GetSample(s));
       }
       Waveform<uint16_t> led_rawwave{start_time,led_waveform};

--- a/UserTools/PhaseIIADCHitFinder/PhaseIIADCHitFinder.cpp
+++ b/UserTools/PhaseIIADCHitFinder/PhaseIIADCHitFinder.cpp
@@ -524,7 +524,7 @@ std::vector<ADCPulse> PhaseIIADCHitFinder::find_pulses_bythreshold(
       in_pulse = false;
       //check if sample is within an already defined window
       for (int i=0; i< (int) window_starts.size(); i++){
-        if ((s>(int)window_starts.at(i)) && (s<(int)window_ends.at(i))){
+        if (((int)s>window_starts.at(i)) && ((int)s<window_ends.at(i))){
           in_pulse = true;
           if(verbosity>4) std::cout << "PhaseIIADCHitFinder: FOUND PULSE" << std::endl;
         }

--- a/UserTools/PhaseIIADCHitFinder/PhaseIIADCHitFinder.cpp
+++ b/UserTools/PhaseIIADCHitFinder/PhaseIIADCHitFinder.cpp
@@ -379,7 +379,7 @@ bool PhaseIIADCHitFinder::build_pulse_and_hit_map(
   HitsOnPMT = this->convert_adcpulses_to_hits(channel_key,pulse_vec);
   Log("PhaseIIADCHitFinder: Filling hit map.",
       v_debug, verbosity);
-  for(int j=0; j < HitsOnPMT.size(); j++){
+  for(int j=0; j < (int) HitsOnPMT.size(); j++){
     Hit ahit = HitsOnPMT.at(j);
     if(hmap.count(channel_key)==0) hmap.emplace(channel_key, std::vector<Hit>{ahit});
     else hmap.at(channel_key).push_back(ahit);
@@ -408,7 +408,7 @@ std::vector<ADCPulse> PhaseIIADCHitFinder::find_pulses_bywindow(
   
   std::vector<ADCPulse> pulses;
 
-  for(int i = 0; i<adc_windows.size();i++){
+  for(int i = 0; i<(int)adc_windows.size();i++){
     // Integrate the pulse to get its area. Use a Riemann sum. Also get
     // the raw amplitude (maximum ADC value within the pulse) and the
     // sample at which the peak occurs.
@@ -523,8 +523,8 @@ std::vector<ADCPulse> PhaseIIADCHitFinder::find_pulses_bythreshold(
     for (size_t s = 0; s < num_samples; ++s) {
       in_pulse = false;
       //check if sample is within an already defined window
-      for (int i=0; i< window_starts.size(); i++){
-        if ((s>window_starts.at(i)) && (s<window_ends.at(i))){
+      for (int i=0; i< (int) window_starts.size(); i++){
+        if ((s>(int)window_starts.at(i)) && (s<(int)window_ends.at(i))){
           in_pulse = true;
           if(verbosity>4) std::cout << "PhaseIIADCHitFinder: FOUND PULSE" << std::endl;
         }
@@ -536,14 +536,14 @@ std::vector<ADCPulse> PhaseIIADCHitFinder::find_pulses_bythreshold(
         }
     }
     //If any pulse crosses the sampling window, restrict it's value to within window
-    for (int j=0; j<window_starts.size(); j++){
+    for (int j=0; j < (int) window_starts.size(); j++){
       if (window_starts.at(j) < 0) window_starts.at(j) = 0;
       if (window_ends.at(j) > static_cast<int>(num_samples)) window_ends.at(j) = static_cast<int>(num_samples)-1;
     }
     // Integrate the pulse to get its area. Use a Riemann sum. Also get
     // the raw amplitude (maximum ADC value within the pulse) and the
     // sample at which the peak occurs.
-    for (int i = 0; i< window_starts.size(); i++){
+    for (int i = 0; i < (int) window_starts.size(); i++){
       size_t pulse_start_sample = static_cast<size_t>(window_starts.at(i));
       size_t pulse_end_sample = static_cast<size_t>(window_ends.at(i));
       unsigned long raw_area = 0; // ADC * samples
@@ -655,9 +655,9 @@ std::vector<ADCPulse> PhaseIIADCHitFinder::find_pulses_bythreshold(
 
 std::vector<Hit> PhaseIIADCHitFinder::convert_adcpulses_to_hits(unsigned long channel_key,std::vector<std::vector<ADCPulse>> pulses){
   std::vector<Hit> thispmt_hits;
-  for(int i=0; i < pulses.size(); i++){
+  for(int i=0; i < (int) pulses.size(); i++){
     std::vector<ADCPulse> apulsevector = pulses.at(i);
-    for(int j=0; j < apulsevector.size(); j++){
+    for(int j=0; j < (int) apulsevector.size(); j++){
       ADCPulse apulse = apulsevector.at(j);
       //Get the time and charge
       double time = apulse.peak_time();

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -379,13 +379,13 @@ bool PhaseIITreeMaker::Execute(){
     }
     
     int cluster_num = 0;
-    for (int i=0; i<MrdTimeClusters.size(); i++){
+    for (int i=0; i<(int)MrdTimeClusters.size(); i++){
       Log("PhaseIITreeMaker Tool: Resetting variables prior to getting MRD cluster info",v_debug,verbosity);
       this->ResetVariables();
       fMRDClusterHits = 0;
       fVetoHit = TrigHasVetoHit;
       std::vector<int> ThisClusterIndices = MrdTimeClusters.at(i);
-      for(int j=0;j<ThisClusterIndices.size(); j++){
+      for(int j=0;j<(int)ThisClusterIndices.size(); j++){
         fMRDHitT.push_back(mrddigittimesthisevent.at(ThisClusterIndices.at(j)));
         fMRDHitDetID.push_back(mrddigitpmtsthisevent.at(ThisClusterIndices.at(j)));
         fMRDClusterHits+=1;
@@ -447,7 +447,7 @@ bool PhaseIITreeMaker::Execute(){
         std::cout << "BeamClusterAnalysis tool: No MRD clusters found.  Will be no tracks." << std::endl;
         return false;
       }
-      for(int i=0; i < MrdTimeClusters.size(); i++) fNumClusterTracks += this->LoadMRDTrackReco(i);
+      for(int i=0; i < (int) MrdTimeClusters.size(); i++) fNumClusterTracks += this->LoadMRDTrackReco(i);
     }
 
     bool got_reco = false;
@@ -653,7 +653,7 @@ void PhaseIITreeMaker::LoadTankClusterHits(std::vector<Hit> cluster_hits){
   fClusterCharge = 0;
   fClusterPE = 0;
   fClusterHits = 0;
-  for (int i = 0; i<cluster_hits.size(); i++){
+  for (int i = 0; i<(int)cluster_hits.size(); i++){
     int channel_key = cluster_hits.at(i).GetTubeId();
     std::map<int, double>::iterator it = ChannelKeyToSPEMap.find(channel_key);
     if(it != ChannelKeyToSPEMap.end()){ //Charge to SPE conversion is available
@@ -739,7 +739,7 @@ void PhaseIITreeMaker::LoadAllMRDHits(){
       unsigned long detkey = thedetector->GetDetectorID();
       if(thedetector->GetDetectorElement()=="Veto") fVetoHit=1; // this is a veto hit, not an MRD hit.
       std::vector<Hit> mrdhits = anmrdpmt.second;
-      for(int j = 0; j<mrdhits.size(); j++){
+      for(int j = 0; j<(int)mrdhits.size(); j++){
         fMRDHitT.push_back(mrdhits.at(j).GetTime());
         fMRDHitDetID.push_back(mrdhits.at(j).GetTubeId());
       }

--- a/UserTools/PlotLAPPDTimesFromStore/PlotLAPPDTimesFromStore.cpp
+++ b/UserTools/PlotLAPPDTimesFromStore/PlotLAPPDTimesFromStore.cpp
@@ -102,7 +102,7 @@ bool PlotLAPPDTimesFromStore::Execute(){
 	bool mufound=false;
 	if(MCParticles){
 		// MCParticles is a std::vector<MCParticle>*
-		for(int particlei=0; particlei<MCParticles->size(); particlei++){
+		for(int particlei=0; particlei<(int)MCParticles->size(); particlei++){
 			MCParticle aparticle = MCParticles->at(particlei);
 			if(aparticle.GetParentPdg()!=0) continue;      // not a primary particle
 			if(aparticle.GetPdgCode()!=13) continue;       // not a muon

--- a/UserTools/PrintADCData/PrintADCData.cpp
+++ b/UserTools/PrintADCData/PrintADCData.cpp
@@ -145,9 +145,9 @@ void PrintADCData::PrintInfoInData(std::map<unsigned long, std::vector<Waveform<
     if(!isAuxData && it1!=RecoADCHits.end()){
       std::vector<std::vector<ADCPulse>> buffer_pulses = RecoADCHits.at(channel_key);
       int num_pulses = 0;
-      for (int i = 0; i < buffer_pulses.size(); i++){
+      for (int i = 0; i < (int) buffer_pulses.size(); i++){
           std::vector<ADCPulse> onebuffer_pulses = buffer_pulses.at(i);
-          for (int j = 0; j < onebuffer_pulses.size(); j++){
+          for (int j = 0; j < (int) onebuffer_pulses.size(); j++){
             ADCPulse apulse = onebuffer_pulses.at(j);
             int pulse_height = apulse.raw_amplitude() - apulse.baseline();
             if (pulse_height >= pulse_threshold) num_pulses +=1;
@@ -182,14 +182,14 @@ void PrintADCData::PrintInfoInData(std::map<unsigned long, std::vector<Waveform<
     //Length of waveform vector should be 1 in normal mode, but greater than
     //1 in a hefty-like format (multiple waveform buffers)
     if(verbosity>3)std::cout << "Waveform size: " << raw_waveforms.size() << std::endl;
-    for (int j=0; j < raw_waveforms.size(); j++){
+    for (int j=0; j < (int) raw_waveforms.size(); j++){
       if(verbosity>4)std::cout << "Printing waveform info for buffer at index " << j << std::endl;
       Waveform<unsigned short> awaveform = raw_waveforms.at(j);
       if(verbosity>4)std::cout << "Waveform start time: " << std::setprecision(16) << awaveform.GetStartTime() << std::endl;
       std::vector<unsigned short>* thewave=awaveform.GetSamples();
       if(verbosity>5){
         std::cout << "BEGIN SAMPLES" << std::endl;
-        for (int i=0; i < thewave->size(); i++){
+        for (int i=0; i < (int) thewave->size(); i++){
           std::cout << thewave->at(i) << std::endl;
         }
       }

--- a/UserTools/PulseSimulation/CreateFakeRawFile.cpp
+++ b/UserTools/PulseSimulation/CreateFakeRawFile.cpp
@@ -189,7 +189,7 @@ void PulseSimulation::FillInitialFileInfo(){
 	// ===================================================================================
 	Log("PulseSimulation Tool: Constructing CardData entries",v_debug,verbosity);
 	// fill all the non-minibuffer info and reset the minibuffers
-	if(emulated_pmtdata_readout.size()<num_adc_cards){
+	if((int)emulated_pmtdata_readout.size()<num_adc_cards){
 //		cout<<"constructing vector of "<<num_adc_cards<<" CardData objects"
 //			<<" and temp databuffer vector with "<<full_buffer_size<<" element data arrays"<<endl;
 		emulated_pmtdata_readout= std::vector<MCCardData>(num_adc_cards);
@@ -221,7 +221,7 @@ void PulseSimulation::FillEmulatedRunInformation(){
 	std::vector<std::string>* TemplateInfoMessages = GetTemplateRunInfo();
 	
 	if(GenerateFakeRootFiles){
-		for(int entryi=0; entryi<InfoTitles.size(); entryi++){
+		for(int entryi=0; entryi<(int)InfoTitles.size(); entryi++){
 			fileout_InfoTitle=InfoTitles.at(entryi);
 			fileout_InfoMessage=TemplateInfoMessages->at(entryi);
 			tRunInformation->Fill();

--- a/UserTools/PulseSimulation/PulseSimulation.cpp
+++ b/UserTools/PulseSimulation/PulseSimulation.cpp
@@ -491,7 +491,7 @@ void PulseSimulation::GenerateMinibufferPulse(int digit_index, double adjusted_d
 	//fLandau->SetRange(-10,100); only set in creation as fixed
 	for(int i=(digit_index-10); i<(digit_index+100); i++){
 		// pulses very close to the front/end of the minibuffer: get tructated.
-		if( (i<0) || (i>(pulsevector.size()-1)) ) continue;
+		if( (i<0) || (i>((int)pulsevector.size()-1)) ) continue;
 		pulsevector.at(i)=fLandau->Eval(i);
 	}
 	
@@ -659,7 +659,7 @@ bool PulseSimulation::FillEmulatedPMTData(){
 		
 		// =================
 		if(DRAW_DEBUG_PLOTS){
-			if(full_buffer_size!=acard.Data.size()){
+			if(full_buffer_size!=(int)acard.Data.size()){
 				cout<<"full_buffer_size="<<full_buffer_size
 					<<", fileout_Data.size()="<<acard.Data.size()<<endl;
 			}
@@ -669,7 +669,7 @@ bool PulseSimulation::FillEmulatedPMTData(){
 				fullbuffergraph  = new TGraph(full_buffer_size/channels_per_adc_card);
 				fullbuffergraph->SetName("fullbuffergraph");
 			}
-			for(int i=0; i<acard.Data.size(); i++){
+			for(int i=0; i<(int)acard.Data.size(); i++){
 				uint16_t theval = acard.Data.at(i);
 				fullbuffergraph->SetPoint(i,i,theval);
 				//if(theval!=0) cout<<"("<<i<<","<<theval<<")"<<", ";
@@ -821,7 +821,7 @@ void PulseSimulation::AddNoiseToWaveforms(){
 		
 		// loop over all the minibuffers in the full buffer
 		int16_t mboffset=0;
-		for(int samplei=0; samplei<temp_card_buffer.size(); samplei++){
+		for(int samplei=0; samplei<(int)temp_card_buffer.size(); samplei++){
 			// Each minibuffer has an offset of ~330 +- 20 ADC counts, distributed... well..
 			// there may be an underlying sine wave of varying amplitude, which is sorta kinda uniform..?
 			if((samplei%(full_buffer_size/minibuffers_per_fullbuffer))==0){
@@ -882,7 +882,7 @@ void PulseSimulation::RiffleShuffle(bool do_shuffle){
 				}
 			}
 		} else {
-			for(int i=0; i<temp_card_buffer.size(); i++) card_buffer.at(i)=temp_card_buffer.at(i);
+			for(int i=0; i<(int)temp_card_buffer.size(); i++) card_buffer.at(i)=temp_card_buffer.at(i);
 		}
 	}
 	// finally, ask a player to cut the deck

--- a/UserTools/RawLoadToRoot/RawLoadToRoot.cpp
+++ b/UserTools/RawLoadToRoot/RawLoadToRoot.cpp
@@ -69,7 +69,7 @@ bool RawLoadToRoot::Execute(){
       unsigned long chank = ijk->first;
       vector<CalibratedADCWaveform<double>> calwaves = ijk->second;
 
-      for(int mmm=0; mmm<TheWaveforms.size(); mmm++){  //loop through minibuffers
+      for(int mmm=0; mmm<(int)TheWaveforms.size(); mmm++){  //loop through minibuffers
 
         CalibratedADCWaveform<double> acalwave = calwaves.at(mmm);
         double basline = acalwave.GetBaseline();
@@ -110,7 +110,7 @@ bool RawLoadToRoot::Execute(){
         double bassline = 0.;
         if(pulsize>0){
           thePulseformHist = new TH1D(puname,puname,(ttot/2),0,ttot);
-          for(int vvv=0; vvv<aWaveform.Samples().size(); vvv++){
+          for(int vvv=0; vvv<(int)aWaveform.Samples().size(); vvv++){
             //115-206 establish the dynamic baseline
             if(vvv==0){
               bassline=aWaveform.GetSample(vvv);
@@ -254,7 +254,7 @@ bool RawLoadToRoot::Execute(){
 
         if(channelnum<59&&channelnum!=57){
         ADCPulse prevpulse;
-          for(int ccc=0; ccc<somepulses.size(); ccc++){
+          for(int ccc=0; ccc<(int)somepulses.size(); ccc++){
 
             ADCPulse apulse = somepulses.at(ccc);
             if(ccc>0){prevpulse = somepulses.at(ccc-1);}

--- a/UserTools/SimpleTankEnergyCalibrator/SimpleTankEnergyCalibrator.cpp
+++ b/UserTools/SimpleTankEnergyCalibrator/SimpleTankEnergyCalibrator.cpp
@@ -68,7 +68,7 @@ bool SimpleTankEnergyCalibrator::Execute(){
   //Get beam window hits 
   std::vector<Hit> BeamHits = this->GetInWindowHits();
   if(verbosity>3) std::cout << "SimpleTankEnergyCalculator Tool: Hit count is " << BeamHits.size() << std::endl;
-  if(BeamHits.size() < TankNHitThreshold){
+  if((int)BeamHits.size() < TankNHitThreshold){
     if(verbosity>3) std::cout << "SimpleTankEnergyCalculator Tool: Hit count " << BeamHits.size() << " not over threshold" << std::endl;
     PassesCriteria = false;
   }
@@ -189,7 +189,7 @@ std::vector<Hit> SimpleTankEnergyCalibrator::GetInWindowHits(){
   for(std::pair<unsigned long, std::vector<Hit>>&& apair : *Hits){
     unsigned long chankey = apair.first;
     std::vector<Hit> ThisTubeHits = apair.second;
-    for(int i=0; i<ThisTubeHits.size(); i++){
+    for(int i=0; i<(int)ThisTubeHits.size(); i++){
       Hit ahit = ThisTubeHits.at(i);
       double hittime = ahit.GetTime();
       if((hittime > TankBeamWindowStart) && (hittime < TankBeamWindowEnd)) BeamHits.push_back(ahit);
@@ -200,7 +200,7 @@ std::vector<Hit> SimpleTankEnergyCalibrator::GetInWindowHits(){
 
 double SimpleTankEnergyCalibrator::GetTotalQ(std::vector<Hit> AllHits){
   double TotalCharge = 0;
-  for (int i = 0; i<AllHits.size(); i++){
+  for (int i = 0; i<(int)AllHits.size(); i++){
     Hit ahit = AllHits.at(i);
     double ThisHitCharge = ahit.GetCharge();
     TotalCharge+=ThisHitCharge;
@@ -210,7 +210,7 @@ double SimpleTankEnergyCalibrator::GetTotalQ(std::vector<Hit> AllHits){
 
 double SimpleTankEnergyCalibrator::GetTotalPE(std::vector<Hit> AllHits){
   double TotalPE = 0;
-  for (int i = 0; i<AllHits.size(); i++){
+  for (int i = 0; i<(int)AllHits.size(); i++){
     Hit ahit = AllHits.at(i);
     double ThisHitCharge = ahit.GetCharge();
     int ThisHitID = ahit.GetTubeId();

--- a/UserTools/SimulatedWaveformDemo/SimulatedWaveformDemo.cpp
+++ b/UserTools/SimulatedWaveformDemo/SimulatedWaveformDemo.cpp
@@ -41,7 +41,7 @@ bool SimulatedWaveformDemo::Initialise(std::string configfile, DataModel &data){
 		Log("SimulatedWaveformDemo Tool: Error getting AllData from pmtDataStore!",v_error,verbosity);
 		return false;
 	}
-	for(int i=0; i<pmtDataVecCopy.size(); i++){
+	for(int i=0; i<(int)pmtDataVecCopy.size(); i++){
 		intptr_t ddatapi = pmtDataVecCopy.at(i);
 		const std::vector<uint16_t>* ddatap = reinterpret_cast<const std::vector<uint16_t>*>(ddatapi);
 		pmtDataVector.push_back(ddatap);
@@ -200,7 +200,7 @@ bool SimulatedWaveformDemo::Execute(){
 		// The pmtDataStore AllData vector contains one waveform entry per ADC card.
 		Log("SimulatedWaveformDemo Tool: Looping over "+to_string(pmtDataVector.size())
 			 +" ADC cards",v_debug,verbosity);
-		for(int cardi=0; cardi<pmtDataVector.size(); cardi++){
+		for(int cardi=0; cardi<(int)pmtDataVector.size(); cardi++){
 			Log("SimulatedWaveformDemo Tool: Looping over "+to_string(ChannelsPerAdcCard)
 				 +" ADC channels",v_debug,verbosity);
 			const std::vector<uint16_t>* card_data = pmtDataVector.at(cardi);

--- a/UserTools/TankCalibrationDiffuser/TankCalibrationDiffuser.cpp
+++ b/UserTools/TankCalibrationDiffuser/TankCalibrationDiffuser.cpp
@@ -497,9 +497,9 @@ bool TankCalibrationDiffuser::Execute(){
       int detectorkey = thistube->GetDetectorID();
       if (thistube->GetDetectorElement()=="Tank"){
         std::vector<std::vector<ADCPulse>> pulses = apair.second;
-        for (int i_minibuffer = 0; i_minibuffer < pulses.size(); i_minibuffer++){
+        for (int i_minibuffer = 0; i_minibuffer < (int) pulses.size(); i_minibuffer++){
           std::vector<ADCPulse> apulsevector = pulses.at(i_minibuffer);
-          for (int i_pulse=0; i_pulse < apulsevector.size(); i_pulse++){
+          for (int i_pulse=0; i_pulse < (int) apulsevector.size(); i_pulse++){
             ADCPulse apulse = apulsevector.at(i_pulse);
             double start_time = apulse.start_time();
             double peak_time = apulse.peak_time();
@@ -1444,12 +1444,12 @@ bool TankCalibrationDiffuser::Finalise(){
   //Histograms already deleted by closing the files ealier
 
   if (verbose > 0) std::cout <<"Deleting TBoxes..."<<std::endl;
-  for (int i_box = 0; i_box < vector_tbox.size();i_box++){
+  for (int i_box = 0; i_box < (int) vector_tbox.size();i_box++){
     delete vector_tbox.at(i_box);
   }
   
   if (verbose > 0) std::cout <<"Deleting TF1s..."<<std::endl;
-  for (int i_tf = 0; i_tf< vector_tf1.size(); i_tf++){
+  for (int i_tf = 0; i_tf < (int) vector_tf1.size(); i_tf++){
     delete vector_tf1.at(i_tf);
   } 
 

--- a/UserTools/TotalLightMap/TotalLightMap.cpp
+++ b/UserTools/TotalLightMap/TotalLightMap.cpp
@@ -214,7 +214,7 @@ bool TotalLightMap::Execute(){
 	bool mufound=false;
 	if(MCParticles){
 		Log("TotalLightMap Tool: Num MCParticles = "+to_string(MCParticles->size()),v_message,verbosity);
-		for(int particlei=0; particlei<MCParticles->size(); particlei++){
+		for(int particlei=0; particlei<(int)MCParticles->size(); particlei++){
 			MCParticle aparticle = MCParticles->at(particlei);
 			aparticle.SetParticleID(particlei);  // override WCSim 'TrackID' with index in MCParticles XXX
 			// Selection criteria pick out particle(s) of interest
@@ -687,7 +687,7 @@ void TotalLightMap::make_pmt_markers(MCParticle primarymuon){
 		// ==============================================
 		// first cumulative light split by parent
 		double totchargenotfrommuon=0;
-		for(int parenti=1; parenti<(chargesfromparents.size()-1); parenti++){
+		for(int parenti=1; parenti<((int)chargesfromparents.size()-1); parenti++){
 			totchargenotfrommuon+=chargesfromparents.at(parenti);
 		}
 		// we'll actually use the in-built ROOT 'Mercator' projection, which is available for TH1s
@@ -1035,7 +1035,7 @@ void TotalLightMap::DrawMarkers(){
 	
 	// draw the pmt markers
 	Log("TotalLightMap Tool: drawing "+to_string(marker_pmts_top.size())+" top cap PMT markers",v_debug,verbosity);
-	for (int i_marker=0;i_marker<marker_pmts_top.size();i_marker++){
+	for (int i_marker=0;i_marker<(int)marker_pmts_top.size();i_marker++){
 		TPolyMarker* marker = marker_pmts_top.at(i_marker);
 		double colour_marker_temp = 254.*((double(marker->GetMarkerColor())-colour_offset)/colour_full_scale);
 		color_marker = int(colour_marker_temp);
@@ -1049,7 +1049,7 @@ void TotalLightMap::DrawMarkers(){
 		marker->Draw();
 	}
 	Log("TotalLightMap Tool: drawing "+to_string(marker_pmts_bottom.size())+" bottom cap PMT markers",v_debug,verbosity);
-	for (int i_marker=0;i_marker<marker_pmts_bottom.size();i_marker++){
+	for (int i_marker=0;i_marker<(int)marker_pmts_bottom.size();i_marker++){
 		TPolyMarker* marker = marker_pmts_bottom.at(i_marker);
 		double colour_marker_temp = 254.*((double(marker->GetMarkerColor())-colour_offset)/colour_full_scale);
 		color_marker = int(colour_marker_temp);
@@ -1063,7 +1063,7 @@ void TotalLightMap::DrawMarkers(){
 		marker->Draw();
 	}
 	Log("TotalLightMap Tool: drawing "+to_string(marker_pmts_wall.size())+" barrel PMT markers",v_debug,verbosity);
-	for (int i_marker=0;i_marker<marker_pmts_wall.size();i_marker++){
+	for (int i_marker=0;i_marker<(int)marker_pmts_wall.size();i_marker++){
 		TPolyMarker* marker = marker_pmts_wall.at(i_marker);
 		double colour_marker_temp = 254.*((double(marker->GetMarkerColor())-colour_offset)/colour_full_scale);
 		color_marker = int(colour_marker_temp);
@@ -1079,7 +1079,7 @@ void TotalLightMap::DrawMarkers(){
 	
 	// draw the lappd markers
 	Log("TotalLightMap Tool: drawing "+to_string(marker_lappds.size())+" LAPPD markers",v_debug,verbosity);
-	for (int i_marker=0; i_marker<marker_lappds.size();i_marker++){
+	for (int i_marker=0; i_marker<(int)marker_lappds.size();i_marker++){
 		TPolyMarker* marker = marker_lappds.at(i_marker);
 		double colour_marker_temp = 254.*((double(marker->GetMarkerColor())-colour_offset)/colour_full_scale);
 		color_marker = int(colour_marker_temp);
@@ -1089,7 +1089,7 @@ void TotalLightMap::DrawMarkers(){
 	}
 	
 	// draw the true vertex markers
-	for(int i_marker=0; i_marker<marker_vtxs.size();i_marker++){
+	for(int i_marker=0; i_marker<(int)marker_vtxs.size();i_marker++){
 		marker_vtxs.at(i_marker)->Draw();  // colour is already set based on particle type
 	}
 	
@@ -1100,7 +1100,7 @@ void TotalLightMap::DrawMarkers(){
 	// and only if it's a CC1PI event
 	lightmap_by_parent_canvas->cd();
 	
-	for(int i_marker=0; i_marker<chargemapcc1p.size();i_marker++){
+	for(int i_marker=0; i_marker<(int)chargemapcc1p.size();i_marker++){
 		TPolyMarker* marker = chargemapcc1p.at(i_marker);
 		double colour_marker_temp = 254.*((double(marker->GetMarkerColor())-colour_offset)/colour_full_scale);
 		color_marker = int(colour_marker_temp);
@@ -1117,7 +1117,7 @@ void TotalLightMap::DrawMarkers(){
 	}
 	
 	// draw the true vertex markers
-	for(int i_marker=0; i_marker<marker_vtxs.size();i_marker++){
+	for(int i_marker=0; i_marker<(int)marker_vtxs.size();i_marker++){
 		marker_vtxs.at(i_marker)->Draw();  // colour is already set based on particle type
 	}
 	

--- a/UserTools/TrackCombiner/TrackCombiner.cpp
+++ b/UserTools/TrackCombiner/TrackCombiner.cpp
@@ -147,7 +147,7 @@ bool TrackCombiner::Execute(){
 		m_data->Stores.at("MRDTracks")->Print(false);
 		return false;
 	}
-	if(theMrdTracks->size()<numtracksinev){
+	if((int)theMrdTracks->size()<numtracksinev){
 		Log("TrackCombiner Tool: Too few entries in MRDTracks vector relative to NumMrdTracks!",v_warning,verbosity);
 		// more is fine as we don't shrink for efficiency
 	}
@@ -432,7 +432,7 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 			bool added_paddle=false;
 			// scan paddles in this layer and see if we can merge them with the
 			// current cluster (if null, we'll create one from the first paddle)
-			for(int paddlei=0; paddlei<hit_paddles_this_layer.size(); ++paddlei){
+			for(int paddlei=0; paddlei<(int)hit_paddles_this_layer.size(); ++paddlei){
 				// get next hit paddle in this layer
 				Paddle* apaddle = hit_paddles_this_layer.at(paddlei);
 //				std::cout<<"checking paddle "<<paddlei<<", currentcluster is currently "<<currentcluster<<std::endl;
@@ -516,7 +516,7 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 			+std::string((orientationi) ? "V" : "H")+" tracks",v_debug,verbosity);
 		std::vector<MrdStub>* mrd_stubs = (orientationi) ? &mrd_stubs_v : &mrd_stubs_h;
 		// scan from layer 2+orientationi again as MRD layers number from 2
-		for(int layeri=(2+orientationi); layeri<(2+clusters_on_layers.size()); layeri+=2){
+		for(int layeri=(2+orientationi); layeri<(2+(int)clusters_on_layers.size()); layeri+=2){
 			// for first layer, make a track for every cluster
 			if(layeri==(2+orientationi)){
 				Log("TrackCombiner Tool: making tracks from clusters in first layer",v_debug,verbosity);
@@ -670,7 +670,7 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 			std::string orientationstring = (orientationi) ? "V" : "H";
 			double tanktrack_entrypoint = (orientationi) ? recoEventMrdEntryPoint.X() : recoEventMrdEntryPoint.Y();
 			std::vector<MrdStub>* mrd_stubs = (orientationi) ? &mrd_stubs_v : &mrd_stubs_h;
-			for(int stubi=0; stubi<mrd_stubs->size(); ++stubi){
+			for(int stubi=0; stubi<(int)mrd_stubs->size(); ++stubi){
 				MrdStub& astub = mrd_stubs->at(stubi);
 				StubCluster& firstcluster = astub.GetClusters()->front();
 				/*
@@ -848,9 +848,9 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 		if(show_all_stubs){
 			// if the number of elements in the two views are different, just re-use the last element
 			primary_h_stub_index = 
-				(mrd_stubs_h.size()<h_stub_indexes.at(stub_i)) ? (mrd_stubs_h.size()-1) : h_stub_indexes.at(stub_i);
+				((int)mrd_stubs_h.size()<h_stub_indexes.at(stub_i)) ? (mrd_stubs_h.size()-1) : h_stub_indexes.at(stub_i);
 			primary_v_stub_index = 
-				(mrd_stubs_v.size()<v_stub_indexes.at(stub_i)) ? (mrd_stubs_v.size()-1) : v_stub_indexes.at(stub_i);
+				((int)mrd_stubs_v.size()<v_stub_indexes.at(stub_i)) ? (mrd_stubs_v.size()-1) : v_stub_indexes.at(stub_i);
 		}
 		// else indices are already set, and we're only running for one loop. Nothing to do.
 		
@@ -875,7 +875,7 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 			std::vector<mrdcluster>* theclusters = (orientationi) ? &vtrackclusters : &htrackclusters;
 			std::vector<mrdcell>* thecells = (orientationi) ? &thevtrackcells : &thehtrackcells;
 			mrdcluster* lastcluster=nullptr;
-			for(int clusteri=0; clusteri<astub->GetClusters()->size(); ++clusteri){
+			for(int clusteri=0; clusteri<(int)astub->GetClusters()->size(); ++clusteri){
 				StubCluster& acluster = astub->GetClusters()->at(clusteri);
 				// convert the StubCluster to an mrdcluster
 				for(Paddle* apaddle : acluster.GetPaddles()){
@@ -889,7 +889,7 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 					double amintime = *std::min_element(hittimes.begin(),hittimes.end());
 					if(amintime<earliest_hit_time) earliest_hit_time = amintime;
 					
-					if(theclusters->size()<(clusteri+1)){
+					if((int)theclusters->size()<(clusteri+1)){
 						theclusters->emplace_back(0, wcsimtubeid-1, apaddle->GetLayer()-2, earliest_hit_time);
 					} else {
 						theclusters->back().AddDigit(0, wcsimtubeid-1, earliest_hit_time);
@@ -927,7 +927,7 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 //		std::cout<<"going to construct this track at "<<numtracksinev<<
 //				 <<" elements from start"<<std::endl;
 		cMRDTrack* atrack = nullptr;
-		if(numtracksinev<thesubevent->GetTracks()->size()){
+		if(numtracksinev<(int)thesubevent->GetTracks()->size()){
 			thesubevent->GetTracks()->at(numtracksinev) = cMRDTrack(
 			numtracksinev, wcsimfile, run_id, event_id, 0, trigger, digitindexes_inthistrack, tubeids_inthistrack, digitqs_inthistrack, digittimes_inthistrack, digitnumphots_inthistrack, digittruetimes_inthistrack, digittrueparents_inthistrack, thehtrackcells, thevtrackcells, htrackclusters, vtrackclusters);
 			atrack = &thesubevent->GetTracks()->at(numtracksinev);
@@ -957,7 +957,7 @@ BoostStore* TrackCombiner::FindShortMrdTracks(std::map<unsigned long,vector<doub
 		numtracksinev++;
 		
 		// checkif we need to grow the MrdTracks container
-		if(numtracksinev>theMrdTracks->size()){
+		if(numtracksinev>(int)theMrdTracks->size()){
 			Log("TrackCombiner Tool: Growing theMrdTracks vector to size "
 				+to_string(numtracksinev),v_debug,verbosity);
 			theMrdTracks->resize(numtracksinev);

--- a/UserTools/TriggerDataDecoder/TriggerDataDecoder.cpp
+++ b/UserTools/TriggerDataDecoder/TriggerDataDecoder.cpp
@@ -79,7 +79,7 @@ bool TriggerDataDecoder::Execute(){
         if(UseTrigMask){
           uint32_t recent_trigger_word = processed_sources.back();
           for(int j = 0; j<(int) TriggerMask.size(); j++){
-            if(TriggerMask.at(j) == recent_trigger_word){
+            if(TriggerMask.at(j) == (int) recent_trigger_word){
               m_data->CStore.Set("NewCTCDataAvailable",true);
               if(verbosity>4) std::cout << "TRIGGER WORD BEING ADDED TO TRIGWORDMAP" << std::endl;
               TimeToTriggerWordMap->emplace(processed_ns.back(),processed_sources.back());
@@ -113,7 +113,7 @@ bool TriggerDataDecoder::Execute(){
           if(UseTrigMask){
             uint32_t recent_trigger_word = processed_sources.back();
             for(int j = 0; j<(int) TriggerMask.size(); j++){
-              if(TriggerMask.at(j) == recent_trigger_word){
+              if(TriggerMask.at(j) == (int) recent_trigger_word){
                 m_data->CStore.Set("NewCTCDataAvailable",true);
                 if(verbosity>4) std::cout << "TRIGGER WORD BEING ADDED TO TRIGWORDMAP" << std::endl;
                 TimeToTriggerWordMap->emplace(processed_ns.back(),processed_sources.back());

--- a/UserTools/VertexGeometryCheck/VertexGeometryCheck.cpp
+++ b/UserTools/VertexGeometryCheck/VertexGeometryCheck.cpp
@@ -62,7 +62,7 @@ bool VertexGeometryCheck::Execute(){
   m_data->Stores.at("ANNIEEvent")->Get("EventNumber",fEventNumber);
   
   // Only check this event
-  if(fShowEvent>0 && fEventNumber!=fShowEvent) return true; 
+  if(fShowEvent>0 && (int)fEventNumber!=fShowEvent) return true; 
   
   // check if event passes the cut
   bool EventCutstatus = false;
@@ -84,22 +84,22 @@ bool VertexGeometryCheck::Execute(){
   	return true;
   }
 	
-	// Retrive digits from RecoEvent
-	auto get_digit = m_data->Stores.at("RecoEvent")->Get("RecoDigit",fDigitList);  ///> Get digits from "RecoEvent" 
+  // Retrive digits from RecoEvent
+  auto get_digit = m_data->Stores.at("RecoEvent")->Get("RecoDigit",fDigitList);  ///> Get digits from "RecoEvent" 
   if(!get_digit){
-  	Log("VertexGeometryCheck  Tool: Error retrieving RecoDigits,no digit from the RecoEvent!",v_error,verbosity); 
-  	return true;
+    Log("VertexGeometryCheck  Tool: Error retrieving RecoDigits,no digit from the RecoEvent!",v_error,verbosity); 
+    return true;
   }
   
 	
-	double recoVtxX, recoVtxY, recoVtxZ, recoVtxT, recoDirX, recoDirY, recoDirZ;
+  double recoVtxX, recoVtxY, recoVtxZ, recoVtxT, recoDirX, recoDirY, recoDirZ;
   double trueVtxX, trueVtxY, trueVtxZ, trueVtxT, trueDirX, trueDirY, trueDirZ;
   double digitX, digitY, digitZ, digitT;
   double dx, dy, dz, px, py, pz, ds, cosphi, sinphi, phi, phideg;
   
   Position vtxPos = fTrueVertex->GetPosition();
-	Direction vtxDir = fTrueVertex->GetDirection();
-	trueVtxX = vtxPos.X();
+  Direction vtxDir = fTrueVertex->GetDirection();
+  trueVtxX = vtxPos.X();
   trueVtxY = vtxPos.Y();
   trueVtxZ = vtxPos.Z();
   trueVtxT = fTrueVertex->GetTime();
@@ -173,7 +173,7 @@ bool VertexGeometryCheck::Execute(){
 }
 
 bool VertexGeometryCheck::Finalise(){
-	fOutput_tfile->cd();
+  fOutput_tfile->cd();
   fOutput_tfile->Write();
   fOutput_tfile->Close();
   Log("VertexGeometryCheck exitting", v_debug,verbosity);

--- a/UserTools/VetoEfficiency/VetoEfficiency.cpp
+++ b/UserTools/VetoEfficiency/VetoEfficiency.cpp
@@ -71,7 +71,7 @@ bool VetoEfficiency::Initialise(std::string configfile, DataModel &data){
 			// trim the extention
 			std::string fname = outputfilename.substr(0,outputfilename.find_last_of("."));
 			// trim the path, if it contains one
-			int last_slash = fname.find_last_of("/");
+			uint last_slash = fname.find_last_of("/");
 			if(last_slash!=std::string::npos){ fname = fname.substr(last_slash+1,std::string::npos); }
 			// build our output name
 			outputfilename="veto_efficiency_"+fname+".root";
@@ -588,10 +588,10 @@ bool VetoEfficiency::Execute(){
 		found_coincidence=false;
 
 		//Check very roughly for coincidences of veto L1/L2 channels (mostly for debugging purposes)
-		for (int il1=0; il1<veto_times.size();il1++){
+		for (int il1=0; il1<(int)veto_times.size();il1++){
 			int in_layer_index = std::distance(vetol1keys.begin(),
                         std::find(vetol1keys.begin(), vetol1keys.end(), veto_chankeys.at(il1)));
-				for (int il2=0; il2<veto_times_layer2.size();il2++){
+				for (int il2=0; il2<(int)veto_times_layer2.size();il2++){
 					int in_layer_index_layer2 = std::distance(vetol2keys.begin(),
                                                         std::find(vetol2keys.begin(), vetol2keys.end(), veto_chankeys_layer2.at(il2)));
 					if (in_layer_index != in_layer_index_layer2) continue;
@@ -672,7 +672,7 @@ bool VetoEfficiency::Execute(){
 			
 			// Create coincidences object for coincidence conditions with the second layer of the veto
 			for (auto&& this_hit : veto_l2_hits){
-				for (int i_veto=0; i_veto<veto_times.size(); i_veto++){
+				for (int i_veto=0; i_veto<(int) veto_times.size(); i_veto++){
 					h_veto_delta_times->Fill(this_hit.first-veto_times.at(i_veto));
 					int in_layer_index = std::distance(vetol1keys.begin(),std::find(vetol1keys.begin(), vetol1keys.end(), veto_chankeys.at(i_veto)));	 
 					int in_layer_index_layer2 = std::distance(vetol2keys.begin(),std::find(vetol2keys.begin(), vetol2keys.end(),this_hit.second));
@@ -794,7 +794,7 @@ bool VetoEfficiency::Execute(){
 				// Require only 1 MRD layer here, can do more stringent cuts
 				// when evaulating the output file
 				if( ((acoincidence.tank_charge > min_tank_charge_) &&
-					 (acoincidence.num_unique_water_pmts > min_unique_water_pmts_)) ||
+					 ((uint) acoincidence.num_unique_water_pmts > min_unique_water_pmts_)) ||
 					((acoincidence.mrdl1hits.size() > min_mrdl1_pmts_) ||
 					 (acoincidence.mrdl2hits.size() > min_mrdl2_pmts_))
 					){
@@ -833,7 +833,7 @@ bool VetoEfficiency::Execute(){
 						int in_layer_index = std::distance(vetol1keys.begin(),
 								std::find(vetol1keys.begin(), vetol1keys.end(), al1pmt));
 						// safety check
-						if(in_layer_index>=l1_hits_L1_.size()){
+						if(in_layer_index>=(int)l1_hits_L1_.size()){
 							Log("VetoEfficiency Tool: Error! Hit on veto L1 PMT index "
 								+to_string(in_layer_index)+" is out of range!",v_error,verbosity);
 							return false;
@@ -845,7 +845,7 @@ bool VetoEfficiency::Execute(){
 						unsigned long l2_key = 1010000 + (100*in_layer_index);
 						// see if that key is in our list of L2 keys hit this event
 						if (verbosity >= v_message) std::cout <<"In-Layer-Chankey "<<in_layer_index<<" saw a hit! Check if l2_key = "<<l2_key<<" also saw something."<<std::endl;
-						for (int i_layer2=0; i_layer2<veto_l2_ids_.size(); i_layer2++){
+						for (int i_layer2=0; i_layer2<(int)veto_l2_ids_.size(); i_layer2++){
 							if (verbosity >= v_message) std::cout <<"Layer 2 hit with chankey "<<veto_l2_ids_.at(i_layer2)<<std::endl;
 						}
 						if(std::find(veto_l2_ids_.begin(),veto_l2_ids_.end(),l2_key)!=veto_l2_ids_.end()){
@@ -905,7 +905,7 @@ bool VetoEfficiency::Execute(){
 						}
 						
 						h_tdc_times->Fill(pulse_start_time_ns);
-						for(int i_veto=0; i_veto < veto_times.size(); i_veto++){
+						for(int i_veto=0; i_veto < (int) veto_times.size(); i_veto++){
 							if (std::find(vetol1keys.begin(),vetol1keys.end(),tdc_key)!=vetol1keys.end()) continue;
 							if (std::find(vetol2keys.begin(),vetol2keys.end(),tdc_key)!=vetol2keys.end()) continue;
 							h_tdc_delta_times->Fill(pulse_start_time_ns-veto_times.at(i_veto));
@@ -962,7 +962,7 @@ bool VetoEfficiency::Execute(){
 						}
 						
 						h_adc_times->Fill(pulse_start_time_ns);
-						for(int i_veto=0; i_veto < veto_times.size(); i_veto++){
+						for(int i_veto=0; i_veto < (int) veto_times.size(); i_veto++){
 						  h_adc_delta_times->Fill(pulse_start_time_ns-veto_times.at(i_veto));
 						  h_adc_delta_times_charge->Fill(pulse.charge(),pulse_start_time_ns-veto_times.at(i_veto));
 						}		
@@ -1026,7 +1026,7 @@ bool VetoEfficiency::Execute(){
 			
 			//TODO
 			for (auto&& this_hit : veto_l2_hits){
-				for (int i_veto=0; i_veto<veto_times.size(); i_veto++){
+				for (int i_veto=0; i_veto<(int)veto_times.size(); i_veto++){
 					h_veto_delta_times->Fill(this_hit.first-veto_times.at(i_veto));
 					int in_layer_index = std::distance(vetol1keys.begin(),std::find(vetol1keys.begin(), vetol1keys.end(), veto_chankeys.at(i_veto)));	 
 					int in_layer_index_layer2 = std::distance(vetol2keys.begin(),std::find(vetol2keys.begin(), vetol2keys.end(),this_hit.second));
@@ -1144,7 +1144,7 @@ bool VetoEfficiency::Execute(){
 				// for a through-going event (upstream veto requirement is always
 				// satisfied by construction), then record it to file
 				if( ((acoincidence.tank_charge > min_tank_charge_) &&
-					 (acoincidence.num_unique_water_pmts > min_unique_water_pmts_)) ||
+					 ((uint) acoincidence.num_unique_water_pmts > min_unique_water_pmts_)) ||
 					((acoincidence.mrdl1hits.size() > min_mrdl1_pmts_) ||
 					 (acoincidence.mrdl2hits.size() > min_mrdl2_pmts_))
 					){
@@ -1183,7 +1183,7 @@ bool VetoEfficiency::Execute(){
 						int in_layer_index = std::distance(vetol2keys.begin(),
 								std::find(vetol2keys.begin(), vetol2keys.end(), al2pmt));
 						// safety check
-						if(in_layer_index>=l2_hits_L2_.size()){
+						if(in_layer_index>=(int)l2_hits_L2_.size()){
 							Log("VetoEfficiency Tool: Error! Hit on veto L2 PMT index "
 								+to_string(in_layer_index)+" is out of range!",v_error,verbosity);
 							return false;
@@ -1195,7 +1195,7 @@ bool VetoEfficiency::Execute(){
 						unsigned long l1_key = 1000000 + (100*in_layer_index);
 						// see if that key is in our list of L1 keys hit this event
 						if (verbosity >= v_message) std::cout <<"In-Layer-Chankey "<<in_layer_index<<" saw a hit! Check if l1_key = "<<l1_key<<" also saw something."<<std::endl;
-						for (int i_layer1=0; i_layer1<veto_l1_ids_.size(); i_layer1++){
+						for (int i_layer1=0; i_layer1<(int)veto_l1_ids_.size(); i_layer1++){
 							if (verbosity >= v_message) std::cout <<"Layer 1 hit with chankey "<<veto_l1_ids_.at(i_layer1)<<std::endl;
 						}
 						if(std::find(veto_l1_ids_.begin(),veto_l1_ids_.end(),l1_key)!=veto_l1_ids_.end()){
@@ -1496,10 +1496,10 @@ void VetoEfficiency::LoadTDCKeys(){
 		}
 	}
 	std::cout <<"Loaded the following veto-l1 keys:"<<std::endl;
-	for (int i=0; i<vetol1keys.size(); i++){
+	for (int i=0; i<(int)vetol1keys.size(); i++){
 		std::cout <<vetol1keys.at(i)<<std::endl;
 	}
-	for (int i=0; i<vetol2keys.size(); i++){
+	for (int i=0; i<(int)vetol2keys.size(); i++){
 		std::cout <<vetol2keys.at(i)<<std::endl;
 	}
 }

--- a/UserTools/VtxExtendedVertexFinder/VtxExtendedVertexFinder.cpp
+++ b/UserTools/VtxExtendedVertexFinder/VtxExtendedVertexFinder.cpp
@@ -228,7 +228,7 @@ RecoVertex* VtxExtendedVertexFinder::FindSimpleDirection(RecoVertex* myVertex) {
   double dx, dy, dz, ds, px, py, pz, q;
   
   RecoDigit digit;
-  for( int idigit=0; idigit<fDigitList->size(); idigit++ ){
+  for( int idigit=0; idigit<(int)fDigitList->size(); idigit++ ){
   	digit = fDigitList->at(idigit);
     if( digit.GetFilterStatus() ){ 
       q = digit.GetCalCharge();

--- a/UserTools/VtxPointDirectionFinder/VtxPointDirectionFinder.cpp
+++ b/UserTools/VtxPointDirectionFinder/VtxPointDirectionFinder.cpp
@@ -130,7 +130,7 @@ RecoVertex* VtxPointDirectionFinder::FindSimpleDirection(RecoVertex* myVertex) {
   double dx, dy, dz, ds, px, py, pz, q;
   
   RecoDigit digit;
-  for( int idigit=0; idigit<fDigitList->size(); idigit++ ){
+  for( int idigit=0; idigit < (int) fDigitList->size(); idigit++ ){
   	digit = fDigitList->at(idigit);
     if( digit.GetFilterStatus() ){ 
       q = digit.GetCalCharge();

--- a/UserTools/VtxSeedGenerator/VtxSeedGenerator.cpp
+++ b/UserTools/VtxSeedGenerator/VtxSeedGenerator.cpp
@@ -124,7 +124,7 @@ bool VtxSeedGenerator::GenerateSeedGrid(int NSeeds) {
   Log("VtxSeedGenerator Tool: Getting clean RecoDigits for event", v_debug,verbosity);
   vSeedDigitList.clear();  
   RecoDigit digit;
-  for( fThisDigit=0; fThisDigit<fDigitList->size(); fThisDigit++ ){
+  for( fThisDigit=0; fThisDigit<(int)fDigitList->size(); fThisDigit++ ){
   	digit = fDigitList->at(fThisDigit);
     if( digit.GetFilterStatus() ){ 
       if( digit.GetDigitType() == fSeedType){ 
@@ -200,7 +200,7 @@ double VtxSeedGenerator::GetMedianSeedTime(Position pos){
   double fC, fN;
   double seedtime;
   std::vector<double> extraptimes;
-  for (int entry=0; entry<vSeedDigitList.size(); entry++){
+  for (int entry=0; entry<(int)vSeedDigitList.size(); entry++){
     fThisDigit = vSeedDigitList.at(entry);
     digitx = fDigitList->at(fThisDigit).GetPosition().X();
     digity = fDigitList->at(fThisDigit).GetPosition().Y();
@@ -253,7 +253,7 @@ bool VtxSeedGenerator::GenerateVertexSeeds(int NSeeds) {
   // Here only the digit type (PMT or LAPPD or all) is specified. 
   vSeedDigitList.clear();  
   RecoDigit digit;
-  for( fThisDigit=0; fThisDigit<fDigitList->size(); fThisDigit++ ){
+  for( fThisDigit=0; fThisDigit<(int)fDigitList->size(); fThisDigit++ ){
   	digit = fDigitList->at(fThisDigit);
     if( digit.GetFilterStatus() ){ 
       if( digit.GetDigitType() == fSeedType){ 
@@ -390,7 +390,7 @@ void VtxSeedGenerator::ChooseNextDigit(double& xpos, double& ypos, double& zpos,
   int numEntries = vSeedDigitList.size();
 
   fCounter++;
-  if( fCounter>=fDigitList->size() ) fCounter = 0;
+  if( fCounter>=(int)fDigitList->size() ) fCounter = 0;
   fThisDigit = vSeedDigitList.at(fLastEntry);
 
   double r = gRandom->Uniform(); 

--- a/UserTools/WCSimDemo/WCSimDemo.cpp
+++ b/UserTools/WCSimDemo/WCSimDemo.cpp
@@ -72,7 +72,7 @@ bool WCSimDemo::Execute(){
 	bool mufound=false;
 	if(MCParticles){
 		Log("WCSimDemo Tool: Num MCParticles = "+to_string(MCParticles->size()),v_message,verbosity);
-		for(int particlei=0; particlei<MCParticles->size(); particlei++){
+		for(int particlei=0; particlei<(int)MCParticles->size(); particlei++){
 			MCParticle aparticle = MCParticles->at(particlei);
 			//if(v_debug<verbosity) aparticle.Print();       // print if we're being *really* verbose
 			if(aparticle.GetParentPdg()!=0) continue;      // not a primary particle

--- a/UserTools/WaveformNNLS/WaveformNNLS.cpp
+++ b/UserTools/WaveformNNLS/WaveformNNLS.cpp
@@ -149,7 +149,7 @@ bool WaveformNNLS::Execute(){
 	else
 	{
 		Waveform<double> example_waveform = rawData[0].front();
-		for(int i = 0; i < example_waveform.GetSamples()->size(); i++)
+		for(int i = 0; i < (int) example_waveform.GetSamples()->size(); i++)
 		{
 			sampletimes.push_back(i);
 		}
@@ -261,9 +261,9 @@ void WaveformNNLS::BuildTemplateMatrix(nnlsmatrix* A, Waveform<double> tempwave,
 	//one sample further in time. The elements below the diagonal
 	//are 0, and any elements that are not part of the template
 	//are 0. 
-	for(int row = 0; row < nrows; row++)
+	for(int row = 0; row < (int) nrows; row++)
 	{
-		for(int col = 0; col < nrows; col++)
+		for(int col = 0; col < (int) nrows; col++)
 		{
 			//elements below diagonal are zero
 			if(col < row)
@@ -299,7 +299,7 @@ void WaveformNNLS::BuildWaveformVector(nnlsvector* b, Waveform<double> wave, vec
 	float t0;
 	float t1;
 	double current_time;
-	for(int j = 0; j < b->length(); j++)
+	for(int j = 0; j < (int) b->length(); j++)
 	{
 		//current time iterating through 
 		//times scaled for nnls matrix
@@ -308,7 +308,7 @@ void WaveformNNLS::BuildWaveformVector(nnlsvector* b, Waveform<double> wave, vec
 		//find value of waveform at this time by 
 		//finding closest sample times. Assumes the
 		//times vector is ordered
-		for(int i = 0; i < times.size() - 1; i++)
+		for(int i = 0; i < (int) times.size() - 1; i++)
 		{
 			t0 = times.at(i);
 			t1 = times.at(i+1);
@@ -337,7 +337,7 @@ void WaveformNNLS::SaveNNLSOutput(NnlsSolution* soln, nnlsmatrix* A, nnlsvector*
 	A->dot(false, x, bsolv); //now bsolv is the fitted vector waveform
 	//turn vector into waveform
 	Waveform<double> ff; //waveform version of nnls full (summed) solution
-	for(int i = 0; i < bsolv->length(); i++)
+	for(int i = 0; i < (int)bsolv->length(); i++)
 	{
 		ff.PushSample(bsolv->get(i));
 


### PR DESCRIPTION
This PR attempts to fix most of the warnings that are issued by ToolAnalysis during the compilation step. Most of the warnings concern the comparison of signed and unsigned integers as well as not properly initialized variables. The functionality of the tools should not be altered by this in any way.