### PR TITLE
Script to compile only the tools you need

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ DataModel/DataModel_Linkdef.hh
 # These are imported as part of ToolPack
 UserTools/ImportedTools
 UserTools/InactiveTools
+build_*/
 

--- a/script/ToolAnalysisMyTools.sh
+++ b/script/ToolAnalysisMyTools.sh
@@ -140,7 +140,7 @@ if [ $# -eq 0 ]; then
     echo "#  Usage: '$0 [configfileName]' or"
     echo "#         '$0 \"configfileName1,configfileName2,...\"' or"
     echo "#         '$0 [configfileName] clean'         or "
-    echo "#         '$0 \"configfileName1,configfileName2\" clean'   
+    echo "#         '$0 \"configfileName1,configfileName2\" clean'   "
     echo "###################################################################################################"
     exit 1
 fi

--- a/script/ToolAnalysisMyTools.sh
+++ b/script/ToolAnalysisMyTools.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Dummy test by M. Ascencio, Dec-2024
+# mascenci@fnal.gov
+
+setBuild(){
+
+        # Copy the main tools, scripts, etc
+        #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        echo -e "\t ####################################################"
+        echo -e "\t ############# Preparing $1 "
+        echo -e "\t ####################################################"
+        echo -e "\t ####### Making the $1 dir"
+        cd ../ # Because I am script dir now
+
+        if [ -d build_$1 ]; then
+           echo -e "\t Ha! Directory 'build_$1' exists. Removing it..."
+           rm -rf build_$1
+           echo -e "\t Directory 'build_$1' removed."
+        fi
+
+        mkdir -p build_$1/UserTools
+        mkdir -p build_$1/configfiles
+
+        echo -e "\t ####### Copying Makefile, DataModel, lib, src, include, linkdef* and Setup.sh to $1"
+        cp Setup.sh build_$1/
+        cp Makefile build_$1/
+        cp -r DataModel build_$1/
+        cp -r lib build_$1/
+        cp -r src build_$1/
+        cp -r include build_$1/
+        cp linkdef* build_$1/
+
+        darray=("recoANNIE" "PlotWaveforms" "Factory" "Examples")
+        echo -e "\t ####### Copying the default Tools"
+        for element in "${darray[@]}"; do
+                echo -e "\t\t @@@@@@@@ Copying $element"
+                cp -r UserTools/$element build_$1/UserTools
+        done
+
+        echo -e "\t ####### Copying configfile/$1"
+        cp -r configfiles/$1 build_$1/configfiles
+        cp -r configfiles/LoadGeometry build_$1/configfiles
+        toolschain="configfiles/$1/ToolsConfig"
+        echo -e "\t ####### Extracting the tools used in $toolschain"
+        array=($(grep -v '^#' $toolschain | awk '{print $2}'))
+        echo -e " "
+        echo -e "\t ####################################################"
+        echo -e "\t \t Extracted tools : "
+        for element in "${array[@]}"; do
+                echo -e "\t \t \t \t tool ---->  " $element
+        done
+        echo -e "\t ####################################################"
+
+        echo -e "\t ####### Copying the extracted Tools"
+        for element in "${array[@]}"; do
+                cp -r UserTools/$element build_$1/UserTools
+        done
+
+        cd build_$1
+
+        echo -e "\t ####### Making the symbolic links"
+        ln -s configfiles/$1/ToolChainConfig $1
+        ln -s /ToolAnalysis/ToolDAQ ToolDAQ
+
+        # Making the Unity.h
+        #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        echo -e "\t ####### Making Unity.h"
+        uarray=("Unity_recoANNIE" "PlotWaveforms" "Factory")
+        farray=("PlotWaveforms")
+
+        # Spe. tools
+        #echo -e "\t #include DummyTool.h"
+        echo "#include \"DummyTool.h\"" >> UserTools/Unity.h
+
+        for element in "${uarray[@]}"; do
+                #echo -e "\t #include $element.h"
+                echo "#include \"$element.h\"" >> UserTools/Unity.h
+        done
+
+        # My tools
+        for element in "${array[@]}"; do
+                #echo -e "\t #include $element.h"
+                echo "#include \"$element.h\"" >> UserTools/Unity.h
+        done
+
+        # making Factory.cpp
+        #%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        rm UserTools/Factory/Factory.cpp
+        echo -e "\t ####### Making Factory/Factory.cpp"
+        echo "#include \"Factory.h\"" >> UserTools/Factory/Factory.cpp
+        echo "Tool* Factory(std::string tool)  {" >> UserTools/Factory/Factory.cpp
+        echo "    Tool* ret = 0;" >> UserTools/Factory/Factory.cpp
+        echo "    if (tool==\"DummyTool\") ret=new DummyTool;" >> UserTools/Factory/Factory.cpp
+
+        # Loop through the array and add the conditional checks
+        for element in "${farray[@]}"; do
+            echo "    if (tool==\"$element\") ret=new $element;" >> UserTools/Factory/Factory.cpp
+        done
+
+        # Loop through the array and add the conditional checks
+        for element in "${array[@]}"; do
+            echo "    if (tool==\"$element\") ret=new $element;" >> UserTools/Factory/Factory.cpp
+        done
+        echo "return ret;" >> UserTools/Factory/Factory.cpp
+        echo "}" >> UserTools/Factory/Factory.cpp
+
+        echo -e "\t DONE!"
+        echo -e "\t Now go to ../build_$1, execute the container and compile it. Use cd ../build_$1; source Setup.sh; make clean; make"
+}
+# Check the arguments
+if [ $# -eq 0 ]; then
+    echo "###################################################################################################"
+    echo "#  No arguments provided. Please provide at least one argument.                                    "
+    echo "#  Usage: '$0 [Toolchain_name]' or '$0 [Toolchain_name] clean'                                     "
+    echo "###################################################################################################"
+    exit 1
+fi
+
+TOOLCHAIN_NAME=$1
+CONFIG_DIR="../configfiles/${TOOLCHAIN_NAME}"
+
+if [ $# -eq 1 ]; then
+    if [ ! -d "$CONFIG_DIR" ]; then
+        echo "ERROR: Toolchain '$TOOLCHAIN_NAME' does not exist in you 'configfiles/'."
+        exit 1
+    fi
+    setBuild $TOOLCHAIN_NAME
+elif [ $# -eq 2 ] && [ "$2" == "clean" ]; then
+    rm -rf ../build_$TOOLCHAIN_NAME
+else
+    echo "Invalid argument. Usage: '$0 [Toolchain_name]' or '$0 [Toolchain_name] clean'"
+    exit 1
+fi

--- a/script/ToolAnalysisMyTools.sh
+++ b/script/ToolAnalysisMyTools.sh
@@ -2,6 +2,25 @@
 # Dummy test by M. Ascencio, Dec-2024
 # mascenci@fnal.gov
 
+##########################################################################
+# chmod +x ToolAnalysisMyTools.sh
+# Description: The script creates a build_{configfileName} directory in ./ToolAnalysis. It copies
+# the necessary default files and directories to build_{configfileName} in addition to the toolchains
+# used in your configfileName. You will need to `source Setup.sh` in the build_{configfileName} directory
+# and compile with `make clean` and `make`. WARNING, do not use `make -jN` where N is the number of cores.
+# For some reason `make -jN` will compile fine but the Total events for example will be random. 
+#
+# USE:
+# ./ToolAnalysisMyTools.sh configfileName
+#
+# If its more than one configfileName you need to use a "," without space as follows:
+# ./ToolAnalysisMyTools.sh "configfileName1,configfileName2,..." 
+#
+# You can clean the built directory with:
+# ./ToolAnalysisMyTools.sh configfileName clean
+# ./ToolAnalysisMyTools.sh "configfileName1,configfileName2,..." clean
+##########################################################################
+
 setBuild(){
 
         # Copy the main tools, scripts, etc
@@ -118,9 +137,10 @@ setBuild(){
 if [ $# -eq 0 ]; then
     echo "###################################################################################################"
     echo "#  No arguments provided. Please provide at least one argument.                                    "
-    echo "#  Usage: '$0 [Toolchain_name]' or"
-    echo "#         '$0 \"Tool1,Tool2,...\"' or"
-    echo "#         '$0 [Toolchain_name] clean'                             "
+    echo "#  Usage: '$0 [configfileName]' or"
+    echo "#         '$0 \"configfileName1,configfileName2,...\"' or"
+    echo "#         '$0 [configfileName] clean'         or "
+    echo "#         '$0 \"configfileName1,configfileName2\" clean'   
     echo "###################################################################################################"
     exit 1
 fi
@@ -140,6 +160,6 @@ if [ $# -eq 1 ]; then
 elif [ $# -eq 2 ] && [ "$2" == "clean" ]; then
     rm -rf ../$DIR_NAME
 else
-    echo "Invalid argument. Usage: '$0 [Toolchain_name]' or '$0 \"Tool1,Tool2,...\" or '$0 [Toolchain_name] clean'"
+    echo "Invalid argument. Usage: '$0 [configfileName]' or '$0 \"configfileName1,configfileName2,...\" or '$0 [configfileName] clean'"
     exit 1
 fi


### PR DESCRIPTION
## Describe your changes
I am adding a bash script in `script/` dir to compile in a `ToolAnalysis/build_[name_here]` directory only the needed tools. This speeds up the compilation time from 40 mins to ~3 minutes depending the tool. Additionally, the .gitignore was modify so the `build_*` dir doesn't interfere later.  

The script after `chmod +x ToolAnalysisMyTools.sh` in `scrip` can be run it  as `scrip/./ToolAnalysisMyTools.sh ConfigfileName` or `scrip./ToolAnalysisMyTools.sh "ConfigfileName1,ConfigfileName2,..."` or `scrip./ToolAnalysisMyTools.sh ConfigfileName clean`. Allowing single Tool, or multiple tools.

## Checklist before submitting your PR
- [x] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [ ] This PR alters the minimum number of files to affect this change
- [ ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ ] For every `new` usage, there is a reason the data must be on the heap
- [ ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Attach any validation or demonstration files here. You may also link to relavant docdb articles.
