### PR TITLE
Adding weight branches necessary for uB comparison

### DIFF
--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -418,7 +418,12 @@ bool PhaseIITreeMaker::Initialise(std::string configfile, DataModel &data){
     if (Reweight_fill){
       fPhaseIITrigTree->Branch("XSecWeights",&fxsec_weights);
       fPhaseIITrigTree->Branch("FluxWeights",&fflux_weights);
-      fPhaseIITrigTree->Branch("weight_All_UBGenie",&fAll);
+      fPhaseIITrigTree->Branch("weight_All0_UBGenie",&fAll0);
+      fPhaseIITrigTree->Branch("weight_All1_UBGenie",&fAll1);
+      fPhaseIITrigTree->Branch("weight_All2_UBGenie",&fAll2);
+      fPhaseIITrigTree->Branch("weight_All3_UBGenie",&fAll3);
+      fPhaseIITrigTree->Branch("weight_All4_UBGenie",&fAll4);
+      fPhaseIITrigTree->Branch("weight_All5_UBGenie",&fAll5);
       fPhaseIITrigTree->Branch("weight_AxFFCCQEshape_UBGenie",&fAxFFCCQEshape);
       fPhaseIITrigTree->Branch("weight_DecayAngMEC_UBGenie",&fDecayAngMEC);
       fPhaseIITrigTree->Branch("weight_NormCCCOH_UBGenie",&fNormCCCOH);
@@ -899,7 +904,7 @@ bool PhaseIITreeMaker::Execute(){
     //DIGITS
     if(Digit_fill) this->LoadDigitHits();
     //DIGITS
-    /*/
+    /*
     if(Digit_fill){
        // get digits from RecoDigit store
        std::vector<RecoDigit>* digitList;
@@ -924,7 +929,7 @@ bool PhaseIITreeMaker::Execute(){
        Log("PhaseIITreeMaker Tool: Got "+to_string(totalPMTs)+" PMT digits; "+to_string(digitT.size()) +" total digits so far",v_debug,verbosity);
        Log("PhaseIITreeMaker Tool: Got "+to_string(totalLAPPDs)+" LAPPD digits; "+to_string(digitT.size()) +" total digits",v_debug,verbosity);
     }
-/*/
+*/
 
     if(MRDReco_fill){
       fNumClusterTracks=0;
@@ -1104,7 +1109,12 @@ void PhaseIITreeMaker::ResetVariables() {
   }
 
   if (Reweight_fill){
-    fAll.clear();
+    fAll0.clear();
+    fAll1.clear();
+    fAll2.clear();
+    fAll3.clear();
+    fAll4.clear();
+    fAll5.clear();
     fAxFFCCQEshape.clear();
     fDecayAngMEC.clear();
     fNormCCCOH.clear();
@@ -2146,7 +2156,12 @@ void PhaseIITreeMaker::FillWeightInfo() {
   bool get_xsec_weights = m_data->Stores.at("ANNIEEvent")->Get("xsec_weights",fxsec_weights);
   bool get_flux_weights = m_data->Stores.at("ANNIEEvent")->Get("flux_weights",fflux_weights);
   if (get_xsec_weights && get_flux_weights){
-    fAll = fxsec_weights["All"];
+    fAll0 = fxsec_weights["All0"];
+    fAll1 = fxsec_weights["All1"];
+    fAll2 = fxsec_weights["All2"];
+    fAll3 = fxsec_weights["All3"];
+    fAll4 = fxsec_weights["All4"];
+    fAll5 = fxsec_weights["All5"];
     fAxFFCCQEshape = fxsec_weights["AxFFCCQEshape"];
     fDecayAngMEC = fxsec_weights["DecayAngMEC"];
     fNormCCCOH = fxsec_weights["NormCCCOH"];

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.h
@@ -273,7 +273,12 @@ class PhaseIITreeMaker: public Tool {
   //Weights
   std::map<std::string, std::vector<double>> fxsec_weights;
   std::map<std::string, std::vector<double>> fflux_weights;
-  std::vector<double> fAll;
+  std::vector<double> fAll0;
+  std::vector<double> fAll1;
+  std::vector<double> fAll2;
+  std::vector<double> fAll3;
+  std::vector<double> fAll4;
+  std::vector<double> fAll5;
   std::vector<double> fAxFFCCQEshape;
   std::vector<double> fDecayAngMEC;
   std::vector<double> fNormCCCOH;


### PR DESCRIPTION
## Describe your changes
Adds weight branches to PhaseIITreeMaker. These branches are necessary to reflect all of MicroBooNE's XSec reweights for the joint analysis. These branches fit alongside existing weight branches and follows their conventions. Branch "weight_All_UBGenie" is removed because keeping it would create handling conflicts in STV-analysis (downstream of ToolAnalysis) code for joint cross-section plots. 

I also removed a couple forward slashes from a comment block in PhaseIITreeMaker. Doing so fixes a visual bug in vim below the comment block where everything was highlighted as a comment. This change does not uncomment anything, add any additional comments, or change the resultant PhaseIITree ntuple. 

## Checklist before submitting your PR
- [x] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [x] This PR alters the minimum number of files to affect this change
- [ NA ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ NA ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [x] For every `new` usage, there is a reason the data must be on the heap
- [x] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
NA
