### PR TITLE
LoadRawData and PreProcessTrigOverlap/CreateMyList 

### DIFF
--- a/UserTools/LoadRawData/LoadRawData.h
+++ b/UserTools/LoadRawData/LoadRawData.h
@@ -54,10 +54,10 @@ class LoadRawData: public Tool {
   bool storerawdata;
 
   int FileNum = 0;
-  int tanktotalentries;
-  int trigtotalentries;
-  int mrdtotalentries;
-  int lappdtotalentries;
+  long tanktotalentries;
+  long trigtotalentries;
+  long mrdtotalentries;
+  long lappdtotalentries;
   bool TankEntriesCompleted;
   bool MRDEntriesCompleted;
   bool TrigEntriesCompleted;

--- a/configfiles/PreProcessTrigOverlap/CreateMyList.sh
+++ b/configfiles/PreProcessTrigOverlap/CreateMyList.sh
@@ -11,7 +11,7 @@ NUMFILES=$(ls -1q ${FILEDIR}/RAWDataR${RUN}* | wc -l)
 
 echo "NUMBER OF FILES IN ${FILEDIR}: ${NUMFILES}"
 
-for p in $(seq 0 $NUMFILES)
+for p in $(seq 0 $(($NUMFILES -1 )))
 do
 	echo "${FILEDIR}/RAWDataR${RUN}S0p${p}" >> my_files.txt
 done


### PR DESCRIPTION
In LoadRawData: LoadRawData.h int variables(mrdtotalentries, tanktotalentries, trigtotalentries and lappdtotalentries) were changed by long.
In CreateMyList, now it removes the last path like in the my_files.txt