### PR TITLE
Fixing uninitialized values

### DIFF
--- a/UserTools/LoadRawData/LoadRawData.cpp
+++ b/UserTools/LoadRawData/LoadRawData.cpp
@@ -54,6 +54,10 @@ bool LoadRawData::Initialise(std::string configfile, DataModel &data){
   MRDEntryNum = 0;
   TrigEntryNum = 0;
   LAPPDEntryNum = 0;
+  tanktotalentries = 0;
+  trigtotalentries = 0;
+  mrdtotalentries = 0;
+  lappdtotalentries = 0;
   FileCompleted = false;
   TankEntriesCompleted = false;
   MRDEntriesCompleted = false;


### PR DESCRIPTION
Uninitialized values in LoadRawData were causing junk memory to be used for comparisons.