### PR TITLE
Fix PMTWaveformSim event skipping

### DIFF
--- a/UserTools/AssignBunchTimingMC/AssignBunchTimingMC.cpp
+++ b/UserTools/AssignBunchTimingMC/AssignBunchTimingMC.cpp
@@ -99,16 +99,6 @@ bool AssignBunchTimingMC::Execute()
         std::cout << "AssignBunchTimingMC: Executing tool..." << std::endl;
     }
 
-    // An upstream tool may opt to skip this execution stage
-    // For example the PMTWaveformSim tool will skip events with no MCHits or if
-    // no waveforms are produced.
-    bool skip = false;
-    bool got_skip_status = m_data->Stores["ANNIEEvent"]->Get("SkipExecute", skip);
-    if (got_skip_status && skip) {
-        Log("AssignBunchTimingMC: An upstream tool told me to skip this event.",v_warning,verbosity);
-        return true;
-    } 
-
     if (!LoadStores())      // Load info from store
         return false;
     if (verbosity >= v_debug) {

--- a/UserTools/ClusterClassifiers/ClusterClassifiers.cpp
+++ b/UserTools/ClusterClassifiers/ClusterClassifiers.cpp
@@ -35,15 +35,6 @@ bool ClusterClassifiers::Initialise(std::string configfile, DataModel &data){
 
 bool ClusterClassifiers::Execute(){
 
-  //We're gonna make ourselves a couple cluster classifier maps boyeeee
-  bool skip = false;
-  bool goodSkipStatus = m_data->Stores.at("ANNIEEvent")->Get("SkipExecute", skip);
-  if (goodSkipStatus && skip) {
-    logmessage = "ClusterClassifier: An upstream tool told me to skip this event.";
-    Log(logmessage, v_warning, verbosity);
-    return true;
-  }
-
   if(verbosity>4) std::cout << "ClusterClassifiers tool: Accessing cluster map in CStore" << std::endl;
   bool get_clusters = false;
   m_data->CStore.Get("ClusterMap",m_all_clusters);

--- a/UserTools/ClusterFinder/ClusterFinder.cpp
+++ b/UserTools/ClusterFinder/ClusterFinder.cpp
@@ -165,16 +165,6 @@ bool ClusterFinder::Execute(){
   //----------------------------------------------------------------------------
   //---------------get the members of the ANNIEEvent----------------------------
   //----------------------------------------------------------------------------
-
-  // An upstream tool may opt to skip this execution stage
-  // For example the PMTWaveformSim tool will skip events with no MCHits or if
-  // no waveforms are produced.
-  bool skip = false;
-  bool got_skip_status = m_data->Stores["ANNIEEvent"]->Get("SkipExecute", skip);
-  if (got_skip_status && skip) {
-    Log("ClusterFinder: An upstream tool told me to skip this event.",v_warning,verbose);
-    return true;
-  } 
   
   m_data->Stores["ANNIEEvent"]->Get("EventNumber", evnum);
   //m_data->Stores["ANNIEEvent"]->Get("BeamStatus", BeamStatus);

--- a/UserTools/PMTWaveformSim/PMTWaveformSim.cpp
+++ b/UserTools/PMTWaveformSim/PMTWaveformSim.cpp
@@ -97,11 +97,51 @@ bool PMTWaveformSim::Execute()
 {
   int load_status = LoadFromStores();
 
-  
+  if (load_status == 0) return false;
+
   // The container for the data that we'll put into the ANNIEEvent
   std::map<unsigned long, std::vector<Waveform<uint16_t>> > RawADCDataMC;
   std::map<unsigned long, std::vector<CalibratedADCWaveform<double>> > CalADCDataMC;
 
+
+  // If MCHits is empty (load_status == 2), create one minimal baseline waveform so that the hit finder doesn't freak out
+  // while keeping the rest of the machinery the same
+  if (load_status == 2) {
+    logmessage = "PMTWaveformSim: Creating single minimal baseline waveform (No MCHits)...";
+    Log(logmessage, v_message, verbosity);
+    
+    // we can use any valid PMT ID --> let's just use 332
+    unsigned long dummy_chankey = 332;
+    
+    // create a short baseline waveform (~50ns) so that the hit finder will be satisfied
+    int num_samples = 25;   // 50ns
+    double noiseSigma = fRandom.Gaus(1, 0.01);   // set the noise to basically 0
+    int baseline = fRandom.Uniform(300, 350);
+    
+    std::vector<uint16_t> rawSamples;
+    std::vector<double> calSamples;
+    
+    for (int i = 0; i < num_samples; i++) {
+      double noise = fRandom.Gaus(0, noiseSigma);
+      int sample = std::round(noise + baseline);
+      sample = (sample > 4095) ? 4095 : ((sample < 0) ? 0 : sample);  // shouldn't matter
+      
+      rawSamples.push_back(sample);
+      calSamples.push_back((sample - baseline) * ADC_TO_VOLT);
+    }
+    
+    std::vector<Waveform<uint16_t>> rawWaveforms;
+    std::vector<CalibratedADCWaveform<double>> calWaveforms;
+    
+    rawWaveforms.emplace_back(0, rawSamples);
+    calWaveforms.emplace_back(0, calSamples, baseline, noiseSigma);
+    
+    RawADCDataMC.emplace(dummy_chankey, rawWaveforms);
+    CalADCDataMC.emplace(dummy_chankey, calWaveforms);
+
+  }
+
+  // normal use case (no blank MCHits)
   for (auto mcHitsIt : *fMCHits) { // Loop over the hit PMTs
     int PMTID = mcHitsIt.first;
 
@@ -177,22 +217,14 @@ bool PMTWaveformSim::Execute()
     CalADCDataMC.emplace(PMTID, calWaveforms);
   }// end loop over PMTs
 
+
   // Publish the waveforms to the ANNIEEvent store if we have them
-   if (RawADCDataMC.size()) {     
-    m_data->Stores.at("ANNIEEvent")->Set("RawADCDataMC",      RawADCDataMC);
-    m_data->Stores.at("ANNIEEvent")->Set("CalibratedADCData", CalADCDataMC);
-   } else {
-     logmessage = "PMTWaveformSim: No waveforms produced. Skipping!";
-     Log(logmessage, v_warning, verbosity);
-     m_data->Stores.at("ANNIEEvent")->Set("SkipExecute", true);
-     return true;
-   }
-     
+  m_data->Stores.at("ANNIEEvent")->Set("RawADCDataMC",      RawADCDataMC);
+  m_data->Stores.at("ANNIEEvent")->Set("CalibratedADCData", CalADCDataMC); 
   
   if (fDebug) 
     FillDebugGraphs(RawADCDataMC);
 
-  m_data->Stores.at("ANNIEEvent")->Set("SkipExecute", false);
   return true;
 }
 
@@ -460,7 +492,7 @@ int PMTWaveformSim::LoadFromStores()
   }
 
   if (fMCHits->empty()) {
-    logmessage = "PMTWaveformSim: The MCHits map is empty! Skipping!";
+    logmessage = "PMTWaveformSim: The MCHits map is empty! Will fill a single PMT with a minimal waveform.";
     Log(logmessage, v_warning, verbosity);
     return 2;
   }

--- a/UserTools/PMTWaveformSim/PMTWaveformSim.cpp
+++ b/UserTools/PMTWaveformSim/PMTWaveformSim.cpp
@@ -110,8 +110,8 @@ bool PMTWaveformSim::Execute()
     logmessage = "PMTWaveformSim: Creating single minimal baseline waveform (No MCHits)...";
     Log(logmessage, v_message, verbosity);
     
-    // we can use any valid PMT ID --> let's just use 332
-    unsigned long dummy_chankey = 332;
+    // we can put the dummy baseline in a dead PMT channel so it won't be integrated
+    unsigned long dummy_chankey = 333;    // PMT ID 333 is dead
     
     // create a short baseline waveform (~50ns) so that the hit finder will be satisfied
     int num_samples = 25;   // 50ns

--- a/UserTools/PMTWaveformSim/README.md
+++ b/UserTools/PMTWaveformSim/README.md
@@ -35,3 +35,6 @@ MakeDebugFile 0     # Produce a root file containing all the simulated waveforms
 
 ## Other notes
 #### CAUTION: In line 90, the RNG seed is set in Initialization based on the clock time. If any other downstream tools are also setting a random seed, there may be unexpected behavior as a result of this tool.
+
+For events with no MCHits (and hence no waveforms to simulate) a "dummy" waveform is simulated in one of the dead PMT channels (333). The dummy waveform is very short (50ns) and samples from a noise distribution lower than normal, as to not have any hits register in the hit finder (the hit finder will skip dead PMTs anyways). Passing at least one waveform to the hit finding tools prevents crashing. **IF** that PMT is ever repaired or comes back online, please move this dummy channel to a different offline channel.
+

--- a/UserTools/PhaseIIADCHitFinder/PhaseIIADCHitFinder.cpp
+++ b/UserTools/PhaseIIADCHitFinder/PhaseIIADCHitFinder.cpp
@@ -140,20 +140,6 @@ bool PhaseIIADCHitFinder::Execute() {
 
       if (mc_waveforms) {
 	      got_raw_data = annie_event->Get("RawADCDataMC", raw_waveform_map);
-	
-        // Some executes are skipped if there are no MCHits or waveforms produced
-	      // Put the cleared maps into the ANNIEEvent to ensure that a downstream
-	      // tool doesn't grab a map from a previous event
-        bool skip = false;
-	      bool got_skip_status = annie_event->Get("SkipExecute", skip);
-        if (got_skip_status && skip) {
-          Log("PhaseIIADCHitFinder: An upstream tool told me to skip this event.",v_warning,verbosity);
-
-          m_data->Stores.at("ANNIEEvent")->Set("RecoADCHits", pulse_map);
-          m_data->Stores.at("ANNIEEvent")->Set("RecoADCAuxHits", aux_pulse_map);
-
-	      return true;
-	      }
       }// end if mc_waveforms
 
     }
@@ -168,7 +154,7 @@ bool PhaseIIADCHitFinder::Execute() {
         verbosity);
       return false;
     }
-    else if ( raw_waveform_map.empty() ) {
+    else if ( raw_waveform_map.empty() && !mc_waveforms ) {
       Log("Error: The PhaseIIADCHitFinder tool found an empty RawADCData entry", v_error,
         verbosity);
       return false;
@@ -197,7 +183,7 @@ bool PhaseIIADCHitFinder::Execute() {
         " entry", v_error, verbosity);
       return false;
     }
-    else if ( calibrated_waveform_map.empty() ) {
+    else if ( calibrated_waveform_map.empty() && !mc_waveforms ) {
       Log("Error: The PhaseIIADCHitFinder tool found an empty CalibratedADCData entry",
         v_error, verbosity);
       return false;

--- a/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
+++ b/UserTools/PhaseIITreeMaker/PhaseIITreeMaker.cpp
@@ -526,16 +526,6 @@ bool PhaseIITreeMaker::Execute(){
   // Reset variables
   this->ResetVariables();
   // Get a pointer to the ANNIEEvent Store
-	
-  // An upstream tool may opt to skip this execution stage
-  // For example the PMTWaveformSim tool will skip events with no MCHits or if
-  // no waveforms are produced.
-  bool skip = false;
-  bool got_skip_status = m_data->Stores["ANNIEEvent"]->Get("SkipExecute", skip);
-  if (got_skip_status && skip) {
-    Log("PhaseIITreeMaker: An upstream tool told me to skip this event.",v_warning,verbosity);
-    return true;
-  } 
 
   //  If only clean events are built, return true for dirty events
   if(fillCleanEventsOnly){


### PR DESCRIPTION
## Describe your changes

If there are no MCHits to reconstruct a waveform, _PMTWaveformSim_ skipped the event and told other downstream tools to do the same. It was originally implemented to be computationally efficient as to not to simulate all waveforms. It also avoided crashing the _PhaseIIADCHitFinder_ tool; it wasn't handling blank waveform entries well since that doesn't exist in the data.

We noted that ultimately we would have to modify the waveform simulator at some point for the efficiency / cross section analyses since we need those "blank" entries. 

My workaround is that if there are no MCHits in an event, rather than skipping the event all together we simulate a "minimal" waveform in one of the dead PMT channels (ID 333) so that the hit finding tool is happy and doesn't crash. The minimal waveform won't register a hit as:

1. It will always be below baseline as I have set the noise to be very low (sigma = 0.01)
2. Even if it does produce a pulse / dc above the pulse threshold, there is a condition in the hit finder that it won't integrate pulses in channels that are labeled "OFF". 

The resulting event information is passed to other tools even though no hits have been registered (like the data) and no downstream tools are skipped.

I also removed logic from the downstream tools that checked whether they should skip the event. This was added previously purely to not crash when loading in the waveform simulated hits. It can be removed as that condition is no longer set by waveform sim. 

One of the tools _(EventSelector)_ also needs its skip logic adjusted, but I have added a commit to the outstanding PR #330 to take care of this.

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [N/A] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Attach any validation or demonstration files here. You may also link to relavant docdb articles.
