### PR TITLE
Bugfix for unsmeared hit times in LoadWCSim

### DIFF
--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -658,10 +658,13 @@ bool LoadWCSim::Execute(){
 			if(verbosity>2) cout<<"digit Q is "<<digiq<<endl;
 			// Get hit parent information
 			std::vector<int> parents = GetHitParentIds(digihit, firsttrigt);
-			//std::cout <<"digittime before adding event time: "<<digittime<<","<<EventTimeNs<<std::endl;
+			if(verbosity>2){ std::cout <<"digittime before adding event time: "<<digittime<<","<<EventTimeNs<<std::endl; }
 			
-			if (!splitSubtriggers) digittime += EventTimeNs;			
-			//std::cout <<"digittime after adding event time: "<<digittime<<std::endl;
+			// Unsmeared hit times are with respect to the MC global time --> therefore we shouldn't add the event / trigger time if using unsmeared
+			if(use_smeared_digit_time){
+				if (!splitSubtriggers) digittime += EventTimeNs;
+			}			
+			if(verbosity>2){ std::cout <<"digittime after adding event time: "<<digittime<<std::endl; }
 			
 			MCHit nexthit(key, digittime, digiq, parents);
 			if(MCHits->count(key)==0) MCHits->emplace(key, std::vector<MCHit>{nexthit});


### PR DESCRIPTION
Bug fix: photon hits from WCSim use unsmeared or smeared hit times (set in config file). It was noticed the unsmeared hit times were systematically shifted towards larger times for delayed hits (> 2us). Smeared hit times did not seem to have this problem. 

In the code, the event time was added back to the hit times. It was determined that the unsmeared hits are with respect to the global MC time, so they do not require this addition. Smeared hit times are taken from WCSim digits, and are triggered output so require this addition to ensure all timing is consistent. 

Upon testing the issue is remedied with the proposed changes. 

## Describe your changes

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [N/A] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
More details on the bug fix and further explanations can be found [here](https://annie-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=5838).
