### PR TITLE
Add csv file output to PrintDQ

### DIFF
--- a/UserTools/PrintDQ/PrintDQ.cpp
+++ b/UserTools/PrintDQ/PrintDQ.cpp
@@ -146,6 +146,36 @@ bool PrintDQ::Finalise()
     std::cout << "" << std::endl;
     std::cout << "" << std::endl;
 
+    // write metrics to .csv file
+    std::ofstream csv_file("R" + std::to_string(fRunNumber) + "_PrintDQ.csv");
+
+    if (!csv_file.is_open()) {
+        Log("PrintDQ Error: Unable to open CSV file for writing", v_error, verbosity);
+        return false;
+    }
+
+    csv_file << "Metric,Counts,Rate (%),Rate Error (+/- %)\n";
+    WritetoCSV(csv_file, "Total Events", totalevents, 0.0, 0.0);  // no corresponding rate for total events
+    WritetoCSV(csv_file, "Has LAPPD Data", totalhas_lappd, has_lappd, er_has_lappd);
+    WritetoCSV(csv_file, "Has BRF Fit", totalhas_BRF, has_BRF, er_has_BRF);
+    WritetoCSV(csv_file, "EventTimeTank = 0", totaltimezero, timezero, er_timezero);
+    WritetoCSV(csv_file, "Beam OK", totalokay_beam, okay_beam, er_okay_beam);
+    WritetoCSV(csv_file, "Total Clusters (rate given as clusters / event)", totalclusters, events_per_cluster, er_events_per_cluster);
+    WritetoCSV(csv_file, "Prompt Clusters", totalclusters_in_prompt, clusters_in_prompt, er_clusters_in_prompt);
+    WritetoCSV(csv_file, "Spill Clusters", totalclusters_in_spill, clusters_in_spill, er_clusters_in_spill);
+    WritetoCSV(csv_file, "Ext Clusters", totalclusters_in_ext, clusters_in_ext, er_clusters_in_ext);
+    WritetoCSV(csv_file, "Extended (CC)", totalext_rate_1, ext_rate_1, er_ext_rate_1);
+    WritetoCSV(csv_file, "Extended (NC)", totalext_rate_2, ext_rate_2, er_ext_rate_2);
+    WritetoCSV(csv_file, "Tank+MRD Coinc", totaltmrd_coinc, tmrd_coinc, er_tmrd_coinc);
+    WritetoCSV(csv_file, "1 MRD Track", totalhas_track, has_track, er_has_track);
+    WritetoCSV(csv_file, "Tank+Veto Coinc", totalveto_hit, veto_hit, er_veto_hit);
+    WritetoCSV(csv_file, "Tank+MRD+Veto Coinc", totalveto_tmrd_coinc, veto_tmrd_coinc, er_veto_tmrd_coinc);
+
+    csv_file.close();
+
+    std::cout << "Run metrics written to " << "R" + std::to_string(fRunNumber) + "_PrintDQ.csv" << std::endl;
+    std::cout << "" << std::endl;
+
     return true;
 }
 
@@ -438,6 +468,13 @@ bool PrintDQ::GrabVariables() {
     }
     
     return true;
+}
+
+
+//------------------------------------------------------------------------------
+
+void PrintDQ::WritetoCSV(std::ofstream& file, const std::string& metric, int count, float percentage, float error) {
+    file << metric << "," << count << "," << percentage << "," << error << "\n";
 }
 
 

--- a/UserTools/PrintDQ/PrintDQ.h
+++ b/UserTools/PrintDQ/PrintDQ.h
@@ -31,6 +31,8 @@ class PrintDQ: public Tool {
         bool GrabVariables();                                                  ///< Assign values to tricky variables (clusterTime, Grouped Triggers, MRD Tracks)
         void FindCounts();                                                     ///< Loop over extracted event information and count them up
         float CalculateStatError(float numerator, float denominator);          ///< Statistical error calculation for the rates
+        void WritetoCSV(std::ofstream& file, const std::string& metric,
+                                 int count, float percentage, float error);    ///< Write each row of metrics to a .csv file
 
     private:
 

--- a/UserTools/PrintDQ/README.md
+++ b/UserTools/PrintDQ/README.md
@@ -13,7 +13,7 @@
 
 ## Data
 
-`PrintDQ` currently just prints out the run statistics and does not add anything to the Store. Here's an example of the print output from the tool:
+`PrintDQ` prints out the run statistics and does not add anything to the Store. It also populates a .csv file with the same statistics (`R<run>_PrintDQ.csv`). Here's an example of the print output from the tool:
 ```
 **************************************
 Run 4314

--- a/configfiles/PrintDQ/README.md
+++ b/configfiles/PrintDQ/README.md
@@ -12,7 +12,7 @@ The `PrintDQ` toolchain runs the clustering tools (MRD + PMT) over the Processed
 
 - Populate the `my_inputs.txt` file with all part files from a Processed runs. Running the script `sh create_my_inputs.sh <run_number>` will automatically populate the input file with all Processed Data part files for that run.
 - Run the toolchain via: `./Analyse ./configfiles/PrintDQ/ToolChain`
-- Run statistics will be outputted via `std::out` once the toolchain completes.
+- Run statistics will be outputted via `std::out` once the toolchain completes, in addition to a .csv file containing the metrics.
 
 
 ************************
@@ -20,3 +20,4 @@ The `PrintDQ` toolchain runs the clustering tools (MRD + PMT) over the Processed
 ************************
 
 - The current version of the `PrintDQ` tool is intended to be run over 1 run at a time. As the clustering tools may take some time to compile, the processing time of this toolchain may take several minutes (for a ~100 part file run) to ~1 hour (~thousands of part files) depending on how many part files exist.
+- Find [here](https://github.com/S81D/PrintDQ/tree/main) a set of scripts to run this toolchain on the grid and produce data quality plots from the outputted .csv files.


### PR DESCRIPTION
## Describe your changes

In an effort to streamline the workflow for analyzing metrics across multiple runs, the tool now outputs the statistics to a .csv file. These can be stored somewhere on the gpvms so others can access the run data and create DQ plots.

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [N/A] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [X] For every `new` usage, there is a reason the data must be on the heap
- [X] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
See README for the tool.
