### PR TITLE
Data Toolchain for NCQE XS analysis

### DIFF
--- a/configfiles/NCQE_XS_Data/ANNIEEventTreeMakerConfig
+++ b/configfiles/NCQE_XS_Data/ANNIEEventTreeMakerConfig
@@ -1,0 +1,35 @@
+ANNIEEventTreeMakerVerbosity 0
+
+fillAllTriggers 1
+fill_singleTrigger 0
+fillLAPPDEventsOnly 0
+TankCluster_fill 1
+cluster_TankHitInfo_fill 1
+
+ApplyDeadMask 1
+VertexLeastSquares 1
+
+TankReco_fill 0
+
+OutputFile ANNIETree.root
+TankClusterProcessing 1
+MRDClusterProcessing 1
+TriggerProcessing 1
+TankHitInfo_fill 1
+MRDHitInfo_fill 1
+MRDReco_fill 1
+SiPMPulseInfo_fill 0
+fillCleanEventsOnly 0
+MCTruth_fill 0
+Reco_fill 1
+RecoDebug_fill 0
+muonTruthRecoDiff_fill 0
+isData 1
+HasGenie 0
+RingCounting_fill 0
+
+LAPPDData_fill 0
+LAPPDReco_fill 0
+RWMBRF_fill 1
+LAPPD_PPS_fill 0
+LAPPD_Waveform_fill 0

--- a/configfiles/NCQE_XS_Data/ClusterClassifiersConfig
+++ b/configfiles/NCQE_XS_Data/ClusterClassifiersConfig
@@ -1,0 +1,1 @@
+verbosity 0

--- a/configfiles/NCQE_XS_Data/ClusterFinderConfig
+++ b/configfiles/NCQE_XS_Data/ClusterFinderConfig
@@ -1,0 +1,13 @@
+# ClusterFinder Config File
+
+verbosity 0
+HitStore Hits #Either MCHits or Hits (accessed in ANNIEEvent store)
+ApplyDeadMask 1
+OutputFile BeamRun_ClusterFinder_DefaultOutput #Output root prefix name for the current run
+ClusterFindingWindow 40 # in ns, size of the window used to "clusterize"
+AcqTimeWindow 70000 # in ns, size of the acquisition window
+ClusterIntegrationWindow 40 # in ns, all hits with +/- 1/2 of this window are considered in the cluster
+MinHitsPerCluster 10 # group of hits are considered clusters above this amount of hits
+end_of_window_time_cut 0.95 # from o to 1, length of the window you want to loop over with respect to acq. window (1 for full window, 0.95 for 95% from the start)
+Plots2D 0 #Draw 2D charge-vs-time plots?
+ChankeyToPMTIDMap ./configfiles/EventDisplay/Data-RecoEvent/Chankey_WCSimID.dat

--- a/configfiles/NCQE_XS_Data/EventSelectorConfig
+++ b/configfiles/NCQE_XS_Data/EventSelectorConfig
@@ -1,0 +1,29 @@
+# EventSelector config file
+
+verbosity 0
+MCPMTVolCut 0
+MCFVCut 0
+MCMRDCut 0
+MCPiKCut 0
+MCIsMuonCut 0
+MCIsElectronCut 0
+MCIsSingleRingCut 0
+MCIsMultiRingCut 0
+MCProjectedMRDHit 0
+MCEnergyCut 0
+Emin 0		#Minimum energy in MeV
+Emax 1000	#Maximum energy in MeV
+MRDRecoCut 0
+RecoPMTVolCut 0
+RecoFVCut 0
+NHitCut 0
+NHitmin 4	#Minimum number of hit digits
+PMTMRDCoincCut 0
+PMTMRDOffset 755
+PromptTrigOnly 0
+TriggerWord -1
+SaveStatusToStore 1
+NoVeto 0
+Veto 0
+ThroughGoing 0
+IsMC 0		#MC or Data?

--- a/configfiles/NCQE_XS_Data/FindMrdTracksConfig
+++ b/configfiles/NCQE_XS_Data/FindMrdTracksConfig
@@ -1,0 +1,12 @@
+# FindMrdTracks Config File
+# all variables retrieved with m_variables.Get() must be defined here!
+
+verbosity 0
+IsData 1
+OutputDirectory .
+OutputFile STEC_MRDTracks_cluster40ns
+DrawTruthTracks 0 # whether to add MC Truth track info for drawing in MrdPaddlePlot Tool
+                  ## note you need to run that tool to actually view the tracks!
+WriteTracksToFile 0	# should the track information be written to a ROOT-file?
+SelectTriggerType 0	#should the loaded data be filtered by trigger type?
+TriggerType Beam	#options: Cosmic, Beam, No Loopback

--- a/configfiles/NCQE_XS_Data/FitRWMWaveformConfig
+++ b/configfiles/NCQE_XS_Data/FitRWMWaveformConfig
@@ -1,0 +1,2 @@
+verbosityFitRWMWaveform 0
+printToRootFile 0

