### PR TITLE
Increase file descriptor limit

### DIFF
--- a/Setup.sh
+++ b/Setup.sh
@@ -4,6 +4,8 @@
 
 ToolDAQapp=`pwd`
 
+ulimit -n 4096
+
 export LIBGL_ALWAYS_INDIRECT=1
 
 source ${ToolDAQapp}/ToolDAQ/root-6.24.06/install/bin/thisroot.sh


### PR DESCRIPTION
When running the `LoadANNIEEvent` tool, which loads ANNIEEvents from the processed part files, it's been noticed that the tool fails to execute when including > ~1020 part files due to Linux's file descriptor limit. The tool runs smoothly until it reaches this limit, where it encounters an error like this:

```
[1]: LoadANNIEEvent: Loading new file /pnfs/annie/persistent/processed/processed_EBV2//R4783/ProcessedData_PMTMRDLAPPD_R4783S0p1017
[1]: LoadANNIEEvent: Loading new file /pnfs/annie/persistent/processed/processed_EBV2//R4783/ProcessedData_PMTMRDLAPPD_R4783S0p1018
[1]: Error Bad Filename: Cannot open /pnfs/annie/persistent/processed/processed_EBV2//R4783/ProcessedData_PMTMRDLAPPD_R4783S0p1019
[1]: LoadANNIEEvent: Loading new file /pnfs/annie/persistent/processed/processed_EBV2//R4783/ProcessedData_PMTMRDLAPPD_R4783S0p1019
[0]: LoadANNIEEvent: Filename /pnfs/annie/persistent/processed/processed_EBV2//R4783/ProcessedData_PMTMRDLAPPD_R4783S0p1019 not found! Proceed to next file

--> Warning errors in this tool and any other downstream tools, failure to load ANNIEEvents to the store
```

As this tool is frequently ran over all part files within a run, and we routinely have more than 1024 part files per run, I have included an increase in the file descriptor (4096) to `Setup.sh`. I have tested it and it alleviates the problem. 