### PR TITLE
Automatic 8ns correction procedure for event building

### DIFF
--- a/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.cpp
+++ b/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.cpp
@@ -1227,6 +1227,18 @@ void ANNIEEventBuilder::ProcessNewTankPMTData(){
 
   if(verbosity>5) std::cout << "ANNIEEventBuilder Tool: Processing new tank data " << std::endl;
 
+  /// -----------------------------------
+  /// ----- Correct 8ns offset issue ----
+  /// -----------------------------------
+ 
+  bool force_all_entries = false;
+  bool FileCompleted = false;
+  m_data->CStore.Get("FileCompleted",FileCompleted);
+  if (FileCompleted) force_all_entries = true;
+
+  if (save_raw_data) this->Correct8nsOffsetRaw(force_all_entries);
+  else this->Correct8nsOffset(force_all_entries);
+
   /// ------------------------------
   ///---------RAW DATA case ----------
   /// -------------------------------
@@ -2769,3 +2781,152 @@ std::cout <<"***NEW BEST MATCH: min_dev: "<<min_dev<<", min_mean: "<<min_mean<<"
   }
 
 }
+
+void ANNIEEventBuilder::Correct8nsOffsetRaw(bool force_all_entries){
+
+  Log("ANNIEEventBuilder: Correct8nsOffsetRaw",v_message,verbosity);
+
+  std::vector<uint64_t> timestamps_tank;
+  std::map<uint64_t, uint64_t> timestamps_to_shift;
+
+  //Make a list of PMT timestamps
+  for(std::pair<uint64_t,std::map<std::vector<int>, std::vector<uint16_t>>> apair : *InProgressTankEvents){
+    uint64_t PMTCounterTimeNs = apair.first;
+    timestamps_tank.push_back(PMTCounterTimeNs);
+  }
+
+  //Exclude the last five (most recent) entries, since those are probably still in progress
+  int number_entries = (timestamps_tank.size() > 6)? timestamps_tank.size() - 5 : 1;
+  if (force_all_entries) number_entries = (int) timestamps_tank.size();
+
+  //Go through the list of PMT timestamps and look for abnormally close timestamps (8ns)
+  //Start with the second entry and always compare to previous entry
+  for (int i_timestamp = 1; i_timestamp < number_entries; i_timestamp++){
+    uint64_t FirstTS = timestamps_tank.at(i_timestamp-1);
+    uint64_t SecondTS = timestamps_tank.at(i_timestamp);
+    uint64_t TSDiff = (SecondTS > FirstTS)? (SecondTS-FirstTS) : (FirstTS-SecondTS);
+    uint64_t ExpectedOffset = 8;
+    if (TSDiff == ExpectedOffset){
+      //if 8ns offset is detected, map the entry with less waveforms onto the one with more waveforms
+      int waveforms_first = int(InProgressTankEvents->at(FirstTS).size());
+      int waveforms_second = int(InProgressTankEvents->at(SecondTS).size());
+      bool first_entry_larger = (waveforms_first > waveforms_second);
+      Log("ANNIEEventBuilder: First TS = "+std::to_string(FirstTS)+", waveforms = "+std::to_string(waveforms_first)+", Second TS = "+std::to_string(SecondTS)+", waveforms = "+std::to_string(waveforms_second)+", first_entry_larger = "+std::to_string(first_entry_larger),v_debug,verbosity);
+      if (first_entry_larger) timestamps_to_shift.emplace(SecondTS,FirstTS);
+      else timestamps_to_shift.emplace(FirstTS,SecondTS); 
+    }
+  }
+
+  //Go through the timestamps to shift and apply the correction
+  for (std::map<uint64_t, uint64_t>::iterator it=timestamps_to_shift.begin(); it!= timestamps_to_shift.end(); it++){
+    uint64_t FirstTS = it->first;
+    uint64_t SecondTS = it->second;
+    Log("ANNIEEventBuilder: Map Timestamp "+std::to_string(FirstTS)+" to timestamp "+std::to_string(SecondTS),v_debug,verbosity);
+    std::map<std::vector<int>, std::vector<uint16_t>> FirstTankEvents = InProgressTankEvents->at(FirstTS);
+    std::map<std::vector<int>, std::vector<uint16_t>> SecondTankEvents = InProgressTankEvents->at(SecondTS);
+    
+    //Merge the two waveform maps
+    SecondTankEvents.insert(FirstTankEvents.begin(), FirstTankEvents.end());
+    Log("ANNIEEventBuilder: Size of Merged Waveforms map: "+std::to_string(SecondTankEvents.size()),v_debug,verbosity);
+
+    //Associated merged map with preferred TS, delete other TS
+    (*InProgressTankEvents)[SecondTS] = SecondTankEvents;
+    InProgressTankEvents->erase(FirstTS);
+    Log("ANNIEEventBuilder: Size of merged TS in InProgressTankEvents: "+std::to_string(InProgressTankEvents->at(SecondTS).size()),v_debug,verbosity);
+  }
+
+}
+
+void ANNIEEventBuilder::Correct8nsOffset(bool force_all_entries){
+
+  Log("ANNIEEventBuilder: Correct8nsOffset",v_message,verbosity);
+  std::vector<uint64_t> timestamps_tank;
+  std::map<uint64_t, uint64_t> timestamps_to_shift;
+  
+  //Make a list of PMT timestamps
+  for(std::pair<uint64_t, std::map<unsigned long,std::vector<Hit>>*> apair : *InProgressHits){
+    uint64_t PMTCounterTimeNs = apair.first;
+    timestamps_tank.push_back(PMTCounterTimeNs);
+  }
+
+  //Go through the list of PMT timestamps and look for abnormally close timestamps (8ns)
+  //Start with the second entry and always compare to previous entry
+  for (int i_timestamp = 1; i_timestamp < (int) timestamps_tank.size(); i_timestamp++){
+    uint64_t FirstTS = timestamps_tank.at(i_timestamp-1);
+    uint64_t SecondTS = timestamps_tank.at(i_timestamp);
+    uint64_t TSDiff = (SecondTS > FirstTS)? (SecondTS-FirstTS) : (FirstTS-SecondTS);
+    uint64_t ExpectedOffset = 8;
+    if (TSDiff == ExpectedOffset){
+      //if 8ns offset is detected, map the entry with less waveforms onto the one with more waveforms
+      int waveforms_first = int(InProgressHits->at(FirstTS)->size());
+      int waveforms_second = int(InProgressHits->at(SecondTS)->size());
+      bool first_entry_larger = (waveforms_first > waveforms_second);
+      Log("ANNIEEventBuilder: First TS = "+std::to_string(FirstTS)+", waveforms = "+std::to_string(waveforms_first)+", Second TS = "+std::to_string(SecondTS)+", waveforms = "+std::to_string(waveforms_second)+", first_entry_larger = "+std::to_string(first_entry_larger),v_debug,verbosity);
+      if (first_entry_larger) timestamps_to_shift.emplace(SecondTS,FirstTS);
+      else timestamps_to_shift.emplace(FirstTS,SecondTS); 
+    }
+  }
+
+  //Go through the timestamps to shift and apply the correction
+  for (std::map<uint64_t, uint64_t>::iterator it=timestamps_to_shift.begin(); it!= timestamps_to_shift.end(); it++){
+    uint64_t FirstTS = it->first;
+    uint64_t SecondTS = it->second;
+    Log("ANNIEEventBuilder: Map Timestamp "+std::to_string(FirstTS)+" to timestamp "+std::to_string(SecondTS),v_debug,verbosity);
+
+    //Get InProgress* {Hits, Chkey, and RecoADCHits} objects
+    std::map<unsigned long,std::vector<Hit>>* FirstTankHits = InProgressHits->at(FirstTS);
+    std::map<unsigned long,std::vector<Hit>>* SecondTankHits = InProgressHits->at(SecondTS);
+    std::vector<unsigned long> FirstChankey = InProgressChkey->at(FirstTS);
+    std::vector<unsigned long> SecondChankey = InProgressChkey->at(SecondTS);
+    std::map<unsigned long,std::vector<Hit>>* FirstTankHitsAux = InProgressHitsAux->at(FirstTS);
+    std::map<unsigned long,std::vector<Hit>>* SecondTankHitsAux = InProgressHitsAux->at(SecondTS);
+    std::map<unsigned long,std::vector<std::vector<ADCPulse>>> FirstRecoADCHits = InProgressRecoADCHits->at(FirstTS);
+    std::map<unsigned long,std::vector<std::vector<ADCPulse>>> SecondRecoADCHits = InProgressRecoADCHits->at(SecondTS);
+    std::map<unsigned long,std::vector<std::vector<ADCPulse>>> FirstRecoADCHitsAux = InProgressRecoADCHitsAux->at(FirstTS);
+    std::map<unsigned long,std::vector<std::vector<ADCPulse>>> SecondRecoADCHitsAux = InProgressRecoADCHitsAux->at(SecondTS);
+
+    //Merge the two hits maps
+    SecondTankHits->insert(FirstTankHits->begin(), FirstTankHits->end());
+    Log("ANNIEEventBuilder: Size of Merged Hits map: "+std::to_string(SecondTankHits->size()),v_debug,verbosity);
+
+    //Merge the two aux hits maps
+    SecondTankHitsAux->insert(FirstTankHitsAux->begin(), FirstTankHitsAux->end());
+    Log("ANNIEEventBuilder: Size of Merged AuxHits map: "+std::to_string(SecondTankHitsAux->size()),v_debug,verbosity);
+
+    //Merge the two channelkey vectors
+    SecondChankey.insert(SecondChankey.end(), FirstChankey.begin(), FirstChankey.end());
+    Log("ANNIEEventBuilder: Size of Merged Chkey vector: "+std::to_string(SecondChankey.size()),v_debug,verbosity);
+
+    //Merge the two RecoADCHits maps
+    SecondRecoADCHits.insert(FirstRecoADCHits.begin(),FirstRecoADCHits.end());
+    Log("ANNIEEventBuilder: Size of Merged RecoADCHits map: "+std::to_string(SecondRecoADCHits.size()),v_debug,verbosity);
+
+    //Merge the two RecoADCHitsAux maps
+    SecondRecoADCHitsAux.insert(FirstRecoADCHitsAux.begin(),FirstRecoADCHitsAux.end());
+    Log("ANNIEEventBuilder: Size of Merged RecoADCHitsAux map: "+std::to_string(SecondRecoADCHitsAux.size()),v_debug,verbosity);
+
+    //Associated merged map with preferred TS, delete other TS
+    (*InProgressHits)[SecondTS] = SecondTankHits;
+    InProgressHits->erase(FirstTS);
+    Log("ANNIEEventBuilder: Size of merged TS in InProgressHits: "+std::to_string(InProgressHits->at(SecondTS)->size()),v_debug,verbosity);
+
+    (*InProgressHitsAux)[SecondTS] = SecondTankHitsAux;
+    InProgressHitsAux->erase(FirstTS);
+    Log("ANNIEEventBuilder: Size of merged TS in InProgressHitsAux: "+std::to_string(InProgressHitsAux->at(SecondTS)->size()),v_debug,verbosity);
+
+    //Do the same for Chkey map
+    (*InProgressChkey)[SecondTS] = SecondChankey;
+    InProgressChkey->erase(FirstTS);
+    Log("ANNIEEventBuilder: Size of merged TS in InProgressChkey: "+std::to_string(InProgressChkey->at(SecondTS).size()),v_debug,verbosity);
+
+    (*InProgressRecoADCHits)[SecondTS] = SecondRecoADCHits;
+    InProgressRecoADCHits->erase(FirstTS);
+    Log("ANNIEEventBuilder: Size of merged TS in InProgressRecoADCHits: "+std::to_string(InProgressRecoADCHits->at(SecondTS).size()),v_debug,verbosity);
+    
+    (*InProgressRecoADCHitsAux)[SecondTS] = SecondRecoADCHitsAux;
+    InProgressRecoADCHitsAux->erase(FirstTS);
+    Log("ANNIEEventBuilder: Size of merged TS in InProgressRecoADCHitsAux: "+std::to_string(InProgressRecoADCHitsAux->at(SecondTS).size()),v_debug,verbosity);
+
+  }
+}
+

