### PR TITLE
TriggerDataDecoder and MRDTracks minor bug fix

### DIFF
--- a/UserTools/FindMrdTracks/FindMrdTracks.cpp
+++ b/UserTools/FindMrdTracks/FindMrdTracks.cpp
@@ -104,7 +104,7 @@ bool FindMrdTracks::Execute(){
 		get_ok = m_data->Stores.at("ANNIEEvent")->Get("MRDTriggerType",MRDTriggertype);
 		if (not get_ok){
 			Log("FindMrdTracks: Did not find MRDTriggerType in ANNIEEvent. Please check the settings in MRDDataDecoder+BuildANNIEEvent/LoadWCSim?",v_error,verbosity);
-			m_data->vars.Set("StopLoop",1);
+			Log("FindMrdTracks tool was supposed to stop the loop, but will continue anyway",3,verbosity);
 		}
 	}
 	Log("FindMrdTracks tool: MRDTriggertype is "+MRDTriggertype+" (from ANNIEEvent store)",v_debug,verbosity);

--- a/UserTools/FindMrdTracks/FindMrdTracks.cpp
+++ b/UserTools/FindMrdTracks/FindMrdTracks.cpp
@@ -104,7 +104,7 @@ bool FindMrdTracks::Execute(){
 		get_ok = m_data->Stores.at("ANNIEEvent")->Get("MRDTriggerType",MRDTriggertype);
 		if (not get_ok){
 			Log("FindMrdTracks: Did not find MRDTriggerType in ANNIEEvent. Please check the settings in MRDDataDecoder+BuildANNIEEvent/LoadWCSim?",v_error,verbosity);
-			Log("FindMrdTracks tool was supposed to stop the loop, but will continue anyway",3,verbosity);
+			m_data->vars.Set("StopLoop",1);
 		}
 	}
 	Log("FindMrdTracks tool: MRDTriggertype is "+MRDTriggertype+" (from ANNIEEvent store)",v_debug,verbosity);

--- a/UserTools/TriggerDataDecoder/TriggerDataDecoder.cpp
+++ b/UserTools/TriggerDataDecoder/TriggerDataDecoder.cpp
@@ -60,11 +60,17 @@ bool TriggerDataDecoder::Initialise(std::string configfile, DataModel &data){
 bool TriggerDataDecoder::Execute(){
 
   if (mode == "EventBuilding"){
+
+    processed_sources.clear();
+    processed_ns.clear();
+	  
     m_data->CStore.Set("NewCTCDataAvailable",false);
     bool PauseCTCDecoding = false;
     m_data->CStore.Get("PauseCTCDecoding",PauseCTCDecoding);
     if (PauseCTCDecoding){
+      if(verbosity > 0){
       std::cout << "TriggerDataDecoder tool: Pausing trigger decoding to let Tank and MRD data catch up..." << std::endl;
+      }
       return true;
     }
     //Clear decoding maps if a new run/subrun is encountered
@@ -98,7 +104,7 @@ bool TriggerDataDecoder::Execute(){
     }
     bool new_ts_available = false;
     std::vector<uint32_t> aTimeStampData = Tdata->TimeStampData;
-    std::cout <<"aTimeStampData.size(): "<<aTimeStampData.size()<<std::endl;
+    if(verbosity>0) std::cout <<"aTimeStampData.size(): "<<aTimeStampData.size()<<std::endl;
     for(int i = 0; i < (int) aTimeStampData.size(); i++){
       if(verbosity>v_debug) std::cout<<"TriggerDataDecoder Tool: Loading next TrigData from entry's index " << i <<std::endl;
       new_ts_available = this->AddWord(aTimeStampData.at(i));

--- a/configfiles/EventBuilderRaw/LoadRawDataConfig
+++ b/configfiles/EventBuilderRaw/LoadRawDataConfig
@@ -1,9 +1,8 @@
 verbosity 0
 BuildType TankAndCTC
-#BuildType CTC
 Mode FileList
-InputFile ./configfiles/DataDecoder/my_files.txt
+InputFile ./configfiles/EventBuilderRaw/my_files.txt
 DummyRunInfo 1
 StoreTrigOverlap 0
-ReadTrigOverlap 1
-StoreRawData 0
+ReadTrigOverlap 0
+StoreRawData 1

--- a/configfiles/PreProcessTrigOverlap/CreateMyList.sh
+++ b/configfiles/PreProcessTrigOverlap/CreateMyList.sh
@@ -1,17 +1,19 @@
-if [ "$#" -ne 2 ]; then
-      echo "Usage: ./CreateMyList.sh DIR RUN"
-      echo "Specified input variable must contain the directory where the files are stored, second variable run number"
+if [ "$#" -ne 1 ]; then
+      echo "Usage: ./CreateMyList.sh RUN"
+      echo "Specified input variable must contain the run number"
       exit 1
 fi
 
-FILEDIR=$1
-RUN=$2
+RUN=$1
+DIR=/pnfs/annie/persistent/raw/raw/
 
-NUMFILES=$(ls -1q ${FILEDIR}/RAWDataR${RUN}* | wc -l)
+NUMFILES=$(ls -1q ${DIR}${RUN}/RAWDataR${RUN}* | wc -l)
 
-echo "NUMBER OF FILES IN ${FILEDIR}: ${NUMFILES}"
+echo "NUMBER OF FILES IN ${DIR}${RUN}: ${NUMFILES}"
+
+rm my_files.txt
 
 for p in $(seq 0 $(($NUMFILES -1 )))
 do
-	echo "${FILEDIR}/RAWDataR${RUN}S0p${p}" >> my_files.txt
+	echo "${DIR}${RUN}/RAWDataR${RUN}S0p${p}" >> my_files.txt
 done


### PR DESCRIPTION
Modify the TriggerDataDecoder tool to increase its performance:

- Triggers stored to the buffer are now cleared
- add verbosity thresholds for some std out messages

Change the FindMRDTracks so that if the tool doesn't find MRD data it spits out an error message instead of haulting the entire toolchain