### PR TITLE
Changes to TreeMaker logic to handle new MC waveforms

### DIFF
--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -721,7 +721,7 @@ bool PhaseIITreeMaker::Execute(){
         }
         bool good_bunch = this->LoadBNBtimingMC(it_cluster_pair_mc->first);
         if(!good_bunch){
-          if(verbosity>v_debug) Log("PhaseIITreeMaker Tool: BNB timing (MC). Continuing tree",v_debug,verbosity);
+          if(verbosity>v_debug) Log("PhaseIITreeMaker Tool: No BNB timing (MC). Continuing tree",v_debug,verbosity);
         }
         }
       }

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -14,9 +14,11 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
   
   hasGenie = false;
   hasBNBtimingMC = false;
+  MCWaveform = false;
 
   m_variables.Get("verbose", verbosity);
   m_variables.Get("IsData",isData);
+  m_variables.Get("PMTWaveformSim",MCWaveform);
   m_variables.Get("HasGenie",hasGenie);
   m_variables.Get("HasBNBtimingMC",hasBNBtimingMC);
   m_variables.Get("TankHitInfo_fill", TankHitInfo_fill);
@@ -545,11 +547,19 @@ bool PhaseIITreeMaker::Execute(){
         return false;
       }
     } else {
+      if (MCWaveform){
+        get_clusters = m_data->CStore.Get("ClusterMap",m_all_clusters);
+        if(!get_clusters){
+          std::cout << "PhaseIITreeMaker tool: MCWaveform --> no clusters found!" << std::endl;
+          return false;
+        }
+      } else {
       get_clusters = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
       if (!get_clusters){
         std::cout <<"PhaseIITreeMaker tool: No clusters found (MC)!" << std::endl;
         return false;
       }
+    }
     }
     get_clusters = m_data->CStore.Get("ClusterMapDetkey",m_all_clusters_detkeys);
     if (!get_clusters){
@@ -560,14 +570,29 @@ bool PhaseIITreeMaker::Execute(){
 
     int cluster_num = 0;
     int cluster_size = 0;
-    if (isData) cluster_size = (int) m_all_clusters->size();
-    else cluster_size = (int) m_all_clusters_MC->size();
+    if (isData) {
+        cluster_size = (int) m_all_clusters->size();
+    } else {
+        if (MCWaveform) {
+            cluster_size = (int) m_all_clusters->size();
+        } else {
+            cluster_size = (int) m_all_clusters_MC->size();
+        }
+    }
       
     std::map<double,std::vector<Hit>>::iterator it_cluster_pair;
     std::map<double,std::vector<MCHit>>::iterator it_cluster_pair_mc;
     bool loop_map = true;
-    if (isData) it_cluster_pair = (*m_all_clusters).begin();
-    else it_cluster_pair_mc = (*m_all_clusters_MC).begin();
+    if (isData) {
+        it_cluster_pair = (*m_all_clusters).begin();
+    } else {
+        if (MCWaveform) {
+            it_cluster_pair = (*m_all_clusters).begin();
+        } else {
+            it_cluster_pair_mc = (*m_all_clusters_MC).begin();
+        }
+    }
+
     if (cluster_size == 0) loop_map = false;
     while (loop_map){
     //for (std::pair<double,std::vector<Hit>>&& cluster_pair : *m_all_clusters) {
@@ -660,6 +685,19 @@ bool PhaseIITreeMaker::Execute(){
           if(verbosity>3) Log("PhaseIITreeMaker Tool: No cluster classifiers.  Continuing tree",v_debug,verbosity);
         }
       } else {
+        if (MCWaveform){
+          std::vector<Hit> cluster_hits = it_cluster_pair->second;
+          fClusterTime = it_cluster_pair->first;
+          if(TankHitInfo_fill){
+            Log("PhaseIITreeMaker Tool: Loading tank cluster hits into cluster tree",v_debug,verbosity);
+            this->LoadTankClusterHits(cluster_hits);
+          }
+
+          bool good_class = this->LoadTankClusterClassifiers(it_cluster_pair->first);
+          if(!good_class){
+            if(verbosity>3) Log("PhaseIITreeMaker Tool: No cluster classifiers.  Continuing tree",v_debug,verbosity);
+          }
+        } else {
         std::vector<MCHit> cluster_hits = it_cluster_pair_mc->second;
         fClusterTime = it_cluster_pair_mc->first;
         std::vector<unsigned long> cluster_detkeys = m_all_clusters_detkeys->at(it_cluster_pair_mc->first);
@@ -674,6 +712,7 @@ bool PhaseIITreeMaker::Execute(){
         bool good_bunch = this->LoadBNBtimingMC(it_cluster_pair_mc->first);
         if(!good_bunch){
           if(verbosity>v_debug) Log("PhaseIITreeMaker Tool: BNB timing (MC). Continuing tree",v_debug,verbosity);
+        }
         }
       }
 
@@ -690,13 +729,25 @@ bool PhaseIITreeMaker::Execute(){
       }
       fPhaseIITankClusterTree->Fill();
       cluster_num += 1;
-      if (isData){
-        it_cluster_pair++;
-        if (it_cluster_pair == (*m_all_clusters).end()) loop_map = false;
+      if (isData) {
+          it_cluster_pair++;
+          if (it_cluster_pair == (*m_all_clusters).end()) {
+              loop_map = false;
+          }
       } else {
-        it_cluster_pair_mc++;
-        if (it_cluster_pair_mc == (*m_all_clusters_MC).end()) loop_map = false;
-      } 
+          if (MCWaveform) {
+              it_cluster_pair++;
+              if (it_cluster_pair == (*m_all_clusters).end()) {
+                  loop_map = false;
+              }
+          } else {
+              it_cluster_pair_mc++;
+              if (it_cluster_pair_mc == (*m_all_clusters_MC).end()) {
+                  loop_map = false;
+              }
+          }
+      }
+
     }
   }
   
@@ -890,7 +941,7 @@ bool PhaseIITreeMaker::Execute(){
 
     // Read hits and load into ntuple
     if(TankHitInfo_fill){
-      this->LoadAllTankHits(isData);
+      this->LoadAllTankHits(isData, MCWaveform);
     }
     if(SiPMPulseInfo_fill) this->LoadSiPMHits();
  
@@ -1615,95 +1666,102 @@ int PhaseIITreeMaker::LoadMRDTrackReco(int SubEventID) {
   return NumClusterTracks;
 }
 
-void PhaseIITreeMaker::LoadAllTankHits(bool IsData) {
-  std::map<unsigned long, std::vector<Hit>>* Hits = nullptr;
-  std::map<unsigned long, std::vector<MCHit>>* MCHits = nullptr;
-  bool got_hits = false;
-  if (IsData) got_hits = m_data->Stores["ANNIEEvent"]->Get("Hits", Hits);
-  else got_hits = m_data->Stores["ANNIEEvent"]->Get("MCHits",MCHits);
-  if (!got_hits){
-    std::cout << "No Hits store in ANNIEEvent. Continuing to build tree " << std::endl;
-    return;
-  }
-  Position detector_center=geom->GetTankCentre();
-  double tank_center_x = detector_center.X();
-  double tank_center_y = detector_center.Y();
-  double tank_center_z = detector_center.Z();
-  fNHits = 0;
+void PhaseIITreeMaker::LoadAllTankHits(bool isData, bool MCWaveform) {
+    std::map<unsigned long, std::vector<Hit>>* Hits = nullptr;
+    std::map<unsigned long, std::vector<MCHit>>* MCHits = nullptr;
+    bool got_hits = false;
 
-  std::map<unsigned long,std::vector<Hit>>::iterator it_tank_data;
-  std::map<unsigned long,std::vector<MCHit>>::iterator it_tank_mc;
-  if (IsData) it_tank_data = (*Hits).begin();
-  else it_tank_mc = (*MCHits).begin();
-  bool loop_tank = true;
-  int hits_size = (IsData)? Hits->size() : MCHits->size();
-  if (hits_size == 0) loop_tank = false;
-
-
-  while (loop_tank){
-  //for(std::pair<unsigned long, std::vector<Hit>>&& apair : *Hits){
-    unsigned long channel_key;
-    if (IsData) channel_key = it_tank_data->first;
-    else channel_key = it_tank_mc->first;
-    Detector* this_detector = geom->ChannelToDetector(channel_key);
-    Position det_position = this_detector->GetDetectorPosition();
-    unsigned long detkey = this_detector->GetDetectorID();
-    unsigned long channel_key_data = channel_key;
-    if (!isData){
-      int wcsimid = channelkey_to_pmtid.at(channel_key);
-      channel_key_data = pmtid_to_channelkey[wcsimid];
-    }
-    std::map<int, double>::iterator it = ChannelKeyToSPEMap.find(channel_key);
-    std::map<int, double>::iterator it_mc = ChannelKeyToSPEMap.find(channel_key_data);
-    bool SPE_available = true;
-    if (IsData) SPE_available = (it != ChannelKeyToSPEMap.end());
-    else SPE_available = (it_mc != ChannelKeyToSPEMap.end());
-    if(SPE_available){ //Charge to SPE conversion is available
-      if (IsData){
-        std::vector<Hit> ThisPMTHits = it_tank_data->second;
-        fNHits+=ThisPMTHits.size();
-        for (Hit &ahit : ThisPMTHits){
-          double hit_charge = ahit.GetCharge();
-          double hit_PE  = hit_charge / ChannelKeyToSPEMap.at(channel_key);
-          fHitX.push_back((det_position.X()-tank_center_x));
-          fHitY.push_back((det_position.Y()-tank_center_y));
-          fHitZ.push_back((det_position.Z()-tank_center_z));
-          fHitT.push_back(ahit.GetTime());
-          fHitQ.push_back(hit_charge);
-          fHitPE.push_back(hit_PE);
-          fHitDetID.push_back(detkey);
-          fHitChankey.push_back(channel_key);
-          fHitChankeyMC.push_back(channel_key);
-          fHitType.push_back(RecoDigit::PMT8inch); // 0 For PMTs
-        }
-      } else {
-        std::vector<MCHit> ThisPMTHits = it_tank_mc->second;
-        fNHits+=ThisPMTHits.size();
-        for (MCHit &ahit : ThisPMTHits){
-          double hit_PE = ahit.GetCharge();
-          double hit_charge  = hit_PE * ChannelKeyToSPEMap.at(channel_key_data);
-          fHitX.push_back((det_position.X()-tank_center_x));
-          fHitY.push_back((det_position.Y()-tank_center_y));
-          fHitZ.push_back((det_position.Z()-tank_center_z));
-          fHitT.push_back(ahit.GetTime());
-          fHitQ.push_back(hit_charge);
-          fHitPE.push_back(hit_PE);
-          fHitDetID.push_back(detkey);
-          fHitChankey.push_back(channel_key_data);
-          fHitChankeyMC.push_back(channel_key);
-          fHitType.push_back(RecoDigit::PMT8inch); // 0 For PMTs
-        }
-      }
-    }
-    if (IsData) {
-      it_tank_data++;
-      if (it_tank_data == (*Hits).end()) loop_tank = false;
+    if (isData) {
+        got_hits = m_data->Stores["ANNIEEvent"]->Get("Hits", Hits);
     } else {
-      it_tank_mc++;
-      if (it_tank_mc == (*MCHits).end()) loop_tank = false;
+        if (MCWaveform) {
+            got_hits = m_data->Stores["ANNIEEvent"]->Get("Hits", Hits);
+        } else {
+            got_hits = m_data->Stores["ANNIEEvent"]->Get("MCHits", MCHits);
+        }
     }
-  }
-  return;
+
+    if (!got_hits) {
+        std::cout << "No Hits store in ANNIEEvent. Continuing to build tree." << std::endl;
+        return;
+    }
+
+    Position detector_center = geom->GetTankCentre();
+    double tank_center_x = detector_center.X();
+    double tank_center_y = detector_center.Y();
+    double tank_center_z = detector_center.Z();
+    fNHits = 0;
+
+    bool loop_tank = true;
+    int hits_size = (isData || MCWaveform) ? Hits->size() : MCHits->size();
+    if (hits_size == 0) loop_tank = false;
+
+    auto it_tank_data = (isData || MCWaveform) ? Hits->begin() : std::map<unsigned long, std::vector<Hit>>::iterator();
+    auto it_tank_mc = (!isData && !MCWaveform) ? MCHits->begin() : std::map<unsigned long, std::vector<MCHit>>::iterator();
+
+    while (loop_tank) {
+        unsigned long channel_key = (isData || MCWaveform) ? it_tank_data->first : it_tank_mc->first;
+        Detector* this_detector = geom->ChannelToDetector(channel_key);
+        Position det_position = this_detector->GetDetectorPosition();
+        unsigned long detkey = this_detector->GetDetectorID();
+        unsigned long channel_key_data = channel_key;
+
+        if (!isData && !MCWaveform) {
+            int wcsimid = channelkey_to_pmtid.at(channel_key);
+            channel_key_data = pmtid_to_channelkey[wcsimid];
+        }
+
+        bool SPE_available = (isData || MCWaveform) ? 
+                             (ChannelKeyToSPEMap.find(channel_key) != ChannelKeyToSPEMap.end()) : 
+                             (ChannelKeyToSPEMap.find(channel_key_data) != ChannelKeyToSPEMap.end());
+
+        if (SPE_available) {
+            if (isData || MCWaveform) {
+                std::vector<Hit> ThisPMTHits = it_tank_data->second;
+                fNHits += ThisPMTHits.size();
+                for (Hit &ahit : ThisPMTHits) {
+                    double hit_charge = ahit.GetCharge();
+                    double hit_PE = hit_charge / ChannelKeyToSPEMap.at(channel_key);
+                    fHitX.push_back(det_position.X() - tank_center_x);
+                    fHitY.push_back(det_position.Y() - tank_center_y);
+                    fHitZ.push_back(det_position.Z() - tank_center_z);
+                    fHitT.push_back(ahit.GetTime());
+                    fHitQ.push_back(hit_charge);
+                    fHitPE.push_back(hit_PE);
+                    fHitDetID.push_back(detkey);
+                    fHitChankey.push_back(channel_key);
+                    fHitChankeyMC.push_back(channel_key);
+                    fHitType.push_back(RecoDigit::PMT8inch);
+                }
+            } else {
+                std::vector<MCHit> ThisPMTHits = it_tank_mc->second;
+                fNHits += ThisPMTHits.size();
+                for (MCHit &ahit : ThisPMTHits) {
+                    double hit_PE = ahit.GetCharge();
+                    double hit_charge = hit_PE * ChannelKeyToSPEMap.at(channel_key_data);
+                    fHitX.push_back(det_position.X() - tank_center_x);
+                    fHitY.push_back(det_position.Y() - tank_center_y);
+                    fHitZ.push_back(det_position.Z() - tank_center_z);
+                    fHitT.push_back(ahit.GetTime());
+                    fHitQ.push_back(hit_charge);
+                    fHitPE.push_back(hit_PE);
+                    fHitDetID.push_back(detkey);
+                    fHitChankey.push_back(channel_key_data);
+                    fHitChankeyMC.push_back(channel_key);
+                    fHitType.push_back(RecoDigit::PMT8inch);
+                }
+            }
+        }
+
+        if (isData || MCWaveform) {
+            it_tank_data++;
+            if (it_tank_data == Hits->end()) loop_tank = false;
+        } else {
+            it_tank_mc++;
+            if (it_tank_mc == MCHits->end()) loop_tank = false;
+        }
+    }
+    return;
 }
 
 bool PhaseIITreeMaker::FillTankRecoInfo() {

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -518,6 +518,16 @@ bool PhaseIITreeMaker::Execute(){
   // Reset variables
   this->ResetVariables();
   // Get a pointer to the ANNIEEvent Store
+	
+  // An upstream tool may opt to skip this execution stage
+  // For example the PMTWaveformSim tool will skip events with no MCHits or if
+  // no waveforms are produced.
+  bool skip = false;
+  bool got_skip_status = m_data->Stores["ANNIEEvent"]->Get("SkipExecute", skip);
+  if (got_skip_status && skip) {
+    Log("PhaseIITreeMaker: An upstream tool told me to skip this event.",v_warning,verbosity);
+    return true;
+  } 
 
   //  If only clean events are built, return true for dirty events
   if(fillCleanEventsOnly){

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
@@ -77,7 +77,7 @@ class PhaseIITreeMaker: public Tool {
   void LoadTankClusterHitsMC(std::vector<MCHit> cluster_hits,std::vector<unsigned long> cluster_detkeys);
   bool LoadTankClusterClassifiers(double cluster_time);
   bool LoadBNBtimingMC(double cluster_time);
-  void LoadAllTankHits(bool IsData);
+  void LoadAllTankHits(bool IsData, bool MCWaveform);
   void LoadSiPMHits();
   
   
@@ -85,6 +85,7 @@ class PhaseIITreeMaker: public Tool {
 
   //General variables
   bool isData;
+  bool MCWaveform;
   bool hasGenie;
   bool hasBNBtimingMC;
 

--- a/UserTools/PhaseIITreeMaker/README.md
+++ b/UserTools/PhaseIITreeMaker/README.md
@@ -81,6 +81,10 @@ Will output to tree if 1.
 IsData (1 or 0)
 Whether the data we are processing is real (Hits) or MC (MCHits).
 
+PMTWaveformSim (1 or 0)
+PMTWaveformSim tool constructs waveforms from MC hits and performs hit finding just like in the data.
+If enabled, IsData should also be 0 to signal it is MC. 
+
 HasGenie (1 or 0)
 Input determines whether GENIE-level information is loaded by the LoadGENIEEvent tool.
 


### PR DESCRIPTION
## Describe your changes

This PR is dependent on Andrew's new PMTWaveformSim tool (https://github.com/ANNIEsoft/ToolAnalysis/pull/324). His new tool generates waveforms from MC hits and runs the data hit finding tool (`PhaseIIADCHitFinder`) over the MC waveforms. Those hits are saved in the same pulse vector as the data hits. The logic of the `PhaseIITreeMaker` needed to be changed to handle data-like hits for MC events. Essentially just added some if / else statements to make sure this tool handles the MC waveform hits just like the data while keeping functionality for other MC truth information.

Other downstream tools will need to be adjusted; I will open separate PRs for each of those tools.

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [X] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
See Andrew's PR for details (https://github.com/ANNIEsoft/ToolAnalysis/pull/324). If you want to use the MC waveform hits, ensure the configuration for `PhaseIITreeMaker` has both `IsData 0` (indicating it is MC) and `PMTWaveformSim 1`. Setting the latter to 0 will use the default MC hits created by summing the individual photon hits in the `ClusterFinder` tool 
