### PR TITLE
EventSelector update

### DIFF
--- a/UserTools/EventSelector/EventSelector.h
+++ b/UserTools/EventSelector/EventSelector.h
@@ -47,7 +47,10 @@ class EventSelector: public Tool {
    kFlagMCEnergyCut   = 0x4000, //16384
    kFlagPMTMRDCoinc   = 0x8000, //32768
    kFlagNoVeto        = 0x10000, //65536
-   kFlagVeto        = 0x20000 //131072
+   kFlagVeto        = 0x20000, //131072
+   kFlagTrigger      = 0x40000,
+   kFlagThroughGoing     = 0x80000,
+   kFlagRecoPDG        = 0x1000000,
   } EventFlags_t;
 
  private:
@@ -150,7 +153,27 @@ class EventSelector: public Tool {
   /// This event selection criteria requires that no veto paddles
   /// of the Front Muon Veto fired during the event
   bool EventSelectionByVetoCut();
-  
+ 
+  /// \brief Event selection by requiring specific triggerword
+  ////
+  /// This event selection criteria requires that the specified triggerword
+  /// is present for this event
+  bool EventSelectionByTrigger(int current_trigger, int reference_trigger);
+
+  /// \brief Event selection for through-going muon candidates
+  ///
+  /// This event selection criterion flags events with a through-going
+  /// muon candidate (FMV + tank + MRD)
+  bool EventSelectionByThroughGoing();
+
+  /// \brief Helper functions to get FMV intersections with muon path
+  bool FindPaddleChankey(double x, double y, int layer, unsigned long &chankey);
+  bool FindPaddleIntersection(std::vector<double> startpos, std::vector<double> endpos, double &x, double &y, double z);
+
+  /// \brief Event selection for reconstructed pdg values (currently just neutron)
+  //
+  bool EventSelectionByRecoPDG(int recoPDG, std::vector<double> & vector_reco_pdg);
+
   /// \brief MC entry number
   uint64_t fMCEventNum;
   
@@ -179,6 +202,7 @@ class EventSelector: public Tool {
   std::vector<double> *vec_pmtclusters_charge = nullptr;
   std::vector<double> *vec_pmtclusters_time = nullptr;
   std::vector<double> *vec_mrdclusters_time = nullptr;
+  std::map<int,double>* ChannelNumToTankPMTSPEChargeMap = nullptr;   ///< PMT SPE Gain Map
 
   //verbosity initialization
   int verbosity=1;
@@ -206,10 +230,18 @@ class EventSelector: public Tool {
   bool fPromptTrigOnly = true;
   bool fNoVetoCut = false;
   bool fVetoCut = false;
+  bool fThroughGoing = false;
   bool fEventCutStatus;
   bool fIsMC; 
+  int fTriggerWord;
+  int fRecoPDG;
 
-  
+  bool get_mrd = false;
+  double pmt_time = 0; 
+  double pmtmrd_coinc_min = 0; 
+  double pmtmrd_coinc_max = 0;
+  int n_hits = 0; 
+ 
   bool fSaveStatusToStore = true;
   /// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.
   int v_error=0;

--- a/UserTools/EventSelector/README.md
+++ b/UserTools/EventSelector/README.md
@@ -7,29 +7,39 @@ EventSelector
 The event selector tool flags events in the input data file as passing or failing
 various event selection criteria.  Current event selection flags that can be
 utilized include:
-  - MCPiKCut: Flags events that had a primary muon or pion produced
-  - MRDRecoCut Flags muon events that do not stop in the MRD according to reco.
-  - MCFVCut: Flags MC muon events that are not generated in the defined Fiducial volume 
-  - MCPMTVolCut: Flags MC muon events that are not generated inside the PMT volume 
-  - MCMRDCut: Flags MC muon events with muons that do not stop in the MRD
-  - PromptTrigOnly: Flags muon events that do not have an MCTriggernum of 0
+  * `MCPiKCut`: Flags events that had a primary muon or pion produced
+  * `MRDRecoCut`: Flags muon events that do not stop in the MRD according to reco.
+  * `MCFVCut`: Flags MC muon events that are not generated in the defined Fiducial volume 
+  * `MCPMTVolCut`: Flags MC muon events that are not generated inside the PMT volume 
+  * `MCMRDCut`: Flags MC muon events with muons that do not stop in the MRD
+  * `PromptTrigOnly`: Flags muon events that do not have an MCTriggernum of 0
                     (any store event with MCTriggernum>0 is a delayed trigger)
-  - NHitCut: Flags events that do not have at least some number of hits (default is 4)
-  - PMTMRDCoincCut: Flags events that do not have a certain time offset between PMT & MRD cluster
-  - Identical cuts, but with the reconstructed information, are prefaced with "Reco"
+  * Identical cuts, but with the reconstructed information, are prefaced with "Reco"
   
 Cuts that are only available in MC:
-  - MCIsElectronCut: Flags events that had a primary electron
-  - MCIsMuonCut: Flags events that had a primary muon
-  - MCIsSingleRingCut: Flags events that had a single ring
-  - MCIsMultiRingCut: Flags events that had multiple rings
-  - MCEnergyCut: Flags events that were in a certain energy range
+  * `MCIsElectronCut`: Flags events that had a primary electron
+  * `MCIsMuonCut`: Flags events that had a primary muon
+  * `MCIsSingleRingCut`: Flags events that had a single ring
+  * `MCIsMultiRingCut`: Flags events that had multiple rings
+  * `MCEnergyCut`: Flags events that were in a certain energy range
+
+Cuts which are available both in MC and data:
+  * `NHitCut`: Flags events that do not have at least some number of hits (default is 4). Note that this cut is applied to the `RecoDigits` object, so you need to convert `Hits` into `RecoDigits` with the `RecoDigitBuilder` tool.
+  * `NHitmin`: Specifies the minimum number of hits for the `NhitCut`
+  * `PMTMRDCoincCut`: Flags events that do not have a certain time offset between PMT & MRD cluster
+  * `PMTMRDOffset`: If the `PMTMRDCoincCut` is used, this variable specifies the expected timing offset between the tank PMTs and the MRD events for the same physics event (due to cable delays etc)
+  * `NoVeto`: Selects events with no coincident veto activity for the time window of the main tank PMT cluster
+  * `Veto`: Selects events with coincident veto activity for the time window of the main tank PMT cluster
+  * `ThroughGoing`: Selects through-going muon events (with hits in the FMV, and coincident activity in the tank and MRD)
+  * `TriggerWord`: Selects only events with a certain triggerword. If set to -1, no triggerword selection
+  * `RecoPDG`: Sets a flag if the specified pdg is present in the data. Currently only works for neutrons (pdg = 2112)
 
 After running the event selector tool, two bitmasks are added to the RecoEvent
 store: "EventFlagApplied" and "EventFlagged".  The prior indicates which event
 selection criteria were checked on the event, while the latter indicates which
 event selection the event actually failed.  The bitmask as of now is given by:
 
+```
    kFlagNone         = 0x00, //0
    kFlagMCFV         = 0x01, //1
    kFlagMCPMTVol     = 0x02, //2
@@ -47,7 +57,12 @@ event selection the event actually failed.  The bitmask as of now is given by:
    kFlagMCProjectedMRDHit = 0x2000, //8192
    kFlagMCEnergyCut   = 0x4000 //16384
    kFlagPMTMRDCoinc   = 0x8000 //32768
-
+   kFlagNoVeto        = 0x10000, //65536
+   kFlagVeto        = 0x20000, //131072
+   kFlagTrigger      = 0x40000,
+   kFlagThroughGoing     = 0x80000,
+   kFlagRecoPDG        = 0x1000000,
+```
 
 For each event, all cuts defined with the config file are checked.  
 
@@ -85,6 +100,11 @@ Emin
 Emax
 PMTMRDCoincCut
 PMTMRDOffset
+Veto
+NoVeto
+ThroughGoing
+TriggerWord
+RecoPDG
 IsMC
 SaveStatusToStore
 ```


### PR DESCRIPTION
Some more options for the `EventSelector` tool, namely:

* the option to select through-going muon events (starting from outside the tank, passing the FMV, water, and the MRD)
* the option to select events by triggerword
* the option to select events based on whether they contain particles of a certain PDG number (currently only implemented for neutrons)

+ updated README file for the EventSelector tool