### PR TITLE
update makefile to support ToolChain folders embedded in a subdirectory within configfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 ToolDAQPath=${PWD}/ToolDAQ
 
-ifeq ($(TOOLCHAIN),)
 TOOLCHAIN:=$(shell find ./configfiles -type d -path ./configfiles/$(MAKECMDGOALS) -exec echo {} \; 2>/dev/null)
 TOOLCHAINNAME:=$(subst ./configfiles/,,$(TOOLCHAIN))
 $(info TOOLCHAINNAME: $(TOOLCHAINNAME))
@@ -16,7 +15,6 @@ NPROCS:=$(shell nproc --all)
 GIT_VERSION := "$(shell git describe --dirty --always)"
 # forward these to variables to internal $(MAKE) calls
 export
-endif
 
 ifeq ($(TOOLCHAIN),)
 TOOLCHAIN:=Dummy

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,13 @@ ToolDAQPath=${PWD}/ToolDAQ
 
 ifeq ($(TOOLCHAIN),)
 TOOLCHAIN:=$(shell find ./configfiles -type d -path ./configfiles/$(MAKECMDGOALS) -exec echo {} \; 2>/dev/null)
+TOOLCHAINNAME:=$(subst ./configfiles/,,$(TOOLCHAIN))
+$(info TOOLCHAINNAME: $(TOOLCHAINNAME))
+ifneq ($(MAKECMDGOALS),clean)
 TOOLS:=$(shell ./gettools.sh $(TOOLCHAIN))
 #OBJECTS:=$(foreach tool,$(TOOLS),UserTools/$(tool)/$(tool).o)
 OBJECTS:=$(shell ./getobjects.sh $(TOOLS))
+endif
 $(info TOOLCHAIN: $(TOOLCHAIN))
 $(info TOOLS needed: $(TOOLS))
 $(info OBJECTS: $(OBJECTS))
@@ -207,7 +211,7 @@ DataModel/%.o: DataModel/%.cpp lib/libLogging.so lib/libStore.so include/Tool.h
 	@echo -e "\n*************** Making " $@ "****************"
 	-$(CCC) -c -o $@ $< -I include -L lib -lStore -lLogging  $(DataModelInclude) $(DataModelLib) $(ZMQLib) $(ZMQInclude) $(BoostLib) $(BoostInclude)
 
-UserTools/MyFactory/Unity.h: configfiles/$(TOOLCHAIN)/ToolsConfig
+UserTools/MyFactory/Unity.h: $(TOOLCHAIN)/ToolsConfig
 	@echo "Generating $@ for ToolChain $(TOOLCHAIN)"
 	@mkdir -p UserTools/MyFactory
 	@echo "//$(TOOLCHAIN)" > $@
@@ -218,7 +222,7 @@ UserTools/MyFactory/Unity.h: configfiles/$(TOOLCHAIN)/ToolsConfig
 
 
 
-UserTools/MyFactory/MyFactory.cpp: UserTools/MyFactory/Unity.h configfiles/$(TOOLCHAIN)/ToolsConfig
+UserTools/MyFactory/MyFactory.cpp: UserTools/MyFactory/Unity.h $(TOOLCHAIN)/ToolsConfig
 	@echo "Generating $@ for ToolChain $(TOOLCHAIN)"
 	@cp UserTools/Factory/Factory.h UserTools/MyFactory/Factory.h
 	@echo '#include "Factory.h"' > $@