--- a/configfiles/NCQE_XS_Data/LoadANNIEEventConfig
+++ b/configfiles/NCQE_XS_Data/LoadANNIEEventConfig
@@ -1,0 +1,4 @@
+verbose 1
+FileForListOfInputs ./configfiles/NCQE_XS_Data/my_inputs.txt
+EventOffset 0
+GlobalEvNr 1

--- a/configfiles/NCQE_XS_Data/TimeClusteringConfig
+++ b/configfiles/NCQE_XS_Data/TimeClusteringConfig
@@ -1,0 +1,13 @@
+#TimeClustering config file
+
+verbosity 0
+MinDigitsForTrack 3
+MaxMrdSubEventDuration 30
+MinSubeventTimeSep 30
+MakeMrdDigitTimePlot 0
+LaunchTApplication 0
+IsData 1
+#OutputROOTFile TimeClustering_MRDTest28_cluster40ns
+OutputROOTFile STEC_TimeClusteringOut
+MapChankey_WCSimID ./configfiles/SimpleTankEnergyCalibrator/MRD_Chankey_WCSimID.dat
+

--- a/configfiles/NCQE_XS_Data/ToolChainConfig
+++ b/configfiles/NCQE_XS_Data/ToolChainConfig
@@ -1,0 +1,23 @@
+#ToolChain dynamic setup file
+
+##### Runtime Paramiters #####
+verbose 1
+error_level 0 # 0= do not exit, 1= exit on unhandeled errors only, 2= exit on unhandeled errors and handeled errors
+attempt_recover 1
+
+###### Logging #####
+log_mode Interactive # Interactive=cout , Remote= remote logging system "serservice_name Remote_Logging" , Local = local file log;
+log_local_path ./log
+log_service LogStore
+
+###### Service discovery #####
+service_publish_sec -1
+service_kick_sec -1
+
+##### Tools To Add #####
+Tools_File ./configfiles/NCQE_XS_Data/ToolsConfig
+
+##### Run Type #####
+Inline -1
+Interactive 0
+

--- a/configfiles/NCQE_XS_Data/ToolsConfig
+++ b/configfiles/NCQE_XS_Data/ToolsConfig
@@ -1,0 +1,10 @@
+myLoadANNIEEvent LoadANNIEEvent ./configfiles/NCQE_XS_Data/LoadANNIEEventConfig
+myLoadGeometry LoadGeometry ./configfiles/LoadGeometry/LoadGeometryConfig
+myTimeClustering TimeClustering configfiles/NCQE_XS_Data/TimeClusteringConfig
+myFindMrdTracks FindMrdTracks configfiles/NCQE_XS_Data/FindMrdTracksConfig
+myClusterFinder ClusterFinder ./configfiles/NCQE_XS_Data/ClusterFinderConfig
+myClusterClassifiers ClusterClassifiers ./configfiles/NCQE_XS_Data/ClusterClassifiersConfig
+myEventSelector EventSelector ./configfiles/NCQE_XS_Data/EventSelectorConfig
+FitRWMWaveform FitRWMWaveform ./configfiles/NCQE_XS_Data/FitRWMWaveformConfig
+VertexLeastSquares VertexLeastSquares configfiles/NCQE_XS_Data/VertexLeastSquaresConfig
+ANNIEEventTreeMaker ANNIEEventTreeMaker ./configfiles/NCQE_XS_Data/ANNIEEventTreeMakerConfig

--- a/configfiles/NCQE_XS_Data/VertexLeastSquaresConfig
+++ b/configfiles/NCQE_XS_Data/VertexLeastSquaresConfig
@@ -1,0 +1,16 @@
+verbosity 0
+UseMCHits 0
+BreakDist 0.005
+YSpacing 0.1
+NPlanarPoints 100
+Regularizer 0
+FittingSteps 200
+FilterHitsCompatibleWindow 0
+OnlyUseReliablePMTs 1
+MinimumReliableTimingStd 1.5
+
+ExternalSeeding 1
+YBuffer 1.0
+RadialBuffer 1.0
+ExternalVertexMaxRadius 4.0
+ExternalVertexMaxHeight 4.0


### PR DESCRIPTION
## Describe your changes

Very similar to the standard `BeamClusterAnalysis` toolchain to produce end-state ntuples for analysis, this toolchain was used for the NCQE Cross Section analysis and executed over the ProcessedData. Adding this to converge the workflow used in the NC analysis with the main repository. 

TODO: Currently bunch cutting and energy reconstruction is not included. Working to add those as separate tools.

## Checklist before submitting your PR
- [X] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [X] This PR alters the minimum number of files to affect this change
- [N/A] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [X] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [N/A] For every `new` usage, there is a reason the data must be on the heap
- [N/A] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)