### PR TITLE
Reduce cluster window from 50 to 40ns

### DIFF
--- a/configfiles/BeamClusterAnalysis/ClusterFinderConfig
+++ b/configfiles/BeamClusterAnalysis/ClusterFinderConfig
@@ -3,9 +3,9 @@
 verbosity 0
 HitStore Hits #Either MCHits or Hits (accessed in ANNIEEvent store)
 OutputFile BeamRun_ClusterFinder_DefaultOutput #Output root prefix name for the current run
-ClusterFindingWindow 50 # in ns, size of the window used to "clusterize"
+ClusterFindingWindow 40 # in ns, size of the window used to "clusterize"
 AcqTimeWindow 70000 # in ns, size of the acquisition window
-ClusterIntegrationWindow 50 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
+ClusterIntegrationWindow 40 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
 MinHitsPerCluster 5 # group of hits are considered clusters above this amount of hits
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #Draw 2D charge-vs-time plots?

--- a/configfiles/BeamClusterAnalysisMC/ClusterFinderConfig
+++ b/configfiles/BeamClusterAnalysisMC/ClusterFinderConfig
@@ -3,9 +3,9 @@
 verbosity 0
 HitStore MCHits #Either MCHits or Hits (accessed in ANNIEEvent store)
 OutputFile BeamRun_ClusterFinder_DefaultOutput #Output root prefix name for the current run
-ClusterFindingWindow 50 # in ns, size of the window used to "clusterize"
+ClusterFindingWindow 40 # in ns, size of the window used to "clusterize"
 AcqTimeWindow 70000 # in ns, size of the acquisition window
-ClusterIntegrationWindow 50 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
+ClusterIntegrationWindow 40 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
 MinHitsPerCluster 5 # group of hits are considered clusters above this amount of hits
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #Draw 2D charge-vs-time plots?


### PR DESCRIPTION
The nominal cluster window length of 50ns was implemented for two reasons it seems: 

1. To account for small cabling delay/TOF differences that would cause hit times to be offset one another by as much as ~10ns. 
2. To ensure all light (hits) are captured from an interaction.

As the timing offsets of the PMTs have been implemented, which remove around 10ns variation of the hit times due to TOF differences that had yet to be subtracted until the laser calibration, we can now reduce the cluster window from 50 to 40ns. 40ns, according to the MC, is enough time to capture all light (scattering + reflections) from a wide class of events. Both data and MC (```BeamClusterAnalysis```, ```BeamClusterAnalysisMC```) have the same clustering window.