### PR TITLE
EventBuilding - fix for aux channels not being saved

### DIFF
--- a/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.cpp
+++ b/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.cpp
@@ -70,7 +70,7 @@ bool ANNIEEventBuilder::Initialise(std::string configfile, DataModel &data){
   m_data->CStore.Get("MRDCrateSpaceToChannelNumMap",MRDCrateSpaceToChannelNumMap);
   m_data->CStore.Get("ChannelNumToTankPMTCrateSpaceMap",ChannelNumToTankPMTCrateSpaceMap);
   m_data->CStore.Get("AuxChannelNumToCrateSpaceMap",AuxChannelNumToCrateSpaceMap);
-
+  
   if(BuildType == "Tank" || BuildType == "TankAndMRD" || BuildType == "TankAndMRDAndCTC" || BuildType == "TankAndCTC" || BuildType == "TankAndMRDAndCTCAndLAPPD"){
     int NumTankPMTChannels = TankPMTCrateSpaceToChannelNumMap.size();
     int NumAuxChannels = AuxCrateSpaceToChannelNumMap.size();
@@ -2050,7 +2050,18 @@ void ANNIEEventBuilder::ManageOrphanage(){
     std::vector<unsigned long> CurrentWaveMapChankeys;
     for (int i_channel = 0; i_channel < (int) CurrentWaveMapChannels.size(); i_channel++){
       std::vector<int> current_cratespace = CurrentWaveMapChannels.at(i_channel);
-      unsigned long current_chankey = TankPMTCrateSpaceToChannelNumMap[current_cratespace];
+      unsigned long current_chankey = 0;
+      if (TankPMTCrateSpaceToChannelNumMap.count(current_cratespace)>0){
+        current_chankey = TankPMTCrateSpaceToChannelNumMap[current_cratespace];
+      } else if (AuxCrateSpaceToChannelNumMap.count(current_cratespace)>0){
+        current_chankey  = AuxCrateSpaceToChannelNumMap.at(current_cratespace);
+      } else {
+        Log("ANNIEEventBuilder: Encountered invalid crate space during orphan movement. Setting chankey = 99999999",v_error,verbosity);
+        current_chankey = 99999999;
+        Log("ANNIEEventBuilder::CrateNum "+to_string(current_cratespace.at(0)),v_error, verbosity);
+        Log("ANNIEEventBuilder::SlotNum "+to_string(current_cratespace.at(1)),v_error, verbosity);
+        Log("ANNIEEventBuilder::ChannelID "+to_string(current_cratespace.at(2)),v_error, verbosity);   
+      }
       CurrentWaveMapChankeys.push_back(current_chankey);
     }
     OrphanStore->Set("WaveformChankeys",CurrentWaveMapChankeys);

--- a/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.cpp
+++ b/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.cpp
@@ -10,7 +10,7 @@ bool ANNIEEventBuilder::Initialise(std::string configfile, DataModel &data){
   //m_variables.Print();
 
   m_data= &data; //assigning transient data pointer
-
+  
   SavePath = "./";
   ProcessedFilesBasename = "ProcessedRawData";
   BuildType = "TankAndMRD";


### PR DESCRIPTION
Bug discovered by @ricfregian which prevents auxiliary channels (such as the AmBe SiPMs) raw waveforms from being stored in the output file when using the default event building mode `TankAndMRDAndCTC(AndLAPPD)`.

During the orphan movement in the `ANNIEEventBuilder`, the code checks whether a certain electronics channel combination is associated with a regular channel or with an auxiliary channel. However, the relevant code reads

`current_chankey = TankPMTCrateSpaceToChannelNumMap[current_cratespace];`

Even if the vector `current_cratespace` does not exist yet as a key in the `TanKPMTCrateSpaceToChannelNumMap`, it will be inserted by this operation. As a consequence, due to this call in the orphan movement, all electronics channels associated with auxiliary channels will be inserted into the `TankPMTCrateSpaceToChannelNumMap` for regular channels. They will therefore all be recognized as regular channels with channelkey 0. 

This bug leads to auxiliary channels not being saved in the case of using the option for raw waveforms. When using the EventBuilding with Hit information (i.e. with the `PhaseIIADCCalibrator` and `PhaseIIADCHitFinder`, not saving the raw waveforms), this bug does not occur since the separation of normal and auxiliary channels happens already in the `PhaseII*` tools and not in the `ANNIEEventBuilder` tool.

The bug does also not appear when using the `Tank` mode of the event builder, since in that case no orphan movement occurs.