### PR TITLE
Fix name of MCTriggerNum in ANNIEEvent in LoadWCSim.cpp

### DIFF
--- a/UserTools/LoadWCSim/LoadWCSim.cpp
+++ b/UserTools/LoadWCSim/LoadWCSim.cpp
@@ -628,7 +628,7 @@ bool LoadWCSim::Execute()
   // If we merged the subtriggers, report an MCTriggerNum of 0
   // so downstream tools know it's a new event
   int reported_triggernum = splitSubtriggers ? MCTriggerNum-1 : 0;
-  m_data->Stores.at("ANNIEEvent")->Set("MCTriggerNum", reported_triggernum);
+  m_data->Stores.at("ANNIEEvent")->Set("MCTriggernum", reported_triggernum);
   m_data->Stores.at("ANNIEEvent")->Set("MCFile", MCFile);
   m_data->Stores.at("ANNIEEvent")->Set("MCFlag", true);
   m_data->Stores.at("ANNIEEvent")->Set("BeamStatus", beamstat);


### PR DESCRIPTION
MCTriggerNum is being retrieved as MCTriggernum by other tools. Change back to this

## Describe your changes

## Checklist before submitting your PR
- [ ] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [ ] This PR alters the minimum number of files to affect this change
- [ ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ ] For every `new` usage, there is a reason the data must be on the heap
- [ ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Attach any validation or demonstration files here. You may also link to relavant docdb articles.
