### PR TITLE
Add script to populate list file for BFV2 toolchain

### DIFF
--- a/configfiles/BeamFetcherV2/CreateMyList.sh
+++ b/configfiles/BeamFetcherV2/CreateMyList.sh
@@ -1,0 +1,19 @@
+if [ "$#" -ne 1 ]; then
+      echo "Usage: ./CreateMyList.sh RUN"
+      echo "Specified input variable must contain the run number"
+      exit 1
+fi
+
+RUN=$1
+DIR=/pnfs/annie/persistent/raw/raw/
+
+NUMFILES=$(ls -1q ${DIR}${RUN}/RAWDataR${RUN}* | wc -l)
+
+echo "NUMBER OF FILES IN ${DIR}${RUN}: ${NUMFILES}"
+
+rm my_files.txt
+
+for p in $(seq 0 $(($NUMFILES -1 )))
+do
+	echo "${DIR}${RUN}/RAWDataR${RUN}S0p${p}" >> my_files.txt
+done


### PR DESCRIPTION
`BeamFetcherV2` toolchain uses the `LoadANNIEEvent` tool to read raw data files and load their info to the store. The tool requires populating a list file with the relevant part files. I have added (copied from the `PreProcessTrigOverlap` toolchain) a simple bash script to populate the list file automatically with all available raw part files for a given run.

Usage: ./CreateMyList.sh RUN

## Describe your changes

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [N/A] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)
