### PR TITLE
Update config files for CC analysis toolchain

### DIFF
--- a/configfiles/CC_MC_RECO_ntuple/EventSelectorConfig
+++ b/configfiles/CC_MC_RECO_ntuple/EventSelectorConfig
@@ -6,7 +6,7 @@ MCFVCut 0
 MCPMTVolCut 0
 MCMRDCut 0
 MCPiKCut 0
-MCIsMuonCut 1
+MCIsMuonCut 0
 MCIsElectronCut 0
 MCIsSingleRingCut 0
 MCIsMultiRingCut 0
@@ -21,5 +21,6 @@ RecoFVCut 0
 RecoPMTVolCut 0
 PMTMRDCoincCut 0
 PMTMRDOffset 10
+TriggerWord 5
 SaveStatusToStore 1
 IsMC 1

--- a/configfiles/CC_MC_RECO_ntuple/FindMrdTracksConfig
+++ b/configfiles/CC_MC_RECO_ntuple/FindMrdTracksConfig
@@ -7,6 +7,6 @@ OutputDirectory .
 OutputFile mrdtrackfile  # the output file built will be '<OutputDirectory>/<OutputFile>.<Run>.<Subrun>.root'
 DrawTruthTracks 0        # whether to add MC Truth track info for drawing in MrdPaddlePlot Tool
                          ## note you need to run that tool to actually view the tracks!
-WriteTracksToFile 1      # should the track information be written to a ROOT-file?
+WriteTracksToFile 0      # should the track information be written to a ROOT-file?
 SelectTriggerType 0      # should the loaded data be filtered by trigger type?
 TriggerType Beam       # options: Cosmic, Beam, No Loopback

--- a/configfiles/CC_MC_RECO_ntuple/LoadGenieEventConfig
+++ b/configfiles/CC_MC_RECO_ntuple/LoadGenieEventConfig
@@ -1,15 +1,15 @@
-verbosity 1
+verbosity 0
 FluxVersion 1  # use 0 to load genie files based on bnb_annie_0000.root etc files
                # use 1 to load files based on beammc_annie_0000.root etc files
 #FileDir NA     # specify "NA" for newer files: full path is saved in WCSim
 #FileDir /pnfs/annie/persistent/users/vfischer/genie_files/BNB_Water_10k_22-05-17
 #FileDir /pnfs/annie/persistent/users/moflaher/genie/BNB_World_10k_11-03-18_gsimpleflux
-FileDir /pnfs/annie/persistent/simulations/genie3/G1810a0211a/standard/tank
-#FileDir .                     ## Use with grid
-FilePattern gntp.0.ghep.root  ## for specifying specific files to load
-#FilePattern LoadWCSimTool      ## use this pattern to load corresponding genie info with the LoadWCSimTool
+#FileDir /pnfs/annie/persistent/simulations/genie3/G1810a0211a/standard/tank
+FileDir .                     ## Use with grid
+#FilePattern gntp.0.ghep.root  ## for specifying specific files to load
+FilePattern LoadWCSimTool      ## use this pattern to load corresponding genie info with the LoadWCSimTool
                                ## N.B: FileDir must still be specified for now!
-ManualFileMatching 1           ## to manually match GENIE event to corresponding WCSim event
+ManualFileMatching 0           ## to manually match GENIE event to corresponding WCSim event
 FileEvents 1000                ## number of events in the WCSim file
                                ## 500 for Marcus files
                                ## 1000 for James files

--- a/configfiles/CC_MC_RECO_ntuple/LoadReweightGenieEventConfig
+++ b/configfiles/CC_MC_RECO_ntuple/LoadReweightGenieEventConfig
@@ -1,20 +1,20 @@
 # Reweightable GENIE cross section and beam flux model uncertainties
-# Revised 28 June 2024
+# Revised 19 Feb 2025
 #
 # Maintainer:James Minock <jminock1018@physics.rutgers.edu>
 
-verbosity 1
+verbosity 0
 FluxVersion 1  # use 0 to load genie files based on bnb_annie_0000.root etc files
                # use 1 to load files based on beammc_annie_0000.root etc files
 #FileDir NA     # specify "NA" for newer files: full path is saved in WCSim
 #FileDir /pnfs/annie/persistent/users/vfischer/genie_files/BNB_Water_10k_22-05-17
 #FileDir /pnfs/annie/persistent/users/moflaher/genie/BNB_World_10k_11-03-18_gsimpleflux
