### PR TITLE
Add versioning for backward compatibility

### DIFF
--- a/DataModel/BeamDataPoint.h
+++ b/DataModel/BeamDataPoint.h
@@ -36,7 +36,7 @@ struct BeamDataPoint : public SerialisableObject {
 
   virtual bool Print() override {
     std::cout << "Value : " << value << '\n';
-    std::cout << "Unit  : " << unit  << '\n'
+    std::cout << "Unit  : " << unit  << '\n';
     std::cout << "Time  : " << time  << '\n';
     return true;
   }

--- a/DataModel/BeamDataPoint.h
+++ b/DataModel/BeamDataPoint.h
@@ -20,8 +20,7 @@ struct BeamDataPoint : public SerialisableObject {
 
   BeamDataPoint() : value(0.), unit(""), time(0) {}
   BeamDataPoint(double Value, const std::string& Unit, uint64_t time=0)
-    : value(Value), unit(Unit), time(time) {
-    std::cout << "BDP - value: " << value << ", unit: " << unit << ", time: " << time << std::endl;}
+    : value(Value), unit(Unit), time(time) {}
   double value;
   std::string unit;
   uint64_t time;

--- a/DataModel/BeamDataPoint.h
+++ b/DataModel/BeamDataPoint.h
@@ -18,8 +18,8 @@ struct BeamDataPoint : public SerialisableObject {
 
   friend class boost::serialization::access;
 
-  BeamDataPoint() : value(0.), unit(""), time(1) {}
-  BeamDataPoint(double Value, const std::string& Unit, uint64_t time=1)
+  BeamDataPoint() : value(0.), unit(""), time(0) {}
+  BeamDataPoint(double Value, const std::string& Unit, uint64_t time=0)
     : value(Value), unit(Unit), time(time) {
     std::cout << "BDP - value: " << value << ", unit: " << unit << ", time: " << time << std::endl;}
   double value;

--- a/DataModel/BeamDataPoint.h
+++ b/DataModel/BeamDataPoint.h
@@ -18,26 +18,39 @@ struct BeamDataPoint : public SerialisableObject {
 
   friend class boost::serialization::access;
 
-  BeamDataPoint() : value(0.), unit(""), time(0) {}
-  BeamDataPoint(double Value, const std::string& Unit, uint64_t time=0)
-    : value(Value), unit(Unit), time(0) {}
+  BeamDataPoint() : value(0.), unit(""), time(1) {}
+  BeamDataPoint(double Value, const std::string& Unit, uint64_t time=1)
+    : value(Value), unit(Unit), time(time) {
+    std::cout << "BDP - value: " << value << ", unit: " << unit << ", time: " << time << std::endl;}
   double value;
   std::string unit;
   uint64_t time;
-
+    
   template<class Archive> void serialize(Archive & ar,
     const unsigned int version)
   {
     ar & value;
     ar & unit;
-    ar & time;
+    if (version > 0)
+      ar & time;
   }
 
   virtual bool Print() override {
     std::cout << "Value : " << value << '\n';
-    std::cout << "Unit  : " << unit  << '\n';
+    std::cout << "Unit  : " << unit  << '\n'
     std::cout << "Time  : " << time  << '\n';
     return true;
   }
 
 };
+
+// Need to increment the class version since we added time as a new variable
+// the version number ensures backward compatibility when serializing 
+BOOST_CLASS_VERSION(BeamDataPoint, 1)
+
+
+
+
+
+
+


### PR DESCRIPTION
When I made changes for the new BeamFetcherV2 I added a member variable to the BeamDataPoint class. This inadvertently broke any files that were created with the old class whenever you tried to load the BeamStatus from the BoostStore. It didn't know how to handle the serialization for the added member.

I've added versioning now to fix this issue. 