### PR TITLE
Add bunchTimes to PhaseIITreeMaker

### DIFF
--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -13,10 +13,12 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
   /////////////////////////////////////////////////////////////////
   
   hasGenie = false;
+  hasBNBtimingMC = false;
 
   m_variables.Get("verbose", verbosity);
   m_variables.Get("IsData",isData);
   m_variables.Get("HasGenie",hasGenie);
+  m_variables.Get("HasBNBtimingMC",hasBNBtimingMC);
   m_variables.Get("TankHitInfo_fill", TankHitInfo_fill);
   m_variables.Get("MRDHitInfo_fill", MRDHitInfo_fill);
   m_variables.Get("fillCleanEventsOnly", fillCleanEventsOnly);
@@ -106,7 +108,10 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
       fPhaseIITankClusterTree->Branch("SiPM1NPulses",&fSiPM1NPulses,"SiPM1NPulses/I");
       fPhaseIITankClusterTree->Branch("SiPM2NPulses",&fSiPM2NPulses,"SiPM2NPulses/I");
     }
-
+    // MC BNB spill structure timing - AssignBunchTimingMC tool
+    if(hasBNBtimingMC){
+      fPhaseIITankClusterTree->Branch("bunchTimes",&fbunchTimes,"bunchTimes/D");
+    }
   } 
 
   if(MRDClusterProcessing){
@@ -638,6 +643,10 @@ bool PhaseIITreeMaker::Execute(){
         if(!good_class){
           if(verbosity>3) Log("PhaseIITreeMaker Tool: No cluster classifiers.  Continuing tree",v_debug,verbosity);
         }
+        bool good_bunch = this->LoadBNBtimingMC(it_cluster_pair_mc->first);
+        if(!good_bunch){
+          if(verbosity>v_debug) Log("PhaseIITreeMaker Tool: BNB timing (MC). Continuing tree",v_debug,verbosity);
+        }
       }
 
       if(SiPMPulseInfo_fill) this->LoadSiPMHits();
@@ -952,6 +961,10 @@ void PhaseIITreeMaker::ResetVariables() {
     fSiPMNum.clear();
   }
 
+  if(hasBNBtimingMC){
+      fbunchTimes = -9999;
+  }
+
   if(TankClusterProcessing){
     fClusterMaxPE = -9999;
     fClusterChargePointX = -9999;
@@ -1223,6 +1236,18 @@ bool PhaseIITreeMaker::LoadTankClusterClassifiers(double cluster_time){
     fClusterChargeBalance = ClusterChargeBalances.at(cluster_time);
   }
   return good_classifiers;
+}
+
+bool PhaseIITreeMaker::LoadBNBtimingMC(double cluster_time){
+  Log("PhaseITreeMaker tool: Getting BNB timing (MC)", v_debug, verbosity);
+  bool got_bnb_times = m_data->Stores.at("ANNIEEvent")->Get("bunchTimes", bunchTimes);
+  if(!got_bnb_times){
+    Log("PhaseITreeMaker tool: BNB timing (MC) not found!", v_debug, verbosity);
+  } else { 
+    Log("PhaseITreeMaker tool: Setting fbunchTimes variables", v_debug, verbosity);
+    fbunchTimes = bunchTimes.at(cluster_time);
+  }
+  return got_bnb_times;
 }
 
 void PhaseIITreeMaker::LoadTankClusterHits(std::vector<Hit> cluster_hits){

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
@@ -76,6 +76,7 @@ class PhaseIITreeMaker: public Tool {
   void LoadTankClusterHits(std::vector<Hit> cluster_hits);
   void LoadTankClusterHitsMC(std::vector<MCHit> cluster_hits,std::vector<unsigned long> cluster_detkeys);
   bool LoadTankClusterClassifiers(double cluster_time);
+  bool LoadBNBtimingMC(double cluster_time);
   void LoadAllTankHits(bool IsData);
   void LoadSiPMHits();
   
@@ -85,6 +86,7 @@ class PhaseIITreeMaker: public Tool {
   //General variables
   bool isData;
   bool hasGenie;
+  bool hasBNBtimingMC;
 
   std::map<int,std::string>* AuxChannelNumToTypeMap;
   std::map<int,double> ChannelKeyToSPEMap;
@@ -205,6 +207,10 @@ class PhaseIITreeMaker: public Tool {
   double fClusterChargeBalance;
   std::vector<int> fADCWaveformChankeys; 
   std::vector<int> fADCWaveformSamples;  
+
+  // ************** MC BNB Spill Structure ************* //
+  std::map<double,double> bunchTimes;
+  double fbunchTimes;
 
   // ************ Muon reconstruction level information ******** //
   std::string MRDTriggertype;

--- a/UserTools/PhaseIITreeMaker/README.md
+++ b/UserTools/PhaseIITreeMaker/README.md
@@ -18,34 +18,43 @@ verbose (1 or 0)
 Defines the level of verbosity for outputs of PhaseIITreeMaker algorithm.
 
 OutputFile TestFile.ntuple.root
-ClusterProcessing 1
-Process cluster-level trees.  Each ntuple entry contains all the PMT hits observed
+Output filename
+
+TankClusterProcessing 1
+Process PMT cluster-level trees.  Each ntuple entry contains all the PMT hits observed
 in a cluster (as defined in the ClusterFinder tool) as well as cluster classifiers
 (as defined in the ClusterClassifiers tool), along with other general information 
-(run/subrun number, nhits, SiPM hits, trigger time).  
+(run/subrun number, nhits, SiPM hits, trigger time).
+
+MRDClusterProcessing 1
+Process MRD cluster-level trees.  Each ntuple entry contains all the MRD hits observed
+in a cluster (as defined in the TimeClustering tool), along with other general information 
+(run/subrun number, nhits, trigger time). 
 
 TriggerProcessing 1
 Process trigger-level trees.  Each ntuple entry contains all PMT hits observed
 for a given trigger, along with other general information (run/subrun number,
-nhits,trigger time).
+nhits,trigger time,beam parameters).
 
+TankHitInfo_fill 1
+Fill in PMT hit information for all hits (Time,Charge,PE,Position).
 
-HitInfo_fill 1
-Fill in hit information for all hits (Time,Charge,PE,Position).
-
+MRDHitInfo_fill 1
+Fill in MRD hit information for all hits (Time,Channel ID).
 
 SiPMPulseInfo_fill 1
 Fill in SiPM pulse information (charge/time/SiPM number).
+
+MRDReco_fill 0
+Fill in track reconstruction parameters defined by the FindMRDTracks tool.
 
 fillCleanEventsOnly (1 or 0)
 Only fill tree with events that pass the event selection defined in the
 EventSelector tool.
 
-
 Reco_fill 0
 Fill in final reconstruction parameters estimated using the Tank
 Reconstruction algorithms.
-
 
 MCTruth_fill (1 or 0)
 Input will determine if Truth information from files given is saved to the
@@ -68,5 +77,16 @@ Input determines if reconstruction variables at each step in the muon event
 reconstruction chain are saved to the tree.  Values include seeds from SeedVtxFinder,
 fits from PointPosFinder, and FOMs for likelihood fits at each reconstruction step.
 Will output to tree if 1.
+
+IsData (1 or 0)
+Whether the data we are processing is real (Hits) or MC (MCHits).
+
+HasGenie (1 or 0)
+Input determines whether GENIE-level information is loaded by the LoadGENIEEvent tool.
+
+HasBNBtimingMC (1 or 0)
+Input determines whether cluster times (MC) are spill-corrected to produce a BNB-realistic timing structure.
+Must have HasGenie 1 and TankClusterProcessing 1 enabled.
+(as defined in the AssignBunchTimingMC tool).  
 
 ```


### PR DESCRIPTION
Add bunchTimes from the AssignBunchTimingMC tool (PR #304) to the PhaseIITreeMaker.

Also add more info to the PhaseIITreeMaker README file to reflect current configurations and use of the tool.