### PR TITLE
Add MC "pulse" width as a configuration variable

### DIFF
--- a/UserTools/ClusterFinder/ClusterFinder.cpp
+++ b/UserTools/ClusterFinder/ClusterFinder.cpp
@@ -27,6 +27,7 @@ bool ClusterFinder::Initialise(std::string configfile, DataModel &data){
   m_variables.Get("Plots2D",draw_2D);
   m_variables.Get("verbosity",verbose);
   m_variables.Get("end_of_window_time_cut",end_of_window_time_cut);
+  m_variables.Get("MC_pulse_width",mc_pulse_width);
 
   //----------------------------------------------------------------------------
   //---------------Get basic geometry properties -------------------------------
@@ -197,6 +198,7 @@ bool ClusterFinder::Execute(){
   }
 
   if(HitStoreName=="MCHits"){
+    if (verbose > 0) std::cout << "ClusterFinder MC pulse_width: " << mc_pulse_width << " [ns]" << endl;
     int vectsize = MCHits->size();
     if (verbose > 3) std::cout <<"ClusterFinder tool: MCHits size: "<<vectsize<<std::endl;
     for(std::pair<unsigned long, std::vector<MCHit>>&& apair : *MCHits){
@@ -237,7 +239,7 @@ bool ClusterFinder::Execute(){
         
 	else {
             bool new_pulse = false;
-        	if (fabs(temp_times[0]-hit1)<10.) {
+        	if (fabs(temp_times[0]-hit1)< mc_pulse_width) {
                 new_pulse=false;
                 temp_charges+=hits_2ns_res_charge.at(i_hit);
 		temp_times.push_back(hit1);

--- a/UserTools/ClusterFinder/ClusterFinder.h
+++ b/UserTools/ClusterFinder/ClusterFinder.h
@@ -67,7 +67,7 @@ class ClusterFinder: public Tool {
   int MinHitsPerCluster;
   bool draw_2D = false;
   double end_of_window_time_cut;
-  double pulse_width;
+  double mc_pulse_width;
 
   // define ANNIEEvent variables
   int evnum;

--- a/UserTools/ClusterFinder/ClusterFinder.h
+++ b/UserTools/ClusterFinder/ClusterFinder.h
@@ -67,6 +67,7 @@ class ClusterFinder: public Tool {
   int MinHitsPerCluster;
   bool draw_2D = false;
   double end_of_window_time_cut;
+  double pulse_width;
 
   // define ANNIEEvent variables
   int evnum;

--- a/UserTools/ClusterFinder/README.md
+++ b/UserTools/ClusterFinder/README.md
@@ -23,6 +23,7 @@ ClusterFindingWindow 50 # in ns, size of the window used to "clusterize"
 AcqTimeWindow 4000 # in ns, size of the acquisition window
 ClusterIntegrationWindow 50 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
 MinHitsPerCluster 10 # group of hits are considered clusters above this amount of hits
+MC_pulse_width 10  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width
 
 verbose 1         #verbosity of the application
 

--- a/configfiles/BeamClusterAnalysis/ClusterFinderConfig
+++ b/configfiles/BeamClusterAnalysis/ClusterFinderConfig
@@ -10,3 +10,4 @@ MinHitsPerCluster 5 # group of hits are considered clusters above this amount of
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #Draw 2D charge-vs-time plots?
 ChankeyToPMTIDMap ./configfiles/EventDisplay/Data-RecoEvent/Chankey_WCSimID.dat
+MC_pulse_width 10  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width

--- a/configfiles/BeamClusterAnalysisMC/ClusterFinderConfig
+++ b/configfiles/BeamClusterAnalysisMC/ClusterFinderConfig
@@ -9,3 +9,4 @@ ClusterIntegrationWindow 40 # in ns, all hits with +/- 1/2 of this window are co
 MinHitsPerCluster 5 # group of hits are considered clusters above this amount of hits
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #Draw 2D charge-vs-time plots?
+MC_pulse_width 10  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width

--- a/configfiles/ClusterFinder/ClusterFinderConfig
+++ b/configfiles/ClusterFinder/ClusterFinderConfig
@@ -8,3 +8,4 @@ ClusterIntegrationWindow 50 # in ns, all hits with +/- 1/2 of this window are co
 MinHitsPerCluster 10 # group of hits are considered clusters above this amount of hits
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #2D charge-vs-time plot to be drawn?
+MC_pulse_width 10  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width


### PR DESCRIPTION
For MC Hits, ClusterFinder will integrate all true photon hits in some window to give you a "digit" or "pulse" of charge = sum of all true photon hits in that window. This was originally set to 10ns to try and be as data-like as possible. This currently gives too many hits per event in the MC as compared to data. Adding it as a config variable in order to more easily tune it without rebuilding ToolAnalysis every time.