### PR TITLE
AmBeWaveform toolchain

### DIFF
--- a/configfiles/AmBeWaveform/FitRWMWaveformConfig
+++ b/configfiles/AmBeWaveform/FitRWMWaveformConfig
@@ -1,0 +1,3 @@
+verbosityFitRWMWaveform 0
+maxPrintNumber 100000
+printToRootFile 1

--- a/configfiles/AmBeWaveform/LoadANNIEEventConfig
+++ b/configfiles/AmBeWaveform/LoadANNIEEventConfig
@@ -1,0 +1,4 @@
+verbose 1
+FileForListOfInputs ./configfiles/AmBeWaveform/my_inputs.txt
+EventOffset 0
+GlobalEvNr 1

--- a/configfiles/AmBeWaveform/README.md
+++ b/configfiles/AmBeWaveform/README.md
@@ -1,0 +1,43 @@
+# AmBeWaveform
+
+***********************
+## Description
+**********************
+
+The `AmBeWaveform` toolchain produces a ROOT file containing all raw AmBe PMT waveforms.
+
+For AmBe source runs, there is a small PMT within the AmBe housing that records the initial scintillation light within the BGO crystal and acts as the primary trigger for the rest of the PMTs. The small AmBe waveforms are stored in the [RWM auxillary channel](https://github.com/S81D/ToolAnalysis/blob/005d0930b57a266b9d8f4c1ef3ad07f31850e871/configfiles/LoadGeometry/AuxChannels.csv#L6). This waveform can be used to reduce backgrounds in the AmBe neutron analysis.
+
+Currently, the `FitRWMWaveform` tool which does the heavy lifting for this toolchain is designed for beam runs and the fitting / storing of both the Booster RWM and RF waveforms. This toolchain will therefore populate the output root file with **both** Booster RWM and Booster RF raw waveforms (Booster RF waveforms will be useless for the AmBe source runs). TO DO: Adjust `FitRWMWaveform` tool to handle and fit small AmBe PMT waveforms and send the information to the store for use by other tools.
+
+
+************************
+## Tools
+************************
+
+The toolchain consists of the following tools:
+
+```
+LoadANNIEEvent
+LoadGeometry
+FitRWMWaveform
+```
+
+
+************************
+## Additional information
+************************
+
+### FitRWMWaveform Config
+```
+verbosityFitRWMWaveform 0
+maxPrintNumber 20000           # controls how many waveforms are written to the root file
+printToRootFile 1              # whether to print the raw waveforms to the root file
+```
+For a 20 part file sample of an AmBe run, there will be ~7000 waveforms recorded in the Booster RWM channel. As stated above, the current iteration of the tool includes the Booster RF channel as well, so for 20 part files we can expect ~14,000 total waveforms. As a result, it is recommended `printToRootFile` is set to 20000 per 20 part files.
+
+
+### Usage
+The toolchain runs quickly (few seconds per part file), but when running over 20 part files as mentioned above the root file quickly explodes in size. For 20 part files, the root file size is ~700 MB. Until the tool is adjusted, the current solution is to use a bash script to run the toolchain in 20 part file chunks, then offload the root files from `/exp/annie/app/users/` to `scratch/` or `persistent/` to avoid overloading your app area.
+
+You can run this bash script via: `sh generate_AmBe_waveforms.sh <run_number>`. Please make the appropriate changes to the bash file prior to running it (like user name, ToolAnalysis directoruy path, etc...).

--- a/configfiles/AmBeWaveform/README.md
+++ b/configfiles/AmBeWaveform/README.md
@@ -38,6 +38,8 @@ For a 20 part file sample of an AmBe run, there will be ~7000 waveforms recorded
 
 
 ### Usage
+Populate `my_inputs.txt` with ProcessedData part files to run the toolchain over. To quickly populate the list file with part files from a processed run, you can do: `sh create_my_inputs.sh <run>`.
+
 The toolchain runs quickly (few seconds per part file), but when running over 20 part files as mentioned above the root file quickly explodes in size. For 20 part files, the root file size is ~700 MB. Until the tool is adjusted, the current solution is to use a bash script to run the toolchain in 20 part file chunks, then offload the root files from `/exp/annie/app/users/` to `scratch/` or `persistent/` to avoid overloading your app area.
 
-You can run this bash script via: `sh generate_AmBe_waveforms.sh <run_number>`. Please make the appropriate changes to the bash file prior to running it (like user name, ToolAnalysis directoruy path, etc...).
+You can run this bash script via: `sh generate_AmBe_waveforms.sh <run_number>`. Please make the appropriate changes to the bash file prior to running it (like user name, ToolAnalysis directory path, etc...).

--- a/configfiles/AmBeWaveform/ToolChainConfig
+++ b/configfiles/AmBeWaveform/ToolChainConfig
@@ -1,0 +1,22 @@
+#ToolChain dynamic setup file
+
+##### Runtime Paramiters #####
+verbose 1
+error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
+attempt_recover 1
+
+###### Logging #####
+log_mode Interactive # Interactive=cout , Remote= remote logging system "serservice_name Remote_Logging" , Local = local file log;
+log_local_path ./log
+log_service LogStore
+
+###### Service discovery #####
+service_publish_sec -1
+service_kick_sec -1
+
+##### Tools To Add #####
+Tools_File ./configfiles/AmBeWaveform/ToolsConfig
+
+##### Run Type #####
+Inline -1
+Interactive 0

--- a/configfiles/AmBeWaveform/ToolsConfig
+++ b/configfiles/AmBeWaveform/ToolsConfig
@@ -1,0 +1,3 @@
+myLoadANNIEEvent LoadANNIEEvent ./configfiles/AmBeWaveform/LoadANNIEEventConfig
+myLoadGeometry LoadGeometry ./configfiles/LoadGeometry/LoadGeometryConfig
+myFitRWMWaveform FitRWMWaveform ./configfiles/AmBeWaveform/FitRWMWaveform

--- a/configfiles/AmBeWaveform/create_my_inputs.sh
+++ b/configfiles/AmBeWaveform/create_my_inputs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ -z "$1" ]]; then
+    echo ""
+    echo "##############################"
+    echo "Error: No run number provided."
+    echo "Usage: $0 <run_number>"
+    echo ""
+    exit 1
+fi
+
+run=$1
+
+output_file="my_inputs.txt"
+processed_dir="/pnfs/annie/persistent/processed/processed_EBV2/R${run}/"
+
+find "$processed_dir" -type f -name "Processed*" | sort -t'/' -k2V > "$output_file"
+
+echo "done"
+

