### PR TITLE
Expanded RingCounting functionality

### DIFF
--- a/UserTools/RingCounting/README.md
+++ b/UserTools/RingCounting/README.md
@@ -1,7 +1,7 @@
 # RingCounting
 
 The RingCounting Tool is used to classify events into single- and multi-Cherenkov-ring-events.
-For this a machine learning approach is used. 
+For this a CNN-based machine learning approach is used. 
 ---
 This Tool uses PMT data in the CNNImage format (see UserTools/CNNImage). For further details on the tool and
 the models used (including performance etc.) see the documentation found on the anniegpvm-machines at (**Todo**)
@@ -14,13 +14,11 @@ All models can be found at
 ```
 /pnfs/annie/persistent/users/dschmid/RingCountingStore/models/
 ```
-and (some) at
-```
-/annie/app/users/dschmid/RingCountingStore/models/
-```
+
 ## Data
 
-- Currently does not add predictions to any BoostStore. This is planned in a future update (**Todo**)
+- In the "load_from_file" mode, this tool adds single- and multi-ring (SR/MR) predictions to the RecoEvent BoostStore. When theh "load_from_file" config parameter is set to 0, the tool instead outputs the predictions to a csv file.
+- The predictions are stored in the "RingCountingSRPrediction" and "RingCountingMRPrediction" variables 
 
 ---
 ## Configuration
@@ -30,9 +28,10 @@ are found at the top of the RingCounting.py file.
 ---
 Exemplary configuration:
 ```
-files_to_load configfiles/RingCounting/files_to_load.txt
-version 1_0_0
-model_path /annie/app/users/dschmid/RingCountingStore/models/
-pmt_mask november_22
-save_to RC_output.csv
+load_from_file 0                                                # If set to 1, load CNNImage formatted csv files
+files_to_load configfiles/RingCounting/files_to_load.txt        # txt file containing files to load in case load_from_file == 1
+version 1_0_0                                                   # Model version
+model_path /annie/app/users/dschmid/RingCountingStore/models/   # Model path
+pmt_mask november_22                                            # PMT mask (zeroed out)
+save_to RC_output.csv                                           # if load_from_file == 1, save predictions as csv
 ```


### PR DESCRIPTION
- Add RC data flow from boost stores, not requiring a pre-computed CNNImage file anymore
- Add "load_from_file" config parameter. Config setting: 0/1
- Add Execute() method in Tool class
- Add get_next_event() method in Tool class
- Change functionality of other methods to support both "load_from_file" settings
- The Tool expects a CNNImage formatted input (std::vector<double>) called "CNNImageCharge" within the "RecoEvent" boost store when not using the input from file
- The predictions are stored in the "RecoEvent" boost store as "RingCountingSRPrediction" and "RingCountingMRPrediction"

Ringcounting/README.md:
- Specify where the predictions are stored (RecoEvent)
- Complete list of config parameters