--- a/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.h
+++ b/UserTools/ANNIEEventBuilder/ANNIEEventBuilder.h
@@ -96,6 +96,9 @@ class ANNIEEventBuilder: public Tool {
 
   bool FetchWaveformsHits();
 
+  //Functions to correct 8ns offset error
+  void Correct8nsOffsetRaw(bool force_all_entries);
+  void Correct8nsOffset(bool force_all_entries);
 
   //Methods for getting all timestamps encountered by decoder tools
   void ProcessNewTankPMTData();

--- a/configfiles/DataDecoder/DataDecoderRaw/ANNIEEventBuilderConfig
+++ b/configfiles/DataDecoder/DataDecoderRaw/ANNIEEventBuilderConfig
@@ -1,0 +1,17 @@
+verbosity 5
+
+BuildType TankAndMRDAndCTC
+ProcessedFilesBasename ProcessedRawData_WholeWaveforms
+NumEventsPerPairing 200
+SavePath ./
+
+MinNumWavesInSet 134 // 1=Just throw any waveforms into ANNIE events if you got em
+
+ExecutesPerBuild 10
+OrphanOldTankTimestamps 1
+OldTimestampThreshold 1000
+OrphanFileBase OrphanStore
+MaxStreamMatchingTimeSeparation 60 // seconds. If one stream is ahead of the others, pause reading
+
+SaveRawData 1
+StoreBeamStatus 0

--- a/configfiles/DataDecoder/DataDecoderRaw/LoadRawDataConfig
+++ b/configfiles/DataDecoder/DataDecoderRaw/LoadRawDataConfig
@@ -1,0 +1,9 @@
+verbosity 11
+BuildType TankAndMRDAndCTC
+#BuildType CTC
+Mode FileList
+InputFile ./configfiles/DataDecoder/my_files.txt
+DummyRunInfo 1
+StoreTrigOverlap 0
+ReadTrigOverlap 1
+StoreRawData 1

--- a/configfiles/DataDecoder/DataDecoderRaw/ToolChainConfig
+++ b/configfiles/DataDecoder/DataDecoderRaw/ToolChainConfig
@@ -1,0 +1,23 @@
+#ToolChain dynamic setup file
+
+##### Runtime Paramiters #####
+verbose 1
+error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
+attempt_recover 1
+
+###### Logging #####
+log_mode Interactive # Interactive=cout , Remote= remote logging system "serservice_name Remote_Logging" , Local = local file log;
+log_local_path ./log
+log_service LogStore
+
+###### Service discovery #####
+service_publish_sec -1
+service_kick_sec -1
+
+##### Tools To Add #####
+Tools_File ./configfiles/DataDecoder/DataDecoderRaw/ToolsConfig
+
+##### Run Type #####
+Inline -1
+Interactive 0
+

--- a/configfiles/DataDecoder/DataDecoderRaw/ToolChainConfig
+++ b/configfiles/DataDecoder/DataDecoderRaw/ToolChainConfig
@@ -2,7 +2,7 @@
 
 ##### Runtime Paramiters #####
 verbose 1
-error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
+error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handled errors
 attempt_recover 1
 
 ###### Logging #####

--- a/configfiles/DataDecoder/DataDecoderRaw/ToolsConfig
+++ b/configfiles/DataDecoder/DataDecoderRaw/ToolsConfig
@@ -1,0 +1,7 @@
+LoadGeometry LoadGeometry ./configfiles/LoadGeometry/LoadGeometryConfig
+LoadRawData LoadRawData ./configfiles/DataDecoder/DataDecoderRaw/LoadRawDataConfig
+PMTDataDecoder PMTDataDecoder ./configfiles/DataDecoder/PMTDataDecoderConfig
+MRDDataDecoder MRDDataDecoder ./configfiles/DataDecoder/MRDDataDecoderConfig
+TriggerDataDecoder TriggerDataDecoder ./configfiles/DataDecoder/TriggerDataDecoderConfig
+BeamDecoder BeamDecoder ./configfiles/DataDecoder/BeamDecoderConfig
+ANNIEEventBuilder ANNIEEventBuilder ./configfiles/DataDecoder/DataDecoderRaw/ANNIEEventBuilderConfig


### PR DESCRIPTION
There is an issue in the VME data which sometimes causes the timestamps for channels of one of the VME crates to be shifted by 8ns with respect to timestamps in the other two VME crates. This leads to problems in the event building since the `ANNIEEventBuilder` recognizes the two VME timestamps as separate VME events and hence concludes that the events are incomplete, leading to no (or less) built events.

In the past, this happened only very rarely, leading to the introduction of the `OffsetVME01`, `OffsetVME03`, and `OffsetPositive` variables to the `PMTDataDecoder` in PR#205 and #PR216. However, this procedure requires to first test which of the VMEs needs to be corrected for the 8ns (by switching the variables `OffsetVME01` and `OffsetVME03` to on/off) and in which direction the shift should occur (by using the `OffsetPositive` variable).

This was fine in the past since the issue happened only for a couple of files per month. However, in recent data the problem seems to occur way more frequently in almost all of the files, making the manual correction procedure quite cumbersome. Therefore, an automatic correction for the 8ns offset is provided here which automatically detects if the 8ns offset is present and subsequently corrects the affected timestamps.

In addition, a separate configuration directory is provided for storing raw waveforms with the event building to highlight the necessary changes.