### PR TITLE
Beam Database query tool change to save all entries

### DIFF
--- a/UserTools/BeamFetcherV2/IFBeamDBInterfaceV2.cpp
+++ b/UserTools/BeamFetcherV2/IFBeamDBInterfaceV2.cpp
@@ -16,6 +16,19 @@ IFBeamDBInterfaceV2::IFBeamDBInterfaceV2()
   fCurl = curl_easy_init();
   if (!fCurl) throw std::runtime_error("IFBeamDBInterfaceV2 failed to"
     " initialize libcurl");
+
+  requiredDevices = {
+    {"E:TOR860", "E12"},
+    {"E:TOR875", "E12"},
+    {"E:THCURR", "KA"},
+    {"E:BTJT2", "DegC"},
+    {"E:HP875", "mm"},
+    {"E:VP875", "mm"},
+    {"E:HPTG1", "mm"},
+    {"E:VPTG1", "mm"},
+    {"E:HPTG2", "mm"},
+    {"E:VPTG2", "mm"},
+    {"E:BTH2T2", "DegC"}};
 }
 
 IFBeamDBInterfaceV2::~IFBeamDBInterfaceV2()
@@ -237,6 +250,14 @@ IFBeamDBInterfaceV2::ParseDBResponseSingleSpan(const std::string& response) cons
 					       unit,
 					       timestamp);
   }
+
+for (auto &ts : retMap) {
+    for (auto &dev : requiredDevices) {
+      if (ts.second.find(dev.first) == ts.second.end()) {
+          ts.second[dev.first] = BeamDataPoint(-9999, dev.second, ts.first);
+      }
+    }
+  }
   
   return retMap;
 }
@@ -280,6 +301,33 @@ IFBeamDBInterfaceV2::ParseDBResponseBundleSpan(const std::string& response) cons
 					       unit,
 					       timestamp);
   }
+
+  // count the total number of elements in retMap times the number of elements in that element, print the total number
+  int total = 0;
+  for (auto &ts : retMap) {
+    total += ts.second.size();
+  }
+  std::cout << "Total number of elements in retMap: " << total << std::endl;
+  std::cout << "Size of retMap is " << retMap.size() << std::endl;
+
+  // check each timestamp in the retMap, to see if it have all the devices in the requiredDevices map keys, if yes, continue
+  // if not, create entry for that device at retMap[TS], use the data type from the value of requiredDevices
+  // use value as -9999, unit as doulbe, timestamp = TS
+  for (auto &ts : retMap) {
+    for (auto &dev : requiredDevices) {
+      if (ts.second.find(dev.first) == ts.second.end()) {
+          //cout<<" not finding device "<<dev.first<<" at time "<<ts.first<<endl;
+          ts.second[dev.first] = BeamDataPoint(-9999., dev.second, ts.first);
+      }
+    }
+  }
+
+  int totalAfter = 0;
+  for (auto &ts : retMap) {
+    totalAfter += ts.second.size();
+  }
+  std::cout << "After inserting, total number of elements in retMap: " << totalAfter << std::endl;
+  std::cout << "Size of retMap is " << retMap.size() << std::endl;
   
   return retMap;
 }
@@ -327,6 +375,15 @@ IFBeamDBInterfaceV2::ParseDBResponseSingle(const std::string& response) const
   retMap[earlyTS][data_type] = BeamDataPoint(std::stod(val_string),
 					     unit,
 					     timestamp);
+
+for (auto &ts : retMap) {
+
+    for (auto &dev : requiredDevices) {
+      if (ts.second.find(dev.first) == ts.second.end()) {
+          ts.second[dev.first] = BeamDataPoint(-9999, dev.second, ts.first);
+      }
+    }
+  }
   
   return retMap;
 }
@@ -370,6 +427,14 @@ IFBeamDBInterfaceV2::ParseDBResponseBundle(const std::string& response) const
     retMap[earlyTS][data_type] = BeamDataPoint(std::stod(val_string),
 					       unit,
 					       timestamp);
+  }
+
+for (auto &ts : retMap) {
+    for (auto &dev : requiredDevices) {
+      if (ts.second.find(dev.first) == ts.second.end()) {
+          ts.second[dev.first] = BeamDataPoint(-9999, dev.second, ts.first);
+      }
+    }
   }
   
   return retMap;

--- a/UserTools/BeamFetcherV2/IFBeamDBInterfaceV2.cpp
+++ b/UserTools/BeamFetcherV2/IFBeamDBInterfaceV2.cpp
@@ -307,8 +307,6 @@ IFBeamDBInterfaceV2::ParseDBResponseBundleSpan(const std::string& response) cons
   for (auto &ts : retMap) {
     total += ts.second.size();
   }
