### PR TITLE
EventSelector modifications for new MC waveform hits

### DIFF
--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -642,17 +642,12 @@ bool EventSelector::EventSelectionByMCProjectedMRDHit() {
 
 bool EventSelector::EventSelectionByPMTMRDCoinc() {
 
-  if (fIsMC){
-    if (fMCWaveform){
-      bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
+  if (!fIsMC || fMCWaveform) {
+	  bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
       if (not has_clustered_pmt) { Log("EventSelector Tool: MCWaveform - Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
-    } else {
-        bool has_clustered_pmt = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
-        if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMapMC from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
-        }
   } else {
-    bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
-    if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
+	  bool has_clustered_pmt = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
+        if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMapMC from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
   }
 
   bool has_clustered_mrd = m_data->CStore.Get("MrdTimeClusters",MrdTimeClusters);
@@ -665,15 +660,12 @@ bool EventSelector::EventSelectionByPMTMRDCoinc() {
   }
   
   int pmt_cluster_size;
-  if (fIsMC) {
-    if (fMCWaveform) {
-        pmt_cluster_size = (int) m_all_clusters->size();
-    } else {
-        pmt_cluster_size = (int) m_all_clusters_MC->size();
-    }
+  if (!fIsMC || fMCWaveform) {
+	  pmt_cluster_size = (int) m_all_clusters->size();
   } else {
-      pmt_cluster_size = (int) m_all_clusters->size();
+	  pmt_cluster_size = (int) m_all_clusters_MC->size();
   }
+	  
   m_data->Stores["RecoEvent"]->Set("NumPMTClusters",pmt_cluster_size);
   vec_pmtclusters_charge->clear();
   vec_pmtclusters_time->clear();
@@ -690,84 +682,53 @@ bool EventSelector::EventSelectionByPMTMRDCoinc() {
 
   pmt_time = -1;
 
-  if (fIsMC){
-    if (fMCWaveform) {
-      if (m_all_clusters->size()){
-      double cluster_time;
-      for(std::pair<double,std::vector<Hit>>&& apair : *m_all_clusters){
-        std::vector<Hit>&Hits = apair.second;
-        double time_temp = 0;
-        double charge_temp = 0;
-        for (unsigned int i_hit = 0; i_hit < Hits.size(); i_hit++){
-          time_temp+=Hits.at(i_hit).GetTime();
-          int tube = Hits.at(i_hit).GetTubeId();
-          // check if PMT is present in the map before accessing it
-	  auto it = ChannelNumToTankPMTSPEChargeMap->find(tube);
-	  if (it != ChannelNumToTankPMTSPEChargeMap->end()) {
-	  	double charge_pe = Hits.at(i_hit).GetCharge() / it->second;
-	  	charge_temp += charge_pe;
-	  } else {
-	  	std::cerr << "PMT channel with hit not found in ChannelNumToTankPMTSPEChargeMap. Skipping this hit." << std::endl;
-	  	continue;
-	  }
-        }
-        if (Hits.size()>0) time_temp/=Hits.size();
-        vec_pmtclusters_charge->push_back(charge_temp);
-        vec_pmtclusters_time->push_back(time_temp);
-        if (time_temp > 2000.) continue;	//not a prompt event
-        if (charge_temp > max_charge){
-          max_charge = charge_temp;
-          prompt_cluster = true;
-          pmt_time = time_temp;
-          n_hits = int(Hits.size());
-        }
-      }
-    }
-    } else {
-      if (m_all_clusters_MC->size()){
-        double cluster_time;
-        for(std::pair<double,std::vector<MCHit>>&& apair : *m_all_clusters_MC){
-          std::vector<MCHit>&MCHits = apair.second;
-          double time_temp = 0;
-          double charge_temp = 0;
-          for (unsigned int i_hit = 0; i_hit < MCHits.size(); i_hit++){
-            time_temp+=MCHits.at(i_hit).GetTime();
-            charge_temp+=MCHits.at(i_hit).GetCharge();
-          }
-          if (MCHits.size()>0) time_temp/=MCHits.size();
-          vec_pmtclusters_charge->push_back(charge_temp);
-          vec_pmtclusters_time->push_back(time_temp);
-          if (time_temp > 2000.) continue;	//not a prompt event
-          if (charge_temp > max_charge){
-            max_charge = charge_temp;
-            prompt_cluster = true;
-            pmt_time = time_temp;
-            n_hits = int(MCHits.size());
-          }
-        }
-      }
-    }
-  } else {
+  // MC Waveform or Data
+  if (!fIsMC || fMCWaveform) {
     if (m_all_clusters->size()){
-      double cluster_time;
-      for(std::pair<double,std::vector<Hit>>&& apair : *m_all_clusters){
-        std::vector<Hit>&Hits = apair.second;
-        double time_temp = 0;
-        double charge_temp = 0;
-        for (unsigned int i_hit = 0; i_hit < Hits.size(); i_hit++){
-          time_temp+=Hits.at(i_hit).GetTime();
-          int tube = Hits.at(i_hit).GetTubeId();
-          // check if PMT is present in the map before accessing it
+    double cluster_time;
+    for(std::pair<double,std::vector<Hit>>&& apair : *m_all_clusters){
+      std::vector<Hit>&Hits = apair.second;
+      double time_temp = 0;
+      double charge_temp = 0;
+      for (unsigned int i_hit = 0; i_hit < Hits.size(); i_hit++){
+        time_temp+=Hits.at(i_hit).GetTime();
+        int tube = Hits.at(i_hit).GetTubeId();
+        // check if PMT is present in the map before accessing it
 	  auto it = ChannelNumToTankPMTSPEChargeMap->find(tube);
 	  if (it != ChannelNumToTankPMTSPEChargeMap->end()) {
-	  	double charge_pe = Hits.at(i_hit).GetCharge() / it->second;
-	  	charge_temp += charge_pe;
+	    double charge_pe = Hits.at(i_hit).GetCharge() / it->second;
+	    charge_temp += charge_pe;
 	  } else {
-	  	std::cerr << "PMT channel with hit not found in ChannelNumToTankPMTSPEChargeMap. Skipping this hit." << std::endl;
-	  	continue;
+	    std::cerr << "PMT channel with hit not found in ChannelNumToTankPMTSPEChargeMap. Skipping this hit." << std::endl;
+	    continue;
 	  }
+      }
+      if (Hits.size()>0) time_temp/=Hits.size();
+      vec_pmtclusters_charge->push_back(charge_temp);
+      vec_pmtclusters_time->push_back(time_temp);
+      if (time_temp > 2000.) continue;	//not a prompt event
+      if (charge_temp > max_charge){
+        max_charge = charge_temp;
+        prompt_cluster = true;
+        pmt_time = time_temp;
+        n_hits = int(Hits.size());
+      }
+    }
+  }
+
+  // MC (parametric)
+  } else {
+    if (m_all_clusters_MC->size()){
+      double cluster_time;
+      for(std::pair<double,std::vector<MCHit>>&& apair : *m_all_clusters_MC){
+        std::vector<MCHit>&MCHits = apair.second;
+        double time_temp = 0;
+        double charge_temp = 0;
+        for (unsigned int i_hit = 0; i_hit < MCHits.size(); i_hit++){
+          time_temp+=MCHits.at(i_hit).GetTime();
+          charge_temp+=MCHits.at(i_hit).GetCharge();
         }
-        if (Hits.size()>0) time_temp/=Hits.size();
+        if (MCHits.size()>0) time_temp/=MCHits.size();
         vec_pmtclusters_charge->push_back(charge_temp);
         vec_pmtclusters_time->push_back(time_temp);
         if (time_temp > 2000.) continue;	//not a prompt event
@@ -775,7 +736,7 @@ bool EventSelector::EventSelectionByPMTMRDCoinc() {
           max_charge = charge_temp;
           prompt_cluster = true;
           pmt_time = time_temp;
-          n_hits = int(Hits.size());
+          n_hits = int(MCHits.size());
         }
       }
     }

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -14,6 +14,7 @@ bool EventSelector::Initialise(std::string configfile, DataModel &data){
 
   fPMTMRDOffset = false;
   fIsMC = true;
+  fMCWaveform = false;
   fPMTMRDOffset = 755;
   fRecoPDG = -1;
 
@@ -50,6 +51,7 @@ bool EventSelector::Initialise(std::string configfile, DataModel &data){
   }
   m_variables.Get("SaveStatusToStore", fSaveStatusToStore);
   m_variables.Get("IsMC",fIsMC);
+  m_variables.Get("PMTWaveformSim",fMCWaveform);
   m_variables.Get("RecoPDG",fRecoPDG);
   m_variables.Get("TriggerExtendedWindow",fTriggerExtended);
   m_variables.Get("BeamOK",fBeamOK);
@@ -632,8 +634,13 @@ bool EventSelector::EventSelectionByMCProjectedMRDHit() {
 bool EventSelector::EventSelectionByPMTMRDCoinc() {
 
   if (fIsMC){
-    bool has_clustered_pmt = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
-    if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMapMC from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
+    if (fMCWaveform){
+      bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
+      if (not has_clustered_pmt) { Log("EventSelector Tool: MCWaveform - Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
+    } else {
+        bool has_clustered_pmt = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
+        if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMapMC from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
+        }
   } else {
     bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
     if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
@@ -649,8 +656,15 @@ bool EventSelector::EventSelectionByPMTMRDCoinc() {
   }
   
   int pmt_cluster_size;
-  if (fIsMC) pmt_cluster_size = (int) m_all_clusters_MC->size();
-  else pmt_cluster_size = (int) m_all_clusters->size();
+  if (fIsMC) {
+    if (fMCWaveform) {
+        pmt_cluster_size = (int) m_all_clusters->size();
+    } else {
+        pmt_cluster_size = (int) m_all_clusters_MC->size();
+    }
+  } else {
+      pmt_cluster_size = (int) m_all_clusters->size();
+  }
   m_data->Stores["RecoEvent"]->Set("NumPMTClusters",pmt_cluster_size);
   vec_pmtclusters_charge->clear();
   vec_pmtclusters_time->clear();
@@ -668,17 +682,27 @@ bool EventSelector::EventSelectionByPMTMRDCoinc() {
   pmt_time = -1;
 
   if (fIsMC){
-    if (m_all_clusters_MC->size()){
+    if (fMCWaveform) {
+      if (m_all_clusters->size()){
       double cluster_time;
-      for(std::pair<double,std::vector<MCHit>>&& apair : *m_all_clusters_MC){
-        std::vector<MCHit>&MCHits = apair.second;
+      for(std::pair<double,std::vector<Hit>>&& apair : *m_all_clusters){
+        std::vector<Hit>&Hits = apair.second;
         double time_temp = 0;
         double charge_temp = 0;
-        for (unsigned int i_hit = 0; i_hit < MCHits.size(); i_hit++){
-          time_temp+=MCHits.at(i_hit).GetTime();
-          charge_temp+=MCHits.at(i_hit).GetCharge();
+        for (unsigned int i_hit = 0; i_hit < Hits.size(); i_hit++){
+          time_temp+=Hits.at(i_hit).GetTime();
+          int tube = Hits.at(i_hit).GetTubeId();
+          // check if PMT is present in the map before accessing it
+	  auto it = ChannelNumToTankPMTSPEChargeMap->find(tube);
+	  if (it != ChannelNumToTankPMTSPEChargeMap->end()) {
+	  	double charge_pe = Hits.at(i_hit).GetCharge() / it->second;
+	  	charge_temp += charge_pe;
+	  } else {
+	  	std::cerr << "PMT channel with hit not found in ChannelNumToTankPMTSPEChargeMap. Skipping this hit." << std::endl;
+	  	continue;
+	  }
         }
-        if (MCHits.size()>0) time_temp/=MCHits.size();
+        if (Hits.size()>0) time_temp/=Hits.size();
         vec_pmtclusters_charge->push_back(charge_temp);
         vec_pmtclusters_time->push_back(time_temp);
         if (time_temp > 2000.) continue;	//not a prompt event
@@ -686,7 +710,31 @@ bool EventSelector::EventSelectionByPMTMRDCoinc() {
           max_charge = charge_temp;
           prompt_cluster = true;
           pmt_time = time_temp;
-          n_hits = int(MCHits.size());
+          n_hits = int(Hits.size());
+        }
+      }
+    }
+    } else {
+      if (m_all_clusters_MC->size()){
+        double cluster_time;
+        for(std::pair<double,std::vector<MCHit>>&& apair : *m_all_clusters_MC){
+          std::vector<MCHit>&MCHits = apair.second;
+          double time_temp = 0;
+          double charge_temp = 0;
+          for (unsigned int i_hit = 0; i_hit < MCHits.size(); i_hit++){
+            time_temp+=MCHits.at(i_hit).GetTime();
+            charge_temp+=MCHits.at(i_hit).GetCharge();
+          }
+          if (MCHits.size()>0) time_temp/=MCHits.size();
+          vec_pmtclusters_charge->push_back(charge_temp);
+          vec_pmtclusters_time->push_back(time_temp);
+          if (time_temp > 2000.) continue;	//not a prompt event
+          if (charge_temp > max_charge){
+            max_charge = charge_temp;
+            prompt_cluster = true;
+            pmt_time = time_temp;
+            n_hits = int(MCHits.size());
+          }
         }
       }
     }
@@ -762,10 +810,14 @@ bool EventSelector::EventSelectionByPMTMRDCoinc() {
   }
   m_data->Stores["RecoEvent"]->Set("MRDClustersTime",vec_mrdclusters_time, true);
   
-  if (fIsMC){
-    if (MrdTimeClusters.size() == 0 || m_all_clusters_MC->size() == 0) return false;
+  if (fIsMC) {
+    if (MrdTimeClusters.size() == 0 || (fMCWaveform ? m_all_clusters->size() == 0 : m_all_clusters_MC->size() == 0)) {
+        return false;
+    }
   } else {
-    if (MrdTimeClusters.size() == 0 || m_all_clusters->size() == 0) return false;
+      if (MrdTimeClusters.size() == 0 || m_all_clusters->size() == 0) {
+          return false;
+      }
   }
 
   pmtmrd_coinc_min = fPMTMRDOffset - 50;
@@ -1027,8 +1079,13 @@ bool EventSelector::FindPaddleChankey(double x, double y, int layer, unsigned lo
 bool EventSelector::EventSelectionByRecoPDG(int recoPDG, std::vector<double> & cluster_reco_pdg){
 
   if (fIsMC){
-    bool has_clustered_pmt = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
-    if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMapMC from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
+    if (fMCWaveform) {
+      bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
+      if (not has_clustered_pmt) { Log("EventSelector Tool: MCWaveform --> Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
+    } else {
+      bool has_clustered_pmt = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
+      if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMapMC from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
+    }
   } else {
     bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
     if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
@@ -1046,23 +1103,49 @@ bool EventSelector::EventSelectionByRecoPDG(int recoPDG, std::vector<double> & c
 
   if (fabs(recoPDG)==2112){
     if (fIsMC){
-      if (m_all_clusters_MC->size()){
-        for(std::pair<double,std::vector<MCHit>>&& apair : *m_all_clusters_MC){
+      if (fMCWaveform) {
+        if (m_all_clusters->size()){
+        double cluster_time;
+        for(std::pair<double,std::vector<Hit>>&& apair : *m_all_clusters){
           double cluster_time = apair.first;
           double charge_balance = ClusterChargeBalances.at(cluster_time);
-          std::vector<MCHit>&MCHits = apair.second;
+          std::vector<Hit>&Hits = apair.second;
           double time_temp = 0;
           double charge_temp = 0;
-          for (unsigned int i_hit = 0; i_hit < MCHits.size(); i_hit++){
-            time_temp+=MCHits.at(i_hit).GetTime();
-            charge_temp+=MCHits.at(i_hit).GetCharge();
+          for (unsigned int i_hit = 0; i_hit < Hits.size(); i_hit++){
+            time_temp+=Hits.at(i_hit).GetTime();
+            int tube = Hits.at(i_hit).GetTubeId();
+            double charge_pe = Hits.at(i_hit).GetCharge()/ChannelNumToTankPMTSPEChargeMap->at(tube);
+            charge_temp+=charge_pe;
           }
           if (cluster_time > 10000 && charge_balance < 0.4 && charge_temp < 120) {
             cluster_reco_pdg.push_back(cluster_time);
             found_pdg = true;
-            std::cout <<"Found neutron candidate for cluster at time = "<<cluster_time<<", with CB = "<<charge_balance <<" and charge "<<charge_temp<<"!!!"<<std::endl;
+            std::cout <<"Found neutron candidate for cluster at time = "<<cluster_time<<", with CB = "<<charge_balance <<"and charge "<<charge_temp<<"!!!"<<std::endl;
           } else {
             std::cout <<"Did not pass neutron candidate cuts!!! Time = "<<cluster_time <<", CB = "<<charge_balance << " and charge "<<charge_temp<<"!!!"<<std::endl;
+          }
+        }
+      }
+      } else {
+        if (m_all_clusters_MC->size()){
+          for(std::pair<double,std::vector<MCHit>>&& apair : *m_all_clusters_MC){
+            double cluster_time = apair.first;
+            double charge_balance = ClusterChargeBalances.at(cluster_time);
+            std::vector<MCHit>&MCHits = apair.second;
+            double time_temp = 0;
+            double charge_temp = 0;
+            for (unsigned int i_hit = 0; i_hit < MCHits.size(); i_hit++){
+              time_temp+=MCHits.at(i_hit).GetTime();
+              charge_temp+=MCHits.at(i_hit).GetCharge();
+            }
+            if (cluster_time > 10000 && charge_balance < 0.4 && charge_temp < 120) {
+              cluster_reco_pdg.push_back(cluster_time);
+              found_pdg = true;
+              std::cout <<"Found neutron candidate for cluster at time = "<<cluster_time<<", with CB = "<<charge_balance <<" and charge "<<charge_temp<<"!!!"<<std::endl;
+            } else {
+              std::cout <<"Did not pass neutron candidate cuts!!! Time = "<<cluster_time <<", CB = "<<charge_balance << " and charge "<<charge_temp<<"!!!"<<std::endl;
+            }
           }
         }
       }

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -97,6 +97,15 @@ bool EventSelector::Execute(){
   	return false;
   };
 
+  // an upstream tool may have told us to skip this event (PMTWaveformSim)
+  bool skip = false;
+  bool goodSkipStatus = m_data->Stores.at("ANNIEEvent")->Get("SkipExecute", skip);
+  if (goodSkipStatus && skip) {
+    logmessage = "EventSelector: An upstream tool told me to skip this event.";
+    Log(logmessage, v_warning, verbosity);
+    return true;
+  }
+	
   // ANNIE Event number
   m_data->Stores.at("ANNIEEvent")->Get("EventNumber",fEventNumber);
   

--- a/UserTools/EventSelector/EventSelector.cpp
+++ b/UserTools/EventSelector/EventSelector.cpp
@@ -96,15 +96,6 @@ bool EventSelector::Execute(){
   	Log("EventSelector Tool: No ANNIEEvent store!",v_error,verbosity); 
   	return false;
   };
-
-  // an upstream tool may have told us to skip this event (PMTWaveformSim)
-  bool skip = false;
-  bool goodSkipStatus = m_data->Stores.at("ANNIEEvent")->Get("SkipExecute", skip);
-  if (goodSkipStatus && skip) {
-    logmessage = "EventSelector: An upstream tool told me to skip this event.";
-    Log(logmessage, v_warning, verbosity);
-    return true;
-  }
 	
   // ANNIE Event number
   m_data->Stores.at("ANNIEEvent")->Get("EventNumber",fEventNumber);
@@ -1048,17 +1039,12 @@ bool EventSelector::FindPaddleChankey(double x, double y, int layer, unsigned lo
 
 bool EventSelector::EventSelectionByRecoPDG(int recoPDG, std::vector<double> & cluster_reco_pdg){
 
-  if (fIsMC){
-    if (fMCWaveform) {
-      bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
-      if (not has_clustered_pmt) { Log("EventSelector Tool: MCWaveform --> Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
-    } else {
-      bool has_clustered_pmt = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
-      if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMapMC from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
-    }
+  if (!fIsMC || fMCWaveform) {
+	bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
+	if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
   } else {
-    bool has_clustered_pmt = m_data->CStore.Get("ClusterMap",m_all_clusters);
-    if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMap from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
+	  bool has_clustered_pmt = m_data->CStore.Get("ClusterMapMC",m_all_clusters_MC);
+      if (not has_clustered_pmt) { Log("EventSelector Tool: Error retrieving ClusterMapMC from CStore, did you run ClusterFinder beforehand?",v_error,verbosity); return false; }
   }
 
   std::map<double,double> ClusterMaxPEs;
@@ -1072,33 +1058,31 @@ bool EventSelector::EventSelectionByRecoPDG(int recoPDG, std::vector<double> & c
   bool found_pdg = false;
 
   if (fabs(recoPDG)==2112){
-    if (fIsMC){
-      if (fMCWaveform) {
-        if (m_all_clusters->size()){
-        double cluster_time;
-        for(std::pair<double,std::vector<Hit>>&& apair : *m_all_clusters){
-          double cluster_time = apair.first;
-          double charge_balance = ClusterChargeBalances.at(cluster_time);
-          std::vector<Hit>&Hits = apair.second;
-          double time_temp = 0;
-          double charge_temp = 0;
-          for (unsigned int i_hit = 0; i_hit < Hits.size(); i_hit++){
-            time_temp+=Hits.at(i_hit).GetTime();
-            int tube = Hits.at(i_hit).GetTubeId();
-            double charge_pe = Hits.at(i_hit).GetCharge()/ChannelNumToTankPMTSPEChargeMap->at(tube);
-            charge_temp+=charge_pe;
-          }
-          if (cluster_time > 10000 && charge_balance < 0.4 && charge_temp < 120) {
-            cluster_reco_pdg.push_back(cluster_time);
-            found_pdg = true;
-            std::cout <<"Found neutron candidate for cluster at time = "<<cluster_time<<", with CB = "<<charge_balance <<"and charge "<<charge_temp<<"!!!"<<std::endl;
-          } else {
-            std::cout <<"Did not pass neutron candidate cuts!!! Time = "<<cluster_time <<", CB = "<<charge_balance << " and charge "<<charge_temp<<"!!!"<<std::endl;
-          }
-        }
-      }
-      } else {
-        if (m_all_clusters_MC->size()){
+	if (!fIsMC || fMCWaveform) {    // data-like
+		if (m_all_clusters->size()){
+	        for(std::pair<double,std::vector<Hit>>&& apair : *m_all_clusters){
+	          double cluster_time = apair.first;
+	          double charge_balance = ClusterChargeBalances.at(cluster_time);
+	          std::vector<Hit>&Hits = apair.second;
+	          double time_temp = 0;
+	          double charge_temp = 0;
+	          for (unsigned int i_hit = 0; i_hit < Hits.size(); i_hit++){
+	            time_temp+=Hits.at(i_hit).GetTime();
+	            int tube = Hits.at(i_hit).GetTubeId();
+	            double charge_pe = Hits.at(i_hit).GetCharge()/ChannelNumToTankPMTSPEChargeMap->at(tube);
+	            charge_temp+=charge_pe;
+	          }
+	          if (cluster_time > 10000 && charge_balance < 0.4 && charge_temp < 120) {
+	            cluster_reco_pdg.push_back(cluster_time);
+	            found_pdg = true;
+	            std::cout <<"Found neutron candidate for cluster at time = "<<cluster_time<<", with CB = "<<charge_balance <<"and charge "<<charge_temp<<"!!!"<<std::endl;
+	          } else {
+	            std::cout <<"Did not pass neutron candidate cuts!!! Time = "<<cluster_time <<", CB = "<<charge_balance << " and charge "<<charge_temp<<"!!!"<<std::endl;
+	          }
+        	}
+     	 }
+	  } else {     // MCHits
+		if (m_all_clusters_MC->size()){
           for(std::pair<double,std::vector<MCHit>>&& apair : *m_all_clusters_MC){
             double cluster_time = apair.first;
             double charge_balance = ClusterChargeBalances.at(cluster_time);
@@ -1118,32 +1102,7 @@ bool EventSelector::EventSelectionByRecoPDG(int recoPDG, std::vector<double> & c
             }
           }
         }
-      }
-    } else {
-      if (m_all_clusters->size()){
-        double cluster_time;
-        for(std::pair<double,std::vector<Hit>>&& apair : *m_all_clusters){
-          double cluster_time = apair.first;
-          double charge_balance = ClusterChargeBalances.at(cluster_time);
-          std::vector<Hit>&Hits = apair.second;
-          double time_temp = 0;
-          double charge_temp = 0;
-          for (unsigned int i_hit = 0; i_hit < Hits.size(); i_hit++){
-            time_temp+=Hits.at(i_hit).GetTime();
-            int tube = Hits.at(i_hit).GetTubeId();
-            double charge_pe = Hits.at(i_hit).GetCharge()/ChannelNumToTankPMTSPEChargeMap->at(tube);
-            charge_temp+=charge_pe;
-          }
-          if (cluster_time > 10000 && charge_balance < 0.4 && charge_temp < 120) {
-            cluster_reco_pdg.push_back(cluster_time);
-            found_pdg = true;
-            std::cout <<"Found neutron candidate for cluster at time = "<<cluster_time<<", with CB = "<<charge_balance <<"and charge "<<charge_temp<<"!!!"<<std::endl;
-          } else {
-            std::cout <<"Did not pass neutron candidate cuts!!! Time = "<<cluster_time <<", CB = "<<charge_balance << " and charge "<<charge_temp<<"!!!"<<std::endl;
-          }
-        }
-      }
-    }
+	  }
   }
 
   return found_pdg;

--- a/UserTools/EventSelector/EventSelector.h
+++ b/UserTools/EventSelector/EventSelector.h
@@ -249,6 +249,7 @@ class EventSelector: public Tool {
   bool fThroughGoing = false;
   bool fEventCutStatus;
   bool fIsMC; 
+  bool fMCWaveform;
   int fTriggerWord;
   int fRecoPDG;
   bool fTriggerExtended = false;

--- a/UserTools/EventSelector/README.md
+++ b/UserTools/EventSelector/README.md
@@ -106,5 +106,6 @@ ThroughGoing
 TriggerWord
 RecoPDG
 IsMC
+PMTWaveformSim
 SaveStatusToStore
 ```


### PR DESCRIPTION
## Describe your changes

See PR https://github.com/ANNIEsoft/ToolAnalysis/pull/329 for more details on why we need to alter downstream tools. For the PMTs,`EventSelector` assumes MC hits are coming from the MC cluster map. For the new MC waveform tool (https://github.com/ANNIEsoft/ToolAnalysis/pull/324) the `ClusterFinder` tool handles the MC hits in an identical fashion to the data hits. We therefore need to adjust some of the logic to allow for this tool to use "data" PMT clusters with MC MRD hits, truth information, etc... 

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [X] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
This PR (just like https://github.com/ANNIEsoft/ToolAnalysis/pull/329) is dependent on Andrew's new MC waveform tool (https://github.com/ANNIEsoft/ToolAnalysis/pull/324).
