### PR TITLE
Adding torch Python package to container

### DIFF
--- a/GetToolDAQ.sh
+++ b/GetToolDAQ.sh
@@ -497,6 +497,7 @@ then
     pip3 install uproot==4.3.7
     pip3 install xgboost==1.6.2
     pip3 install tensorflow==2.10.0
+    pip3 install torch==1.12.1
     pip3 install PyQt5
     # set tensorflow verbosity to suppress info messages about not having a GPU or maximal acceleration
     # https://stackoverflow.com/questions/35911252/disable-tensorflow-debugging-information/42121886#42121886


### PR DESCRIPTION
"torch" is needed for MuonFitter in order to perform the fitting of the tracks. I tested in a virtual environment on my linux subsystem, and it installs and works fine with the other python packages. This will require the updated container to be pushed to the gpvms.