### PR TITLE
Bugfix for LoadRawData tool

### DIFF
--- a/UserTools/LoadRawData/LoadRawData.cpp
+++ b/UserTools/LoadRawData/LoadRawData.cpp
@@ -163,7 +163,7 @@ bool LoadRawData::Execute(){
   }
 
   //If more MRD events than VME events abort
-  if (mrdtotalentries > tanktotalentries && BuildType != "MRD"){
+  if (mrdtotalentries > tanktotalentries && BuildType != "MRD" && BuildType != "MRDAndCTC"){
     std::cout << "LoadRawData tool ERROR: More MRD entries than VME entries! Stopping toolchain" << std::endl;
     m_data->vars.Set("StopLoop",1);
   }


### PR DESCRIPTION
If the number of MRD entries exceeds the number of tank entries when loading in the raw data, the tool (and resulting toolchain) stops. Not sure why the condition exists, but when we are trying to build events without the Tank (MRD efficiency analysis for example) we don't expect any Tank entries so this condition shouldn't apply.  

There is an exception for building MRD-only events (BuildType = MRD) however this should be expanded to also include BuildType = MRDAndCTC if we are interested in the MRD + CTC event pairing. 