### PR TITLE
Update ClusterFinderConfig - expand MC pulse width

### DIFF
--- a/configfiles/BeamClusterAnalysisMC/ClusterFinderConfig
+++ b/configfiles/BeamClusterAnalysisMC/ClusterFinderConfig
@@ -9,4 +9,4 @@ ClusterIntegrationWindow 40 # in ns, all hits with +/- 1/2 of this window are co
 MinHitsPerCluster 5 # group of hits are considered clusters above this amount of hits
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #Draw 2D charge-vs-time plots?
-MC_pulse_width 10  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width
+MC_pulse_width 35  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width

--- a/configfiles/CC_MC_RECO_ntuple/ClusterFinderConfig
+++ b/configfiles/CC_MC_RECO_ntuple/ClusterFinderConfig
@@ -1,11 +1,12 @@
 # ClusterFinder Config File
 
+verbosity 0
 HitStore MCHits #Either MCHits or Hits (accessed in ANNIEEvent store)
 OutputFile mc_clusters.root
-ClusterFindingWindow 50 # in ns, size of the window used to "clusterize"
+ClusterFindingWindow 40 # in ns, size of the window used to "clusterize"
 AcqTimeWindow 70000 # in ns, size of the acquisition window
-ClusterIntegrationWindow 50 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
+ClusterIntegrationWindow 40 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
 MinHitsPerCluster 5 # group of hits are considered clusters above this amount of hits
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #Draw 2D charge-vs-time plots?
-verbosity 0
+MC_pulse_width 35  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width

--- a/configfiles/ClusterFinder/ClusterFinderConfig
+++ b/configfiles/ClusterFinder/ClusterFinderConfig
@@ -3,10 +3,10 @@
 verbosity 0
 HitStore Hits #Either MCHits or Hits (accessed in ANNIEEvent store)
 OutputFile Run1415S0_AllPMTs_ClusterFinder #Output root prefix name for the current run
-ClusterFindingWindow 50 # in ns, size of the window used to "clusterize"
-AcqTimeWindow 4000 # in ns, size of the acquisition window
-ClusterIntegrationWindow 50 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
-MinHitsPerCluster 10 # group of hits are considered clusters above this amount of hits
+ClusterFindingWindow 40 # in ns, size of the window used to "clusterize"
+AcqTimeWindow 70000 # in ns, size of the acquisition window
+ClusterIntegrationWindow 40 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
+MinHitsPerCluster 5 # group of hits are considered clusters above this amount of hits
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #2D charge-vs-time plot to be drawn?
 MC_pulse_width 35  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width

--- a/configfiles/ClusterFinder/ClusterFinderConfig
+++ b/configfiles/ClusterFinder/ClusterFinderConfig
@@ -1,5 +1,6 @@
 # ClusterFinder Config File
 
+verbosity 0
 HitStore Hits #Either MCHits or Hits (accessed in ANNIEEvent store)
 OutputFile Run1415S0_AllPMTs_ClusterFinder #Output root prefix name for the current run
 ClusterFindingWindow 50 # in ns, size of the window used to "clusterize"
@@ -8,4 +9,4 @@ ClusterIntegrationWindow 50 # in ns, all hits with +/- 1/2 of this window are co
 MinHitsPerCluster 10 # group of hits are considered clusters above this amount of hits
 end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
 Plots2D 0 #2D charge-vs-time plot to be drawn?
-MC_pulse_width 10  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width
+MC_pulse_width 35  # width of MC "pulse" in which to integrate true photon hits - all true photon hits on a single PMT will be combined into a "pulse" of this width


### PR DESCRIPTION
## Describe your changes

Extend MC pulse width to align data and MC. Photons hit within this larger window will be considered a "hit". 10ns is too narrow and leads to WAY too many PMT "hits" for high energy events. 35ns seems to align the number of PMT hits between data and MC. 

As there are still a few things that need to be optimized for the tuning campaign, this may change in the future. Hit digitization seems like it will be changed in way of a Waveform simulator that Andrew is planning on rolling in. Therefore the pulse width may have to be changed in the future. This is a "best fit" to what we currently have. 

I included the PR as James is beginning his production run for the WCSim / ToolAnalysis analysis root files.

## Checklist before submitting your PR
- [ x] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [ x] This PR alters the minimum number of files to affect this change
- [ N/A ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ N/A ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ N/A ] For every `new` usage, there is a reason the data must be on the heap
- [ N/A ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Slide 9 from this presentation highlights the change: https://annie-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=5488&filename=WCSim%20Tuning%20Status%20_%20June%203%202024%20_%20Steven%20Doran%20_%20ANNIE%20summer%20workshop%202024.pdf&version=2 

Again there's more things to re-tune i just wanted to get this on board as James is about to produce some collaboration-wide files.