--- a/configfiles/AmBeWaveform/generate_AmBe_waveforms.sh
+++ b/configfiles/AmBeWaveform/generate_AmBe_waveforms.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Author: Steven Doran
+
+echo ""
+echo "Please make sure you have done the following:
+
+		- Using the following toolchain:
+				* LoadANNIEEvent
+				* LoadGeometry
+				* FitRWMWaveform
+		
+		- Enable 'printToRootFile 1' in the FitRWMWaveform tool
+		- Per 20 part files, ensure 'maxPrintNumber 20000' (you can expect ~15,000 waveforms per 20 part files)
+
+        - Set the correct configurations in this script:
+                * pro_dir   (processed files directory)
+                * step_size (number of files to execute per toolchain execution)
+                * user      (name of present user)
+                * TA_folder (name of ToolAnalysis directory)
+                * toolchain (name of toolchain to be executed) 
+                * offload   (scratch or persistent area where you can copy large root files to - /exp/annie/app/ only allocates ~50 GB of space)
+
+        - Have a temporary tmp/ folder bind mounted for singularity in your /exp/annie/app/user/<user>/ area
+                * example: singularity shell -B/pnfs:/pnfs,/exp/annie/app/users/$user/temp_directory:/tmp, ...
+
+"
+sleep 5
+
+# Check if the user provided a run argument
+if [[ -z "$1" ]]; then
+    echo ""
+	echo "##############################"
+	echo "Error: No run number provided."
+    echo "Usage: $0 <run_number>"
+	echo ""
+    exit 1
+fi
+
+
+#
+#
+#
+# ********************************************************************* #
+run=$1
+
+pro_dir="/pnfs/annie/persistent/processed/processed_EBV2/R${run}/"
+step_size=20
+
+user="<user>"
+
+TA_folder="ToolAnalysis/"
+toolchain="AmBeWaveform"
+
+offload="/pnfs/annie/scratch/users/${user}/AmBe_dump/"
+
+# ********************************************************************* #
+#
+#
+#
+
+
+echo ""
+echo "Generating AmBe waveforms for Run ${run}..."
+echo ""
+echo "User set to $user"
+echo ""
+
+# Check if the run was processed
+if [[ ! -d "$pro_dir" ]]; then
+    echo "Error: Directory $pro_dir does not exist."
+    echo ""
+	exit 1
+fi
+
+# Get the list of raw files and count them
+pro_files=($(ls "$pro_dir" | grep "^ProcessedData_PMT_R${run}S0p"))
+num_pro_files=${#pro_files[@]}
+
+if (( num_pro_files <= step_size )); then
+    start_indices=("0")
+    end_indices=($(($num_pro_files - 1)))
+else
+    start_indices=("0")
+    end_indices=()
+    
+    for (( i=step_size; i<num_pro_files; i+=step_size )); do
+        start_indices+=("$i")
+        end_indices+=("$((i - 1))")
+    done
+    end_indices+=("$((num_pro_files - 1))")
+fi
+
+echo ""
+echo "Start indices: ${start_indices[@]}"
+echo "End indices: ${end_indices[@]}"
+echo ""
+
+
+# run the toolchain over each step
+
+for (( idx=0; idx<${#start_indices[@]}; idx++ )); do
+    p_start=${start_indices[$idx]}
+    p_end=${end_indices[$idx]}
+
+    echo ""
+    echo "Running over [${p_start},${p_end}]"
+    echo ""
+
+	my_files="my_inputs.txt"
+    rm -f "$my_files"
+
+    # Create the input file based on the start + end index
+    for p in $(seq "$p_start" "$p_end"); do
+        echo "${pro_dir}/ProcessedData_PMT_R${run}S0p${p}" >> "$my_files"
+    done
+
+	cp $my_files /exp/annie/app/users/$user/$TA_folder/configfiles/$toolchain/.
+
+	echo ""
+    cat /exp/annie/app/users/$user/$TA_folder/configfiles/$toolchain/$my_files
+    echo ""
+    echo ""
+    echo ""
+
+	sleep 3
+
+    # Enter the Singularity environment and execute commands
+    singularity shell -B/pnfs:/pnfs,/exp/annie/app/users/$user/temp_directory:/tmp,/exp/annie/data:/exp/annie/data,/exp/annie/app:/exp/annie/app /cvmfs/singularity.opensciencegrid.org/anniesoft/toolanalysis:latest << EOF
+
+    cd /exp/annie/app/users/$user/$TA_folder
+
+    source Setup.sh
+
+    ./Analyse ./configfiles/$toolchain/ToolChainConfig
+
+    exit
+
+EOF
+
+	echo ""
+	ls -lrth /exp/annie/app/users/$user/$TA_folder
+	echo ""
+
+    # copy large root files from /annie/app area to some persistent or scratch area
+	mkdir -p $offload/$run
+
+    # setup transfer
+    source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setup
+    setup ifdhc v2_5_4
+
+    echo ""
+    echo "Copying ProcessedData Files..."
+    echo ""
+
+	ifdh cp /exp/annie/app/users/$user/$TA_folder/RWMBRFWaveforms.root $offload/$run/AmBeWaveforms_${run}_p${p_start}_p${p_end}.root
+    sleep 1
+	rm -rf /exp/annie/app/users/$user/$TA_folder/RWMBRFWaveforms.root
+
+	ls -lrth $offload/$run
+	echo ""
+
+	sleep 5
+
+
+echo ""
+echo "done"
+echo ""
+
+done

--- a/configfiles/AmBeWaveform/my_inputs.txt
+++ b/configfiles/AmBeWaveform/my_inputs.txt
@@ -1,0 +1,3 @@
+/pnfs/annie/persistent/processed/processed_EBV2/R4499/ProcessedData_PMT_R4499S0p0
+/pnfs/annie/persistent/processed/processed_EBV2/R4499/ProcessedData_PMT_R4499S0p1
+/pnfs/annie/persistent/processed/processed_EBV2/R4499/ProcessedData_PMT_R4499S0p2


### PR DESCRIPTION
## Describe your changes

Toolchain to extract small AmBe PMT waveforms to a root file. These waveforms are stored in the Booster RWM aux channel and are useful for rejecting backgrounds for the AmBe neutron analysis.

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [X] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [X] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
The `FitRWMWaveform` tool is designed to fit the Booster RF and Booster RWM waveforms from the beam. I am working to modify this tool so that it can do the background rejection in the actual tool and remove the need to store all those raw waveforms in a separate root file. Until that time comes, I have included a toolchain for the calibration folk to use to extract the small AmBe PMT waveforms. 

We will still need this toolchain even when those changes are made though. Config files will be modified accordingly.