-  std::cout << "Total number of elements in retMap: " << total << std::endl;
-  std::cout << "Size of retMap is " << retMap.size() << std::endl;
 
   // check each timestamp in the retMap, to see if it have all the devices in the requiredDevices map keys, if yes, continue
   // if not, create entry for that device at retMap[TS], use the data type from the value of requiredDevices
@@ -326,8 +324,6 @@ IFBeamDBInterfaceV2::ParseDBResponseBundleSpan(const std::string& response) cons
   for (auto &ts : retMap) {
     totalAfter += ts.second.size();
   }
-  std::cout << "After inserting, total number of elements in retMap: " << totalAfter << std::endl;
-  std::cout << "Size of retMap is " << retMap.size() << std::endl;
   
   return retMap;
 }

--- a/UserTools/BeamFetcherV2/IFBeamDBInterfaceV2.h
+++ b/UserTools/BeamFetcherV2/IFBeamDBInterfaceV2.h
@@ -68,6 +68,9 @@ class IFBeamDBInterfaceV2 {
       QueryBeamDBBundle(std::string bundle, uint64_t time) const;
 
     int RunQuery(const std::stringstream &url_stream, std::string &response_string) const;
+
+    /// @brief The list of devices required to save in the root tree
+    std::map<std::string, std::string> requiredDevices;
     
   protected:
     /// @brief Create the singleton IFBeamDBInterfaceV2 object

--- a/UserTools/BeamFetcherV2/README.md
+++ b/UserTools/BeamFetcherV2/README.md
@@ -20,21 +20,22 @@ FetchFromTrigger: The following objects will be put into the CStore
  
 ## Configuration
 
-The main configuration variable for the `BeamFetcher` tool is `FetchFromTimes`, which determines whether to use the tigger timestamps or user input timestamps. The `DevicesFile`, `IsBundle`, and `TimeChunkStepInMilliseconds` variables are required regardless of the fetch mode. You can also set the  `SaveROOT` bool in order to save out a TTree with the timestamp and device values as the leaves. 
+The main configuration variable for the `BeamFetcherV2` tool is `FetchFromTimes`, which determines whether to use the tigger timestamps or user input timestamps. The `DevicesFile`, `IsBundle`, and `TimeChunkStepInMilliseconds` variables are required regardless of the fetch mode. You can also set the  `SaveROOT` bool in order to save out a TTree with the timestamp and device values as the leaves. 
 
 If `FetchFromTimes == 1` then you will also need the additional config variables. The preferred timestamp format is chosen with the `TimestampMode` variable (LOCALDATE/MSEC/DB). For LOCALDATE mode you use Start/EndDate files with string formatted times (like 2023-04-11 23:03:19.163505). For MSEC mode you use the Start/EndMillisecondsSinceEpoch variables. For DB mode you must first run `LoadRunInfo` and the run timestamps will be pulled from the CStore. 
 
 ```
-# BeamFetcher config file
-verbose 5
+# BeamFetcherV2 config file
+verbose 1
 #
 # These three are always needed
 #
-DevicesFile ./configfiles/BeamFetcher/devices.txt # File containing one device per line or a bundle
+DevicesFile ./configfiles/BeamFetcherV2/devices.txt # File containing one device per line or a bundle
 IsBundle 0 # bool stating whether DevicesFile contains bundles or individual devices
 FetchFromTimes 0 # bool defining how to grab the data (from input times (1) or trigger(0))
 TimeChunkStepInMilliseconds 3600000 # one hour
 SaveROOT 0 # bool, do you want to write a ROOT file with the timestamps and devices?
+DeleteCTCData 0 # bool, delete viewed CTC timestamps? Helps reduce memory overhead when not running ANNIEEventBuilder.
 #
 # These parameters are only needed if FetchFromTimes == 1
 #

--- a/UserTools/BeamFetcherV2/devices.txt
+++ b/UserTools/BeamFetcherV2/devices.txt
@@ -1,0 +1,1 @@
+BoosterNeutrinoBeam_read


### PR DESCRIPTION
For the event building toolchain, we first run the ```BeamFetcherV2``` toolchain to create a root file containing all beam device information for a particular run. The Event building will then read from this root file and pass the individual event beam information along through the store. This way, we also permanently save device information to a persistent location in case that information is temporarily stored in the database and is un-queriable in the future or if we decide to develop some beam quality FOM we wish to retroactively apply. 

Along these lines, as the ```BeamFetcherV2``` toolchain queries and stores the beam device information into the output root file, it was noticed that if a particular entry is blank/missing, the root file will not save any of the entries for a particular device (branch within the root file), as there would then be unequal entries across root branches within the same TTree. To remedy this, we just assign -9999 to blank entries so that the device branch will not miss any additional entries. Probably not the most efficient way to do it but it works fine. No devices have nominal values near -9999 so its easy to reject those entries (some have nominal values around 0 so we can't use that).