### PR TITLE
Fix TimeClustering bug

### DIFF
--- a/UserTools/TimeClustering/TimeClustering.cpp
+++ b/UserTools/TimeClustering/TimeClustering.cpp
@@ -352,7 +352,6 @@ bool TimeClustering::Execute(){
 					mrddigitchankeysthisevent.push_back(chankey);
 					mrddigittimesthisevent.push_back(hitsonthismrdpmt.GetTime());
 					mrddigitchargesthisevent.push_back(hitsonthismrdpmt.GetCharge());
-					mrddigitchankeysthisevent.push_back(chankey);
 					if(MakeMrdDigitTimePlot){  // XXX XXX XXX rename
 						// fill the histogram if we're checking
 						if (MakeSingleEventPlots) mrddigitts_single->Fill(hitsonthismrdpmt.GetTime());


### PR DESCRIPTION
Fix for a bug which effects output of TimeClustering in MC. 

We were previously appending `chankey` twice to a vector, when we only needed it once. The effect of this is that the earlier half of hits in the time cluster were counted twice, and the later half of hits were lost. 

The fix is simple - don't append `chankey` twice to the offending vector.