### PR TITLE
Add FitRWMWaveform to Unity + Factory

### DIFF
--- a/UserTools/Factory/Factory.cpp
+++ b/UserTools/Factory/Factory.cpp
@@ -173,5 +173,6 @@ if (tool=="BeamQuality") ret=new BeamQuality;
 if (tool=="BackTracker") ret=new BackTracker;
 if (tool=="PrintDQ") ret=new PrintDQ;
 if (tool=="AssignBunchTimingMC") ret=new AssignBunchTimingMC;
+if (tool=="FitRWMWaveform") ret=new FitRWMWaveform;
 return ret;
 }

--- a/UserTools/Unity.h
+++ b/UserTools/Unity.h
@@ -181,3 +181,4 @@
 #include "BackTracker.h"
 #include "PrintDQ.h"
 #include "AssignBunchTimingMC.h"
+#include "FitRWMWaveform.h"


### PR DESCRIPTION
## Describe your changes

In [PR #289](https://github.com/ANNIEsoft/ToolAnalysis/pull/289/files) I forgot to add the tool to Factory + Unity. We noticed in the `PrintDQ` tool that we were getting 0% of events with a BRF fit - i suspect its because the `FitRWMWaveform` tool was never compiled / built.

## Checklist before submitting your PR
- [x] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [N/A] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
- Original PR with the tool: https://github.com/ANNIEsoft/ToolAnalysis/pull/289
- `PrintDQ` toolchain where we noticed there was a 0% fit rate: https://github.com/ANNIEsoft/ToolAnalysis/tree/Application/configfiles/PrintDQ
