### PR TITLE
Add checks to ignore trigger channels

### DIFF
--- a/UserTools/LAPPDGausBaselineSubtraction/LAPPDGausBaselineSubtraction.cpp
+++ b/UserTools/LAPPDGausBaselineSubtraction/LAPPDGausBaselineSubtraction.cpp
@@ -46,6 +46,12 @@ bool LAPPDGausBaselineSubtraction::Execute(){
         vector<Waveform<double>> Vfwavs;
         int bi = (int)(channelno-LAPPDchannelOffset)/30;
 
+        // leave trigger channels unchanged
+        if (channelno == 1005 || channelno == 1035){
+            blsublappddata.insert(pair <int,vector<Waveform<double>>> (channelno,Vwavs));
+            continue;
+        }
+
         //loop over all Waveforms
         for(int i=0; i<Vwavs.size(); i++){
 		Waveform<double> bwav = Vwavs.at(i);


### PR DESCRIPTION
Previous version processed trigger channels in the same way as data signal channels. There are now checks to leave the trigger channels unchanged.