### PR TITLE
Modification to the BeamFetcher Tool, adjusting for the SQL database now being in UTC

### DIFF
--- a/UserTools/BeamFetcher/BeamFetcher.cpp
+++ b/UserTools/BeamFetcher/BeamFetcher.cpp
@@ -35,7 +35,7 @@ bool BeamFetcher::Initialise(std::string config_filename, DataModel& data)
     timestamp_mode = "MSEC";
   }
 
-  // SQL Page now in UTC, no need for timezone shift and/or Daylight Savings Adjustment
+  
 
   bool got_runnumber = m_variables.Get("RunNumber",RunNumber);
   if (timestamp_mode == "DB"){

--- a/UserTools/BeamFetcher/BeamFetcher.cpp
+++ b/UserTools/BeamFetcher/BeamFetcher.cpp
@@ -25,7 +25,6 @@ bool BeamFetcher::Initialise(std::string config_filename, DataModel& data)
 
   // Default values
   timestamp_mode = "MSEC";	//Other option: LOCALDATE, DB
-  DaylightSavings = false; 
 
   m_variables.Get("verbose", verbosity_);
 
@@ -36,14 +35,7 @@ bool BeamFetcher::Initialise(std::string config_filename, DataModel& data)
     timestamp_mode = "MSEC";
   }
 
-  bool got_daylight_savings = m_variables.Get("DaylightSavings",DaylightSavings);
-  if (DaylightSavings != 1 && DaylightSavings != 0){
-    Log("Error: DaylightSavings setting "+std::to_string(DaylightSavings)+" not recognized"
-      "Setting default option 0",0,verbosity_);
-    DaylightSavings = 0;
-  }
-  TimeZoneShift = 21600000;
-  if (DaylightSavings) TimeZoneShift = 18000000;
+  // SQL Page now in UTC, no need for timezone shift and/or Daylight Savings Adjustment
 
   bool got_runnumber = m_variables.Get("RunNumber",RunNumber);
   if (timestamp_mode == "DB"){

--- a/UserTools/BeamFetcher/BeamFetcher.cpp
+++ b/UserTools/BeamFetcher/BeamFetcher.cpp
@@ -269,11 +269,11 @@ void BeamFetcher::ConvertDateToMSec(std::string start_str,std::string end_str,ui
   boost::posix_time::ptime ptime_start(boost::posix_time::time_from_string(start_str));
   boost::posix_time::time_duration start_duration;
   start_duration = boost::posix_time::time_duration(ptime_start - Epoch);
-  start_ms = start_duration.total_milliseconds()+TimeZoneShift;
+  start_ms = start_duration.total_milliseconds();
   boost::posix_time::time_duration end_duration;
   boost::posix_time::ptime ptime_end(boost::posix_time::time_from_string(end_str));
   end_duration = boost::posix_time::time_duration(ptime_end - Epoch);
-  end_ms = end_duration.total_milliseconds()+TimeZoneShift;
+  end_ms = end_duration.total_milliseconds();
 
   if (verbosity_ > 2)  std::cout <<"BeamFetcher: start_ms: "<<start_ms<<", end_ms: "<<end_ms<<std::endl;
 

--- a/UserTools/BeamFetcher/BeamFetcher.h
+++ b/UserTools/BeamFetcher/BeamFetcher.h
@@ -54,7 +54,7 @@ class BeamFetcher: public Tool {
     uint64_t end_ms_since_epoch;
     void ConvertDateToMSec(std::string start_str,std::string end_str,uint64_t &start_ms,uint64_t &end_ms);
     uint64_t TimeZoneShift;
-    bool DaylightSavings;
+    //bool DaylightSavings;
     std::map<int,std::map<std::string,std::string>> RunInfoDB;
     int RunNumber;
 

--- a/UserTools/BeamFetcher/BeamFetcher.h
+++ b/UserTools/BeamFetcher/BeamFetcher.h
@@ -54,7 +54,6 @@ class BeamFetcher: public Tool {
     uint64_t end_ms_since_epoch;
     void ConvertDateToMSec(std::string start_str,std::string end_str,uint64_t &start_ms,uint64_t &end_ms);
     uint64_t TimeZoneShift;
-    //bool DaylightSavings;
     std::map<int,std::map<std::string,std::string>> RunInfoDB;
     int RunNumber;
 

--- a/UserTools/BeamFetcher/BeamFetcher.h
+++ b/UserTools/BeamFetcher/BeamFetcher.h
@@ -53,7 +53,6 @@ class BeamFetcher: public Tool {
     uint64_t start_ms_since_epoch;
     uint64_t end_ms_since_epoch;
     void ConvertDateToMSec(std::string start_str,std::string end_str,uint64_t &start_ms,uint64_t &end_ms);
-    uint64_t TimeZoneShift;
     std::map<int,std::map<std::string,std::string>> RunInfoDB;
     int RunNumber;
 


### PR DESCRIPTION
The BeamFetcher toolchain fetches the starting time and end times for a run according to a .txt file (ANNIE_RunInformation_PSQL.txt) which is traditionally copied from the SQL database. Since the database is now in UTC, there no longer is a need to convert the SQL times (previously Chicago time). Also, there is a configuration variable in the BeamFetcher Config file that applies a time shift if there is Daylight Savings, so that is also no longer needed.