### PR TITLE
Fixing GReWeightResonanceDecay Double Application

### DIFF
--- a/UserTools/LoadReweightGenieEvent/LoadReweightGenieEvent.cpp
+++ b/UserTools/LoadReweightGenieEvent/LoadReweightGenieEvent.cpp
@@ -1296,7 +1296,6 @@ void LoadReweightGenieEvent::SetupWeightCalculators(genie::rew::GReWeight& rw, c
 	rw.AdoptWghtCalc( "hadro_intranuke", new GReWeightINuke	       );
 	rw.AdoptWghtCalc( "hadro_agky",	     new GReWeightAGKY         );
 	rw.AdoptWghtCalc( "xsec_nc",     new GReWeightNuXSecNC         );
-	rw.AdoptWghtCalc( "res_dk",      new GReWeightResonanceDecay   );
 	rw.AdoptWghtCalc( "xsec_empmec", new GReWeightXSecEmpiricalMEC );
 	// GReWeightDISNuclMod::CalcWeight() is not implemented, so we won't
 	// bother to use it here. - S. Gardiner, 9 Dec 2019


### PR DESCRIPTION
I'm not an ANNIE collaborator, but I found this issue in MicroBooNE and saw it also exists here after some googling.

@nitish-nayak and I found an issue that causes the GReWeightResonanceDecay calculator to be applied twice, leading to squared weights for the BR1gamma, BR1eta, and Theta_Delta2Npi knobs. This was recently fixed in GENIE, described [here](https://github.com/GENIE-MC/Reweight/pull/34).