### PR TITLE
Add BRF / beam jitter to the MC

### DIFF
--- a/UserTools/AssignBunchTimingMC/AssignBunchTimingMC.cpp
+++ b/UserTools/AssignBunchTimingMC/AssignBunchTimingMC.cpp
@@ -15,6 +15,7 @@ bool AssignBunchTimingMC::Initialise(std::string configfile, DataModel &data){
     bool got_width     = m_variables.Get("bunchwidth", fbunchwidth);
     bool got_interval  = m_variables.Get("bunchinterval", fbunchinterval);
     bool got_count     = m_variables.Get("bunchcount", fbunchcount);
+    bool got_BRF       = m_variables.Get("BRFfituncertainty", fBRF);
     bool got_sample    = m_variables.Get("sampletype", fsample);
     bool got_trigger   = m_variables.Get("prompttriggertime", ftriggertime);
     bool got_waveform  = m_variables.Get("PMTWaveformSim", fPMTWaveformSim);
@@ -49,6 +50,15 @@ bool AssignBunchTimingMC::Initialise(std::string configfile, DataModel &data){
         Log(logmessage, v_warning, verbosity);
     }
 
+    // Uncertainty due to beam signals / electronic jitter in our system
+    // see https://annie-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=6489 for more information
+    if (!got_BRF) {
+        fBRF = 0;
+        logmessage = ("Warning (AssignBunchTimingMC): \"BRFfituncertainty\" not "
+            "set in the config file. Using default: 0ns (no uncertainty will be included for this)");
+        Log(logmessage, v_warning, verbosity);
+    }
+
     if (!got_sample) {
         fsample = 0;    // assume they are using the Tank samples
         logmessage = ("Warning (AssignBunchTimingMC): \"sampletype\" not "
@@ -78,6 +88,7 @@ bool AssignBunchTimingMC::Initialise(std::string configfile, DataModel &data){
         std::cout<<"bunch width       = "<<fbunchwidth<<" ns"<<"\n";
         std::cout<<"bunch interval    = "<<fbunchinterval<<" ns"<<"\n";
         std::cout<<"number of bunches = "<<fbunchcount<<"\n";
+        std::cout<<"BRF uncertainty   = "<<fBRF<<"\n";
         std::cout<<"PMTWaveformSim    = "<<fPMTWaveformSim<<"\n";
         std::cout<<"sample type       = "<<(fsample == 0 ? "(0) Tank" : "(1) World")<<"\n";
         std::cout<<"trigger time      = "<<(ftriggertime == 0 ? "(0) prompt trigger starts when first particle arrives (default WCSim)" 
@@ -206,6 +217,9 @@ bool AssignBunchTimingMC::LoadStores()
 
 void AssignBunchTimingMC::BNBtiming()
 {
+
+    // Add instrinsic bunch width and the jitter from our beam signals / fitting
+
     // Determined from GENIE samples (as of Dec 2024)
     const double tank_time = 33.0;    // Tank neutrino arrival time: 33ns
     const double world_time = 33.0;   // WORLD neutrino arrival time: 33ns
@@ -229,9 +243,17 @@ void AssignBunchTimingMC::BNBtiming()
     std::normal_distribution<double> distribution(0, fbunchwidth); 
     jitter = distribution(generator);
 
+    // assign beam jitter (BRF uncertainty)
+    std::normal_distribution<double> BRF_distribution(0, fBRF);
+    BRF_jitter = BRF_distribution(generator);
+
     if (verbosity >= v_message) {
-        std::string logmessage = "AssignBunchTimingMC: bunchNumber = " + std::to_string(bunchNumber) + " | t0 = " + std::to_string(new_nu_time);
-        Log(logmessage, v_debug, verbosity);
+        std::ostringstream logmessage;
+        logmessage << "AssignBunchTimingMC: bunchNumber = " << bunchNumber
+                << " | t0 = " << new_nu_time
+                << " | sampled intrinsic bunch jitter = " << jitter << " ns"
+                << " | sampled BRF jitter = " << BRF_jitter << " ns";
+        Log(logmessage.str(), v_debug, verbosity);
     }
 
 }
@@ -292,8 +314,8 @@ void AssignBunchTimingMC::CalculateClusterAndBunchTimesPMTWaveformSim(std::vecto
         Log(logmessage, v_debug, verbosity);
     }
 
-    // calculate BunchTime
-    bunchTime = fbunchinterval * bunchNumber + clusterTime + jitter + new_nu_time ;
+    // calculate BunchTime (add the two gaussian contributions independently)
+    bunchTime = fbunchinterval * bunchNumber + clusterTime + jitter + BRF_jitter + new_nu_time ;
     if (verbosity >= v_debug) {
         std::string logmessage = "AssignBunchTimingMC: bunchTime = " + std::to_string(bunchTime);
         Log(logmessage, v_debug, verbosity);

--- a/UserTools/AssignBunchTimingMC/AssignBunchTimingMC.h
+++ b/UserTools/AssignBunchTimingMC/AssignBunchTimingMC.h
@@ -46,13 +46,16 @@ class AssignBunchTimingMC: public Tool {
         double fbunchwidth;       ///< BNB intrinsic bunch width in ns
         double fbunchinterval;    ///< BNB bunch spacing in ns
         int fbunchcount;          ///< number of BNB bunches per spill
+        double fBRF;              ///< BRF fit uncertainty extracted from the data (due to any additional electronic jitter unaccounted for)
         int fsample;              ///< GENIE Tank or WORLD samples
         int ftriggertime;         ///< whether the samples used the default WCSim prompt trigger = 0 (when particles enter the volume), or the adjusted prompt trigger based on the start of the beam dump
         bool fPMTWaveformSim;     ///< whether to use the PMTWaveform data-like hits or the defaul MCHits
 
+
         double new_nu_time;       ///< offset needed to make the cluster times beam realistic
         int bunchNumber;          ///< randomly assigned bunch number
         double jitter;            ///< random jitter based on the intrinsic bunch width
+        double BRF_jitter;        ///< random jitter based on the beam timing + fit uncertainties
         double bunchTime;         ///< individual bunch time assigned for a specific cluster
 
         /// \brief verbosity levels: if 'verbosity' < this level, the message type will be logged.

--- a/UserTools/AssignBunchTimingMC/README.md
+++ b/UserTools/AssignBunchTimingMC/README.md
@@ -15,16 +15,17 @@
 
 verbosity 0
 
-PMTWaveformSim 1       # Whether we're using the data-like hits output from PMTWaveformSim
-
 # BNB properties taken from: MicroBooNE https://doi.org/10.1103/PhysRevD.108.052010
-bunchwidth 1.308       # BNB instrinic bunch spread [ns]
-bunchinterval 18.936   # BNB bunch spacings [ns]
-bunchcount 81          # number of BNB bunches per spill
+bunchwidth 1.308          # BNB instrinic bunch spread [ns]
+bunchinterval 18.936      # BNB bunch spacings [ns]
+bunchcount 81             # number of BNB bunches per spill
 
-sampletype 1           # Tank (0) or World (1) genie samples you are running over
-prompttriggertime 1    # WCSim prompt trigger settings: (0 = default, t0 = 0 when a particle enters the volume)
-                       #                                (1 = modified, t0 = 0 when the neutrino beam dump begins)
+# Uncertainty extracted from Data / MC comparisons, see here: https://annie-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=6489 
+BRFfituncertainty 1.809   # jitter in our beam signals / BRF fitting uncertainty [ns]
+
+sampletype 0              # Tank (0) or World (1) genie samples you are running over
+prompttriggertime 1       # WCSim prompt trigger settings: (0 = default, t0 = 0 when a particle enters the volume)
+                          #                                (1 = modified, t0 = 0 when the neutrino beam dump begins)
 ```
 
 

--- a/configfiles/BeamClusterAnalysisMC/AssignBunchTimingMCConfig
+++ b/configfiles/BeamClusterAnalysisMC/AssignBunchTimingMCConfig
@@ -7,6 +7,8 @@ bunchwidth 1.308       # BNB instrinic bunch spread [ns]
 bunchinterval 18.936   # BNB bunch spacings [ns]
 bunchcount 81          # number of BNB bunches per spill
 
+BRFfituncertainty 1.809 # jitter in our beam signals / BRF fitting uncertainty [ns]
+
 sampletype 0           # Tank (0) or World (1) genie samples you are running over
 prompttriggertime 1    # WCSim prompt trigger settings: (0 = default, t0 = 0 when a particle enters the volume)
                        #                                (1 = modified, t0 = 0 when the neutrino beam dump begins)

--- a/configfiles/CC_MC_RECO_ntuple/AssignBunchTimingMCConfig
+++ b/configfiles/CC_MC_RECO_ntuple/AssignBunchTimingMCConfig
@@ -7,6 +7,8 @@ bunchwidth 1.308       # BNB instrinic bunch spread [ns]
 bunchinterval 18.936   # BNB bunch spacings [ns]
 bunchcount 81          # number of BNB bunches per spill
 
+BRFfituncertainty 1.809   # jitter in our beam signals / BRF fitting uncertainty [ns]
+
 sampletype 0           # Tank (0) or World (1) genie samples you are running over
 prompttriggertime 1    # WCSim prompt trigger settings: (0 = default, t0 = 0 when a particle enters the volume)
                        #                                (1 = modified, t0 = 0 when the neutrino beam dump begins)


### PR DESCRIPTION
For both the NC and stroboscopic analyses, correctly modeling the spill structure of the BNB is important to ensure any selection cuts / Data and MC comparison is accurate. 

The observed bunch width in ANNIE can be broken down into: 

$\sigma_{Data} = \sqrt{ <\sigma_{TOF}>^2 + <\sigma_{PMT}>^2 + <\sigma_{BNB}>^2 + <\sigma_{BRF}>^2}$

What is already included in the MC:
- $\sigma_{BNB}$ (Intrinsic BNB bunch width, based on observations from MicroBooNE)
- $\sigma_{PMT}$ (PMT timing jitter, based on 2023 laser calibration data - this is implemented in _PMTWaveformSim_)
- $\sigma_{TOF}$ (Simulation handles this, no corrections for the reconstructed vertex are being applied here)

What was remaining (that is now included) was the beam timing jitter / the uncertainty in the BRF fitting (which we use to improve the bunch reconstruction in the data). This term was determined by comparing the observed bunch width in the MC and data for muon events (CCinc and throughgoing muons for FY22 and FY23). Since the current version of the simulation already includes:

$\sigma_{MC} = \sqrt{ <\sigma_{TOF}>^2 + <\sigma_{PMT}>^2 + <\sigma_{BNB}>^2 }$

The final term can be extracted based on the remaining discrepancy. More details can be found [here](https://annie-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=6489).

## Describe your changes

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [N/A] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [X] For every `new` usage, there is a reason the data must be on the heap
- [X] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
The default value set in the README was the weighted average observed for CCinc and throughgoing muons in FY22 and FY23 data. If using newer data (FY24 and later) a similar analysis is needed to verify if the beam timing uncertainties have changed. 
