### PR TITLE
AmBeWaveform configfile has typo for the FitRWMWaveform

### DIFF
--- a/configfiles/AmBeWaveform/ToolsConfig
+++ b/configfiles/AmBeWaveform/ToolsConfig
@@ -1,3 +1,4 @@
 myLoadANNIEEvent LoadANNIEEvent ./configfiles/AmBeWaveform/LoadANNIEEventConfig
 myLoadGeometry LoadGeometry ./configfiles/LoadGeometry/LoadGeometryConfig
-myFitRWMWaveform FitRWMWaveform ./configfiles/AmBeWaveform/FitRWMWaveform
+myFitRWMWaveform FitRWMWaveform ./configfiles/AmBeWaveform/FitRWMWaveformConfig
+


### PR DESCRIPTION
## Describe your changes
As it says in the title. Just a change in AmBeWaveform configfile

## Checklist before submitting your PR
- [x] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)

- [x] This PR alters the minimum number of files to affect this change

- [ ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ ] For every `new` usage, there is a reason the data must be on the heap
- [ ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Attach any validation or demonstration files here. You may also link to relavant docdb articles.