@@ -230,8 +234,9 @@ UserTools/MyFactory/MyFactory.cpp: UserTools/MyFactory/Unity.h configfiles/$(TOO
 	echo 'return ret;' >> $@;\
 	echo '}' >> $@
 
-%:: configfiles/%/ToolsConfig
-	if [[ `head -n1 UserTools/MyFactory/Unity.h | sed s://::` != "$(TOOLCHAIN)" ]]; then rm -rf UserTools/MyFactory/Unity.h  UserTools/MyFactory/MyFactory.cpp UserTools/MyFactory/MyFactory.o; fi
+$(TOOLCHAINNAME):: $(TOOLCHAIN)/ToolsConfig
+	@echo "Target $@"
+	@if [[ `head -n1 UserTools/MyFactory/Unity.h 2>/dev/null | sed s://::` != "$(TOOLCHAIN)" ]]; then rm -rf UserTools/MyFactory/Unity.h  UserTools/MyFactory/MyFactory.cpp UserTools/MyFactory/MyFactory.o; fi
 	@echo "making NEW"
 	@if [ ! -z "$(TOOLCHAIN)" ]; then echo "making ToolChain $(TOOLCHAIN)";fi
 	@# check tools file exists

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ToolDAQPath=${PWD}/ToolDAQ
 
 ifeq ($(TOOLCHAIN),)
-TOOLCHAIN:=$(shell find ./configfiles -type d -name $(MAKECMDGOALS) -exec echo {} \; 2>/dev/null)
+TOOLCHAIN:=$(shell find ./configfiles -type d -path ./configfiles/$(MAKECMDGOALS) -exec echo {} \; 2>/dev/null)
 TOOLS:=$(shell ./gettools.sh $(TOOLCHAIN))
 #OBJECTS:=$(foreach tool,$(TOOLS),UserTools/$(tool)/$(tool).o)
 OBJECTS:=$(shell ./getobjects.sh $(TOOLS))

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 ToolDAQPath=${PWD}/ToolDAQ
 
 ifeq ($(TOOLCHAIN),)
-TOOLCHAIN:=$(shell find ./configfiles -type d -name $(MAKECMDGOALS) -exec basename {} \; 2>/dev/null)
+TOOLCHAIN:=$(shell find ./configfiles -type d -name $(MAKECMDGOALS) -exec echo {} \; 2>/dev/null)
 TOOLS:=$(shell ./gettools.sh $(TOOLCHAIN))
 #OBJECTS:=$(foreach tool,$(TOOLS),UserTools/$(tool)/$(tool).o)
 OBJECTS:=$(shell ./getobjects.sh $(TOOLS))
-#$(info TOOLCHAIN: $(TOOLCHAIN))
+$(info TOOLCHAIN: $(TOOLCHAIN))
 $(info TOOLS needed: $(TOOLS))
 $(info OBJECTS: $(OBJECTS))
 NPROCS:=$(shell nproc --all)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ToolDAQPath=${PWD}/ToolDAQ
 
+ifeq ($(TOOLCHAIN),)
 TOOLCHAIN:=$(shell find ./configfiles -type d -path ./configfiles/$(MAKECMDGOALS) -exec echo {} \; 2>/dev/null)
 TOOLCHAINNAME:=$(subst ./configfiles/,,$(TOOLCHAIN))
 $(info TOOLCHAINNAME: $(TOOLCHAINNAME))
@@ -15,6 +16,7 @@ NPROCS:=$(shell nproc --all)
 GIT_VERSION := "$(shell git describe --dirty --always)"
 # forward these to variables to internal $(MAKE) calls
 export
+endif
 
 ifeq ($(TOOLCHAIN),)
 TOOLCHAIN:=./configfiles/Dummy

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,14 @@ GIT_VERSION := "$(shell git describe --dirty --always)"
 export
 
 ifeq ($(TOOLCHAIN),)
-TOOLCHAIN:=Dummy
+TOOLCHAIN:=./configfiles/Dummy
+TOOLCHAINNAME:=Dummy
 endif
 
 CPPFLAGS= -fmax-errors=1 -DVERSION=\"$(GIT_VERSION)\" -Wno-reorder -Wno-sign-compare -Wno-unused-variable -Wno-unused-but-set-variable -Werror=return-type -Wl,--no-as-needed
 
-CC=g++ -std=c++1y -O3 -fPIC -shared $(CPPFLAGS)
-CCC= g++ -std=c++1y -O3 -fPIC  $(CPPFLAGS)
+CC=g++ -std=c++1y -g -O3 -fPIC -shared $(CPPFLAGS)
+CCC= g++ -std=c++1y -g -O3 -fPIC  $(CPPFLAGS)
 
 
 ZMQLib= -L $(ToolDAQPath)/zeromq-4.0.7/lib -lzmq

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ To compile only the DataModel objects and those Tools needed for a toolchain 'My
 make -j$(nproc) MyToolChain
 ```
 
+or for a ToolChain within a hierarchy, e.g. a toolchain described by `./configfiles/EnergyReco/Predict/ToolChainConfig`
+```
+make -j$(nproc) EnergyReco/Predict
+```
+
 Note that compilation can take some time. After the first initial build:
 * If only files in the UserTools have been modified, only the modified Tools will be rebuilt, along with libMyTools.so and the Analyse application.
 * If anything in the DataModel has been modified, those DataModel objects will need to be rebuilt, along with libDataModel.so, ALL Tools, libMyTool.so and Analyse. This will be considerably slower (building all Tools takes a long time), and is where building a specific toolchain can help speed things up.

--- a/gettools.sh
+++ b/gettools.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-if [ $# -eq 0 ] || [ ! -f "configfiles/$1/ToolsConfig" ]; then
+TOOLCHAIN="${1##./configfiles/}"
+#echo "get tools for toolchain '${TOOLCHAIN}'"
+if [ $# -eq 0 ] || [ ! -f "configfiles/$TOOLCHAIN/ToolsConfig" ]; then
 	DIRS=( $(find -L UserTools -maxdepth 1 -mindepth 1 -type d -exec basename {} \; | grep -v -e Factory -e template -e InactiveTools) )
 	declare -a TOOLS;
 	# filter out python tools as they do not need to go into Unity/Factory
@@ -20,7 +22,7 @@ if [ $# -eq 0 ] || [ ! -f "configfiles/$1/ToolsConfig" ]; then
 	echo "${TOOLS[@]}"
 	#ls UserTools/*/*.cpp | sed 's/.cpp$//' | xargs -n1 basename | grep -v -e Factory -e template -e InactiveTools
 else
-	#echo "getting tools needed for toolchain $1" >&2
+	#echo "getting tools needed for toolchain $TOOLCHAIN" >&2
         # parse into bash array
 	declare -a TOOLS;
 	while read -r line; do
@@ -30,6 +32,6 @@ else
 		TOOL=$(echo "${line}" | cut -d' ' -f 2)
 		TOOLS+=( "${TOOL}" )
 		#echo "adding tool ${TOOL}"  >&2
-	done < <(cat "./configfiles/$1/ToolsConfig")
+	done < <(cat "./configfiles/$TOOLCHAIN/ToolsConfig")
 	echo "${TOOLS[@]}"
 fi

--- a/gettools.sh
+++ b/gettools.sh
@@ -19,7 +19,9 @@ if [ $# -eq 0 ] || [ ! -f "configfiles/$TOOLCHAIN/ToolsConfig" ]; then
 		TOOLS+=( "${TOOLNAME}" )
 	done
 	
-	echo "${TOOLS[@]}"
+	#echo "${TOOLS[@]}"
+	UNIQUE_TOOLS=( $(for ATOOL in "${TOOLS[@]}"; do echo "${ATOOL}"; done | sort -u) )
+	echo "${UNIQUE_TOOLS[@]}"
 	#ls UserTools/*/*.cpp | sed 's/.cpp$//' | xargs -n1 basename | grep -v -e Factory -e template -e InactiveTools
 else
 	#echo "getting tools needed for toolchain $TOOLCHAIN" >&2
@@ -33,5 +35,7 @@ else
 		TOOLS+=( "${TOOL}" )
 		#echo "adding tool ${TOOL}"  >&2
 	done < <(cat "./configfiles/$TOOLCHAIN/ToolsConfig")
-	echo "${TOOLS[@]}"
+	#echo "${TOOLS[@]}"
+	UNIQUE_TOOLS=( $(for ATOOL in "${TOOLS[@]}"; do echo "${ATOOL}"; done | sort -u) )
+	echo "${UNIQUE_TOOLS[@]}"
 fi


### PR DESCRIPTION
## Describe your changes
Update to allow `make ToolChainName` to work with toolchains embedded in subfolders e.g. `./configfiles/EnergyReco/Predict`
Note usage in this case would be `make EnergyReco/Predict` - i.e. specify the relative hierarchy within configfiles

## Checklist before submitting your PR
- [✓] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [✓] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [N/A] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