-FileDir /pnfs/annie/persistent/simulations/genie3/G1810a0211a/standard/tank
-#FileDir .                     ## Use with grid
-FilePattern gntp.0.ghep.root  ## for specifying specific files to load
-#FilePattern LoadWCSimTool      ## use this pattern to load corresponding genie info with the LoadWCSimTool
+#FileDir /pnfs/annie/persistent/simulations/genie3/G1810a0211a/standard/tank
+FileDir .                     ## Use with grid
+#FilePattern gntp.0.ghep.root  ## for specifying specific files to load
+FilePattern LoadWCSimTool      ## use this pattern to load corresponding genie info with the LoadWCSimTool
                                ## N.B: FileDir must still be specified for now!
-ManualFileMatching 1           ## to manually match GENIE event to corresponding WCSim event
+ManualFileMatching 0           ## to manually match GENIE event to corresponding WCSim event
 FileEvents 1000                ## number of events in the WCSim file
                                ## 500 for Marcus files
                                ## 1000 for James files
@@ -24,8 +24,7 @@ genie_module_label generator
 
 genie_central_values MaCCQE:4.9778|RPA_CCQE:0.151|NormCCMEC:1.31189|XSecShape_CCMEC:1.0
 
-weight_functions_xsec All,AxFFCCQEshape,DecayAngMEC,NormCCCOH,Norm_NCCOH,RPA_CCQE,RootinoFix,ThetaDelta2NRad,Theta_Delta2Npi,TunedCentralValue,VecFFCCQEshape,XSecShape_CCMEC
-#weight_functions_xsec All2
+weight_functions_xsec All0,All1,All2,All3,All4,All5,AxFFCCQEshape,DecayAngMEC,NormCCCOH,Norm_NCCOH,RPA_CCQE,RootinoFix,ThetaDelta2NRad,Theta_Delta2Npi,TunedCentralValue,VecFFCCQEshape,XSecShape_CCMEC
 
   # INDIVIDUAL WEIGHT CALCULATORS
   # Thse use "minmax" mode and represent a variation between two extremes. The
