### PR TITLE
Fixing bug in PhaseIITreeMaker.cpp

### DIFF
--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -1529,8 +1529,8 @@ void PhaseIITreeMaker::LoadDigitHits(){
           }
    // Extract the PMT & LAPPD digit information
    // ===============================
-        NDigitsPMTs = 0; // number of digits from PMT hits in the event
-        NDigitsLAPPDs = 0; // number of digits from LAPPD hits in the event
+        fNDigitsPMTs = 0; // number of digits from PMT hits in the event
+        fNDigitsLAPPDs = 0; // number of digits from LAPPD hits in the event
   //loop through all digits
         for(RecoDigit &adigit : *digitList){
 	   fdigitX.push_back(adigit.GetPosition().X());
@@ -1540,8 +1540,8 @@ void PhaseIITreeMaker::LoadDigitHits(){
 	   if(adigit.GetDigitType()==0){fNDigitsPMTs+=1;} //when the digit type is zero we have a PMT digit
 	   else{fNDigitsLAPPDs+=1;}// when it is 1 we have LAPPD
            }
-        Log("PhaseIITreeMaker Tool: Got "+to_string(NDigitsPMTs)+" PMT digits; "+to_string(fdigitT.size()) +" total digits so far",v_debug,verbosity);
-        Log("PhaseIITreeMaker Tool: Got "+to_string(NDigitsLAPPDs)+" LAPPD digits; "+to_string(fdigitT.size()) +" total digits",v_debug,verbosity);
+        Log("PhaseIITreeMaker Tool: Got "+to_string(fNDigitsPMTs)+" PMT digits; "+to_string(fdigitT.size()) +" total digits so far",v_debug,verbosity);
+        Log("PhaseIITreeMaker Tool: Got "+to_string(fNDigitsLAPPDs)+" LAPPD digits; "+to_string(fdigitT.size()) +" total digits",v_debug,verbosity);
    return;
 }       
 //DIGITS

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -1529,8 +1529,8 @@ void PhaseIITreeMaker::LoadDigitHits(){
           }
    // Extract the PMT & LAPPD digit information
    // ===============================
-        int totalPMTs =0; // number of digits from PMT hits in the event
-        int totalLAPPDs = 0; // number of digits from LAPPD hits in the event
+        NDigitsPMTs = 0; // number of digits from PMT hits in the event
+        NDigitsLAPPDs = 0; // number of digits from LAPPD hits in the event
   //loop through all digits
         for(RecoDigit &adigit : *digitList){
 	   fdigitX.push_back(adigit.GetPosition().X());
@@ -1540,8 +1540,8 @@ void PhaseIITreeMaker::LoadDigitHits(){
 	   if(adigit.GetDigitType()==0){fNDigitsPMTs+=1;} //when the digit type is zero we have a PMT digit
 	   else{fNDigitsLAPPDs+=1;}// when it is 1 we have LAPPD
            }
-        Log("PhaseIITreeMaker Tool: Got "+to_string(totalPMTs)+" PMT digits; "+to_string(fdigitT.size()) +" total digits so far",v_debug,verbosity);
-        Log("PhaseIITreeMaker Tool: Got "+to_string(totalLAPPDs)+" LAPPD digits; "+to_string(fdigitT.size()) +" total digits",v_debug,verbosity);
+        Log("PhaseIITreeMaker Tool: Got "+to_string(NDigitsPMTs)+" PMT digits; "+to_string(fdigitT.size()) +" total digits so far",v_debug,verbosity);
+        Log("PhaseIITreeMaker Tool: Got "+to_string(NDigitsLAPPDs)+" LAPPD digits; "+to_string(fdigitT.size()) +" total digits",v_debug,verbosity);
    return;
 }       
 //DIGITS

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -989,8 +989,8 @@ void PhaseIITreeMaker::ResetVariables() {
   fEventNumber = -9999;
   fEventTimeTank_Tree = 9999;
   fNHits = -9999;
-  fNDigitsPMTs = -9999;
-  fNDigitsLAPPDs = -9999;
+  fNDigitsPMTs = 0;
+  fNDigitsLAPPDs = 0;
   fVetoHit = -9999;
   fEventTimeMRD_Tree = 9999;
   fTriggerword = -1;
@@ -1529,8 +1529,6 @@ void PhaseIITreeMaker::LoadDigitHits(){
           }
    // Extract the PMT & LAPPD digit information
    // ===============================
-        fNDigitsPMTs = 0; // number of digits from PMT hits in the event
-        fNDigitsLAPPDs = 0; // number of digits from LAPPD hits in the event
   //loop through all digits
         for(RecoDigit &adigit : *digitList){
 	   fdigitX.push_back(adigit.GetPosition().X());


### PR DESCRIPTION
NDigitsPMTs and NDigitsLAPPDs are initialized to -9999. Then, they are incremented in order to count the number of PMT/LAPPD digits in the event. But this way, there is a -9999 offset to their values. So I initialize them to 0 before incrementing. Also I removed the totalPMTs and totalLAPPDs variables because they are basically not used.

## Describe your changes

## Checklist before submitting your PR
- [ ] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [ ] This PR alters the minimum number of files to affect this change
- [ ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ ] For every `new` usage, there is a reason the data must be on the heap
- [ ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Attach any validation or demonstration files here. You may also link to relavant docdb articles.
