### PR TITLE
Fix out-of-bounds access in LAPPDStoreFindT0::Tfit when i = 6

### DIFF
--- a/UserTools/LAPPDFindT0/LAPPDFindT0.cpp
+++ b/UserTools/LAPPDFindT0/LAPPDFindT0.cpp
@@ -181,7 +181,7 @@ double LAPPDFindT0::Tfit(std::vector<double>* wf)
     if(FindT0VerbosityLevel==2) cout<<i<<" "<<ppre<<" "<<pvol<<" "<<T0signalmax<<endl;
 
     if(oldLaser == 1){
-        if(firstcross && pvol > T0signalmax && ppre < T0signalmax && i>5 && i<250){ //trigger up to +200 2020 data
+        if(firstcross && pvol > T0signalmax && ppre < T0signalmax && i>6 && i<250){ //trigger up to +200 2020 data
           if(FindT0VerbosityLevel>1) cout<<"Old t0 bin: "<<i<<endl;
           TGraph *edge = new TGraph();
           for(int j=-7; j<1; j++){
@@ -200,7 +200,7 @@ double LAPPDFindT0::Tfit(std::vector<double>* wf)
       }
     }else{
 
-      if(firstcross && pvol < T0signalmax && ppre > T0signalmax && i>5 && i<250){
+      if(firstcross && pvol < T0signalmax && ppre > T0signalmax && i>6 && i<250){
 
           if(FindT0VerbosityLevel>1) cout<<"New t0 bin: "<<i<<endl;
 


### PR DESCRIPTION
## Describe your changes

In line 188, wf->at(i-7) causes an out-of-bounds access when i = 6, leading to a potential crash. Similarly, the same issue occurs in line 209.

## Checklist before submitting your PR
- [ ] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [ ] This PR alters the minimum number of files to affect this change
- [ ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ ] For every `new` usage, there is a reason the data must be on the heap
- [ ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Attach any validation or demonstration files here. You may also link to relavant docdb articles.
