### PR TITLE
Add BeamFetcherV2 toolchain

### DIFF
--- a/configfiles/BeamFetcherV2/BeamFetcherV2Config
+++ b/configfiles/BeamFetcherV2/BeamFetcherV2Config
@@ -1,0 +1,8 @@
+# BeamFetcher config file
+verbose 5
+DevicesFile ./configfiles/BeamFetcherV2/devices.txt # File containing one device per line or a bundle
+IsBundle 1 # bool stating whether DevicesFile contains bundles or individual devices
+FetchFromTimes 0 # bool defining how to grab the data (from input times (1) or trigger(0))
+TimeChunkStepInMilliseconds 3600000 # one hour
+SaveROOT 1 # bool, do you want to write a ROOT file with the timestamps and devices?
+DeleteCTCData 1

--- a/configfiles/BeamFetcherV2/DefaultTriggerMask.txt
+++ b/configfiles/BeamFetcherV2/DefaultTriggerMask.txt
@@ -1,0 +1,3 @@
+#Triggers are given by Jonathan; place one number per line. Values are index + 1
+#4+1: Delayed beam.  32+1: LED trigger. 34+1: AmBe and Cosmic trigger.  35+1: MRD_CR_Trigger. 30+1: LED_Start. 45+1, 46+1: Laser. 14+1: AmBe external trigger
+14

--- a/configfiles/BeamFetcherV2/LoadRawDataConfig
+++ b/configfiles/BeamFetcherV2/LoadRawDataConfig
@@ -1,5 +1,4 @@
 verbosity 11
-#BuildType TankAndMRDAndCTC
 BuildType CTC
 Mode FileList
 InputFile ./configfiles/BeamFetcherV2/my_files.txt

--- a/configfiles/BeamFetcherV2/LoadRawDataConfig
+++ b/configfiles/BeamFetcherV2/LoadRawDataConfig
@@ -1,0 +1,9 @@
+verbosity 11
+#BuildType TankAndMRDAndCTC
+BuildType CTC
+Mode FileList
+InputFile ./configfiles/BeamFetcherV2/my_files.txt
+DummyRunInfo 1
+StoreTrigOverlap 0
+ReadTrigOverlap 0
+StoreRawData 0

--- a/configfiles/BeamFetcherV2/README.md
+++ b/configfiles/BeamFetcherV2/README.md
@@ -1,0 +1,25 @@
+# Configure files
+
+***********************
+#Description
+**********************
+
+Configure files are simple text files for passing variables to the Tools.
+
+Text files are read by the Store class (src/Store) and automatically assigned to an internal map for the relevant Tool to use.
+
+
+************************
+#Usage
+************************
+
+Any line starting with a "#" will be ignored by the Store, as will blank lines.
+
+Variables should be stored one per line as follows:
+
+
+Name Value #Comments 
+
+
+Note: Only one value is permitted per name and they are stored in a string stream and template cast back to the type given.
+

--- a/configfiles/BeamFetcherV2/README.md
+++ b/configfiles/BeamFetcherV2/README.md
@@ -4,22 +4,6 @@
 #Description
 **********************
 
-Configure files are simple text files for passing variables to the Tools.
+See the BeamFetcherV2 tool for description/usage. 
 
-Text files are read by the Store class (src/Store) and automatically assigned to an internal map for the relevant Tool to use.
-
-
-************************
-#Usage
-************************
-
-Any line starting with a "#" will be ignored by the Store, as will blank lines.
-
-Variables should be stored one per line as follows:
-
-
-Name Value #Comments 
-
-
-Note: Only one value is permitted per name and they are stored in a string stream and template cast back to the type given.
-
+Loads CTC triggers from the TriggerDataDecoder tool, then fetches the beam database entries through queries based on the CTC trigger timestamps.

--- a/configfiles/BeamFetcherV2/ToolChainConfig
+++ b/configfiles/BeamFetcherV2/ToolChainConfig
@@ -1,0 +1,26 @@
+#ToolChain dynamic setup file
+
+##### Runtime Parameters #####
+verbose 1 ## Verbosity level of ToolChain
+error_level 0 # 0= do not exit, 1= exit on unhandled errors only, 2= exit on unhandled errors and handled errors
+attempt_recover 1 ## 1= will attempt to finalise if an execute fails
+remote_port 24002
+IO_Threads 1 ## Number of threads for network traffic (~ 1/Gbps)
+
+###### Logging #####
+log_mode Interactive # Interactive=cout , Remote= remote logging system "serservice_name Remote_Logging" , Local = local file log;
+log_local_path ./log
+log_service LogStore
+
+
+###### Service discovery ##### Ignore these settings for local analysis
+service_publish_sec -1
+service_kick_sec -1
+
+##### Tools To Add #####
+Tools_File configfiles/BeamFetcherV2/ToolsConfig  ## list of tools to run and their config files
+
+##### Run Type #####
+Inline -1 ## number of Execute steps in program, -1 infinite loop that is ended by user 
+Interactive 0 ## set to 1 if you want to run the code interactively
+

--- a/configfiles/BeamFetcherV2/ToolsConfig
+++ b/configfiles/BeamFetcherV2/ToolsConfig
@@ -1,0 +1,4 @@
+LoadGeometry LoadGeometry ./configfiles/LoadGeometry/LoadGeometryConfig
+LoadRawData LoadRawData ./configfiles/BeamFetcherV2/LoadRawDataConfig
+TriggerDataDecoder TriggerDataDecoder ./configfiles/BeamFetcherV2/TriggerDataDecoderConfig
+BeamFetcherV2 BeamFetcherV2 ./configfiles/BeamFetcherV2/BeamFetcherV2Config

--- a/configfiles/BeamFetcherV2/TriggerDataDecoderConfig
+++ b/configfiles/BeamFetcherV2/TriggerDataDecoderConfig
@@ -1,0 +1,4 @@
+verbosity 0
+TriggerMaskFile ./configfiles/BeamFetcherV2/DefaultTriggerMask.txt
+StoreTrigOverlap 0
+ReadTrigOverlap 0

--- a/configfiles/BeamFetcherV2/devices.txt
+++ b/configfiles/BeamFetcherV2/devices.txt
@@ -1,0 +1,1 @@
+BoosterNeutrinoBeam_read

--- a/configfiles/BeamFetcherV2/my_files.txt
+++ b/configfiles/BeamFetcherV2/my_files.txt
@@ -1,0 +1,4 @@
+/pnfs/annie/persistent/raw/raw/4774/RAWDataR4774S0p1
+/pnfs/annie/persistent/raw/raw/4774/RAWDataR4774S0p2
+/pnfs/annie/persistent/raw/raw/4774/RAWDataR4774S0p3
+/pnfs/annie/persistent/raw/raw/4774/RAWDataR4774S0p4


### PR DESCRIPTION
Add a toolchain to run the ```BeamFetcherV2``` tool that queries the beam database and can pass along beam device information in the event building process.