### PR TITLE
Update BFV2 for fetching on many raw part files

### DIFF
--- a/UserTools/BeamFetcherV2/BeamFetcherV2.cpp
+++ b/UserTools/BeamFetcherV2/BeamFetcherV2.cpp
@@ -239,7 +239,25 @@ bool BeamFetcherV2::FetchFromTrigger()
   }
 
   if (fDeleteCTCData)
+  {
+    uint64_t FirstTriggerTimestamp = TimeToTriggerWordMap->begin()->first;
+    const uint64_t MAX_CACHE_DURATION_MS = 1200000; // save only 20 mins of data maximum
+    uint64_t minTimestampAllowed = FirstTriggerTimestamp - MAX_CACHE_DURATION_MS;
+    if (!BeamDataQuery.empty())
+    {
+      std::map<uint64_t, std::map<std::string, BeamDataPoint>> newBeamDataQuery;
+      for (auto it = BeamDataQuery.lower_bound(minTimestampAllowed); it != BeamDataQuery.end(); ++it)
+      {
+        newBeamDataQuery.emplace(*it); 
+      }
+    }
+    BeamDataQuery.swap(newBeamDataQuery); // swap and release memory
+
     TimeToTriggerWordMap->clear();
+    std::map<uint64_t, std::vector<uint32_t>> *TimeToTriggerWordMapComplete = nullptr;
+    m_data->CStore.Get("TimeToTriggerWordMapComplete", TimeToTriggerWordMapComplete);
+    TimeToTriggerWordMapComplete->clear();
+  }
 
   return true;
 }


### PR DESCRIPTION
## Describe your changes
Add a memory clean for BeamDataQuery map, also clean the TimeToTriggerWordMapComplete from trigger data decoder. Now we can run BFV2 for the whole run to avoid the entry lost issue at the beginning of processing.

## Checklist before submitting your PR
- [ x ] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [ x ] This PR alters the minimum number of files to affect this change
- [ x ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ x ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ x ] For every `new` usage, there is a reason the data must be on the heap
- [ x ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)


