### PR TITLE
Update ANNIEEventTreeMaker to save the LAPPD trigger timing

### DIFF
--- a/UserTools/ANNIEEventTreeMaker/ANNIEEventTreeMaker.cpp
+++ b/UserTools/ANNIEEventTreeMaker/ANNIEEventTreeMaker.cpp
@@ -1523,6 +1523,11 @@ void ANNIEEventTreeMaker::FillLAPPDPulse()
     for (it = lappdPulses.begin(); it != lappdPulses.end(); it++)
     {
       int stripno = it->first;
+      //int channelNum = it->first;
+      //Channel *chan = geom->GetChannel(channelNum);
+      //int stripno = chan->GetStripNum();
+      //int stripSide = chan->GetStripSide();
+      
       vector<vector<LAPPDPulse>> stripPulses = it->second;
 
       vector<LAPPDPulse> pulse0 = stripPulses.at(0);
@@ -1594,6 +1599,11 @@ void ANNIEEventTreeMaker::FillLAPPDHit()
     for (it = lappdHits.begin(); it != lappdHits.end(); it++)
     {
       int stripno = it->first;
+      //int channelNum = it->first;
+      //Channel *chan = geom->GetChannel(channelNum);
+      //int stripno = chan->GetStripNum();
+
+
       vector<LAPPDHit> stripHits = it->second;
       for (int i = 0; i < stripHits.size(); i++)
       {
@@ -2675,8 +2685,10 @@ void ANNIEEventTreeMaker::FillLAPPDWaveform()
     // get the waveforms from channel number
     unsigned long channel = it->first;
     channel = channel % 1000 + 1000;
-    if ((channel % 1000) % 30 == 5)
-      continue;
+    
+    // if ((channel % 1000) % 30 == 5)
+      // continue;
+    
     Waveform<double> waveforms = it->second.at(0);
     vector<double> wav = *waveforms.GetSamples();
     vector<double> wave = wav;


### PR DESCRIPTION
## Describe your changes

- LAPPD trigger signal is stored in channel 5 one each ACDC, but was previously suppressed and not saved.
- Updated the code to save the trigger signal along with the waveforms from the other channels.

## Checklist before submitting your PR
- [ ] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [x] This PR alters the minimum number of files to affect this change
- [ ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ ] For every `new` usage, there is a reason the data must be on the heap
- [ ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Attach any validation or demonstration files here. You may also link to relavant docdb articles.