@@ -59,7 +58,14 @@ TunedCentralValue type:UBGenie|random_seed:99|parameter_list:["MaCCQE","RPA_CCQE
 RootinoFix type:UBGenie|random_seed:101|parameter_list:["RESRootino"]|parameter_sigma:[1]|mode:multisim|number_of_multisims:1
 
   # ALL OTHER RECOMMENDED SYSTEMATIC VARIATIONS THROWN TOGETHER
-All type:UBGenie|random_seed:100|parameter_list:["MaCCQE","CoulombCCQE","MaNCEL","EtaNCEL","NormCCMEC","NormNCMEC","FracPN_CCMEC","FracDelta_CCMEC","MaCCRES","MvCCRES","MaNCRES","MvNCRES","NonRESBGvpCC1pi","NonRESBGvpCC2pi","NonRESBGvpNC1pi","NonRESBGvpNC2pi","NonRESBGvnCC1pi","NonRESBGvnCC2pi","NonRESBGvnNC1pi","NonRESBGvnNC2pi","NonRESBGvbarpCC1pi","NonRESBGvbarpCC2pi","NonRESBGvbarpNC1pi","NonRESBGvbarpNC2pi","NonRESBGvbarnCC1pi","NonRESBGvbarnCC2pi","NonRESBGvbarnNC1pi","NonRESBGvbarnNC2pi","AhtBY","BhtBY","CV1uBY","CV2uBY","AGKYxF1pi","AGKYpT1pi","MFP_pi","MFP_N","FrCEx_pi","FrInel_pi","FrAbs_pi","FrCEx_N","FrInel_N","FrAbs_N","RDecBR1gamma","RDecBR1eta"]|parameter_sigma:[3.467735,1.5,1,1,1.0,2.0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]|mode:multisim|number_of_multisims:1000
+All0 type:UBGenie|random_seed:100|parameter_list:["MaCCQE","CoulombCCQE","MaNCEL","EtaNCEL","NormCCMEC","NormNCMEC","FracPN_CCMEC","FracDelta_CCMEC","MaCCRES","MvCCRES","MaNCRES","MvNCRES","NonRESBGvpCC1pi","NonRESBGvpCC2pi","NonRESBGvpNC1pi","NonRESBGvpNC2pi","NonRESBGvnCC1pi","NonRESBGvnCC2pi","NonRESBGvnNC1pi","NonRESBGvnNC2pi","NonRESBGvbarpCC1pi","NonRESBGvbarpCC2pi","NonRESBGvbarpNC1pi","NonRESBGvbarpNC2pi","NonRESBGvbarnCC1pi","NonRESBGvbarnCC2pi","NonRESBGvbarnNC1pi","NonRESBGvbarnNC2pi","AhtBY","BhtBY","CV1uBY","CV2uBY","AGKYxF1pi","AGKYpT1pi","MFP_pi","MFP_N","FrCEx_pi","FrInel_pi","FrAbs_pi","FrCEx_N","FrInel_N","FrAbs_N","RDecBR1gamma","RDecBR1eta"]|parameter_sigma:[3.467735,1.5,1,1,1.0,2.0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]|mode:multisim|number_of_multisims:100
 
-All2 type:UBGenie|random_seed:100|parameter_list:["MaCCQE","CoulombCCQE"]|parameter_sigma:[3.467735,1.5]|mode:multisim|number_of_multisims:10
+All1 type:UBGenie|random_seed:1101|parameter_list:["MaCCQE","CoulombCCQE","MaNCEL","EtaNCEL","NormCCMEC","NormNCMEC","FracPN_CCMEC","FracDelta_CCMEC","MaCCRES","MvCCRES","MaNCRES","MvNCRES","NonRESBGvpCC1pi","NonRESBGvpCC2pi","NonRESBGvpNC1pi","NonRESBGvpNC2pi","NonRESBGvnCC1pi","NonRESBGvnCC2pi","NonRESBGvnNC1pi","NonRESBGvnNC2pi","NonRESBGvbarpCC1pi","NonRESBGvbarpCC2pi","NonRESBGvbarpNC1pi","NonRESBGvbarpNC2pi","NonRESBGvbarnCC1pi","NonRESBGvbarnCC2pi","NonRESBGvbarnNC1pi","NonRESBGvbarnNC2pi","AhtBY","BhtBY","CV1uBY","CV2uBY","AGKYxF1pi","AGKYpT1pi","MFP_pi","MFP_N","FrCEx_pi","FrInel_pi","FrAbs_pi","FrCEx_N","FrInel_N","FrAbs_N","RDecBR1gamma","RDecBR1eta"]|parameter_sigma:[3.467735,1.5,1,1,1.0,2.0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]|mode:multisim|number_of_multisims:100
 
+All2 type:UBGenie|random_seed:1102|parameter_list:["MaCCQE","CoulombCCQE","MaNCEL","EtaNCEL","NormCCMEC","NormNCMEC","FracPN_CCMEC","FracDelta_CCMEC","MaCCRES","MvCCRES","MaNCRES","MvNCRES","NonRESBGvpCC1pi","NonRESBGvpCC2pi","NonRESBGvpNC1pi","NonRESBGvpNC2pi","NonRESBGvnCC1pi","NonRESBGvnCC2pi","NonRESBGvnNC1pi","NonRESBGvnNC2pi","NonRESBGvbarpCC1pi","NonRESBGvbarpCC2pi","NonRESBGvbarpNC1pi","NonRESBGvbarpNC2pi","NonRESBGvbarnCC1pi","NonRESBGvbarnCC2pi","NonRESBGvbarnNC1pi","NonRESBGvbarnNC2pi","AhtBY","BhtBY","CV1uBY","CV2uBY","AGKYxF1pi","AGKYpT1pi","MFP_pi","MFP_N","FrCEx_pi","FrInel_pi","FrAbs_pi","FrCEx_N","FrInel_N","FrAbs_N","RDecBR1gamma","RDecBR1eta"]|parameter_sigma:[3.467735,1.5,1,1,1.0,2.0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]|mode:multisim|number_of_multisims:100
+
+All3 type:UBGenie|random_seed:1103|parameter_list:["MaCCQE","CoulombCCQE","MaNCEL","EtaNCEL","NormCCMEC","NormNCMEC","FracPN_CCMEC","FracDelta_CCMEC","MaCCRES","MvCCRES","MaNCRES","MvNCRES","NonRESBGvpCC1pi","NonRESBGvpCC2pi","NonRESBGvpNC1pi","NonRESBGvpNC2pi","NonRESBGvnCC1pi","NonRESBGvnCC2pi","NonRESBGvnNC1pi","NonRESBGvnNC2pi","NonRESBGvbarpCC1pi","NonRESBGvbarpCC2pi","NonRESBGvbarpNC1pi","NonRESBGvbarpNC2pi","NonRESBGvbarnCC1pi","NonRESBGvbarnCC2pi","NonRESBGvbarnNC1pi","NonRESBGvbarnNC2pi","AhtBY","BhtBY","CV1uBY","CV2uBY","AGKYxF1pi","AGKYpT1pi","MFP_pi","MFP_N","FrCEx_pi","FrInel_pi","FrAbs_pi","FrCEx_N","FrInel_N","FrAbs_N","RDecBR1gamma","RDecBR1eta"]|parameter_sigma:[3.467735,1.5,1,1,1.0,2.0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]|mode:multisim|number_of_multisims:100
+
+All4 type:UBGenie|random_seed:1104|parameter_list:["MaCCQE","CoulombCCQE","MaNCEL","EtaNCEL","NormCCMEC","NormNCMEC","FracPN_CCMEC","FracDelta_CCMEC","MaCCRES","MvCCRES","MaNCRES","MvNCRES","NonRESBGvpCC1pi","NonRESBGvpCC2pi","NonRESBGvpNC1pi","NonRESBGvpNC2pi","NonRESBGvnCC1pi","NonRESBGvnCC2pi","NonRESBGvnNC1pi","NonRESBGvnNC2pi","NonRESBGvbarpCC1pi","NonRESBGvbarpCC2pi","NonRESBGvbarpNC1pi","NonRESBGvbarpNC2pi","NonRESBGvbarnCC1pi","NonRESBGvbarnCC2pi","NonRESBGvbarnNC1pi","NonRESBGvbarnNC2pi","AhtBY","BhtBY","CV1uBY","CV2uBY","AGKYxF1pi","AGKYpT1pi","MFP_pi","MFP_N","FrCEx_pi","FrInel_pi","FrAbs_pi","FrCEx_N","FrInel_N","FrAbs_N","RDecBR1gamma","RDecBR1eta"]|parameter_sigma:[3.467735,1.5,1,1,1.0,2.0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]|mode:multisim|number_of_multisims:100
+
+All5 type:UBGenie|random_seed:1105|parameter_list:["MaCCQE","CoulombCCQE","MaNCEL","EtaNCEL","NormCCMEC","NormNCMEC","FracPN_CCMEC","FracDelta_CCMEC","MaCCRES","MvCCRES","MaNCRES","MvNCRES","NonRESBGvpCC1pi","NonRESBGvpCC2pi","NonRESBGvpNC1pi","NonRESBGvpNC2pi","NonRESBGvnCC1pi","NonRESBGvnCC2pi","NonRESBGvnNC1pi","NonRESBGvnNC2pi","NonRESBGvbarpCC1pi","NonRESBGvbarpCC2pi","NonRESBGvbarpNC1pi","NonRESBGvbarpNC2pi","NonRESBGvbarnCC1pi","NonRESBGvbarnCC2pi","NonRESBGvbarnNC1pi","NonRESBGvbarnNC2pi","AhtBY","BhtBY","CV1uBY","CV2uBY","AGKYxF1pi","AGKYpT1pi","MFP_pi","MFP_N","FrCEx_pi","FrInel_pi","FrAbs_pi","FrCEx_N","FrInel_N","FrAbs_N","RDecBR1gamma","RDecBR1eta"]|parameter_sigma:[3.467735,1.5,1,1,1.0,2.0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]|mode:multisim|number_of_multisims:100

--- a/configfiles/CC_MC_RECO_ntuple/LoadWCSimConfig
+++ b/configfiles/CC_MC_RECO_ntuple/LoadWCSimConfig
@@ -10,8 +10,8 @@ verbose 1
 
 #InputFile /annie/app/users/jminock/ToolAnalysis/wcsim_0.root
 #InputFile /pnfs/annie/persistent/users/mnieslon/wcsim/output/tankonly/wcsim_ANNIEp2v7_beamlike/wcsim_beamlike_muon_0.100.root
-InputFile /pnfs/annie/persistent/simulations/wcsim/G1810a0211a/standard/tank/pmt/wcsim_0.0.0.root
-#InputFile ./wcsim_0.*.root
+#InputFile /pnfs/annie/persistent/simulations/wcsim/G1810a0211a/standard/tank/pmt/wcsim_0.0.0.root
+InputFile ./wcsim_0.0.0.root
 #InputFile /pnfs/annie/persistent/users/mnieslon/wcsim/output/tankonly/wcsim_ANNIEp2v7_beam/pmt-files/wcsim_beam_gst_1060_91_0.7091.root
 
 WCSimVersion 3               ## should reflect the WCSim version of the files being loaded

--- a/configfiles/CC_MC_RECO_ntuple/LoadWCSimLAPPDConfig
+++ b/configfiles/CC_MC_RECO_ntuple/LoadWCSimLAPPDConfig
@@ -5,8 +5,8 @@ verbose 0
 #InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_24-09-17_BNB_Water_10k_22-05-17/wcsim_lappd_0.49......19.root
 #InputFile /pnfs/annie/persistent/users/moflaher/wcsim/lappd/tankonly/wcsim_lappd_tankonly_03-05-17_rhatcher/wcsim_lappd_0.49......00.root      ## first of the DOE proposal files
 #InputFile /pnfs/annie/persistent/users/mnieslon/wcsim/output/tankonly/wcsim_ANNIEp2v7_beamlike/wcsim_beamlike_muon_lappd_0.100.root
-InputFile /pnfs/annie/persistent/simulations/wcsim/G1810a0211a/standard/tank/lappd/wcsim_lappd_0.0.0.root
-#InputFile ./wcsim_lappd_0.*.root
+#InputFile /pnfs/annie/persistent/simulations/wcsim/G1810a0211a/standard/tank/lappd/wcsim_lappd_0.0.0.root
+InputFile ./wcsim_lappd_0.0.0.root
 #InputFile /annie/app/users/jminock/ToolAnalysis/wcsim_lappd_0.root
 
 WCSimVersion 3               ## should reflect the WCSim version of the files being loaded

--- a/configfiles/CC_MC_RECO_ntuple/MCRecoEventLoaderConfig
+++ b/configfiles/CC_MC_RECO_ntuple/MCRecoEventLoaderConfig
@@ -1,10 +1,10 @@
 # MCRecoEventLoader config file
 
-verbosity 1
+verbosity 0
 GetPionKaonInfo 1
 GetNRings 1
 ParticleID 13
-DoParticleSelection 1
+DoParticleSelection 0
 xshift 0.0
 yshift 14.46469
 zshift -168.1


### PR DESCRIPTION
## Describe your changes
Updates to CC analysis ToolChain config files to reflect needs of analysis and updated Tools.

EventSelector: Added TriggerWord to satisfy changes in PR #311 and turning off cuts to include potential background events.

FindMrdTracks: Output file is not necessary for CC analysis. Turning off to reduce clutter.

LoadGenieEvent: Verbosity turned down to reduce terminal clutter; can be turned up if needed. Everything else is to load in GENIE file in pwd and automatically match events to corresponding wcsim events. This allows correct GENIE to WCSim event alignment for tank and world samples. Previous configuration only worked for tank samples.

LoadReweightGenieEvent: Same as above. Also includes new weight configuration to match uB. Additional "All" weights are necessary with respective random seeds. Furthermore, the number of universes for "All" was decreased from 1000 to 100. So in addition to matching uB for joint analysis, run time is faster and the resultant ntuple file will take up less space.

LoadWCSim: Loads in WCSim file in pwd. Defaults to run 0, subrun 0. A bug exists where LoadWCSim cannot load in WCSim files from /pnfs/ directly.

LoadWCSimLAPPD: Same as above.

MCRecoEventLoader: Verbosity turned down to reduce terminal clutter; can be turned up if needed. Turning of particle selection to include potential background events.

ToolChain can run with all changes implemented.

## Checklist before submitting your PR
- [x] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [x] This PR alters the minimum number of files to affect this change
- [ NA ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ NA ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ NA ] For every `new` usage, there is a reason the data must be on the heap
- [ NA ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
NA
