### PR TITLE
BugFix in EBV2 Toolchain

### DIFF
--- a/UserTools/EBLAPPD/EBLAPPD.cpp
+++ b/UserTools/EBLAPPD/EBLAPPD.cpp
@@ -210,8 +210,8 @@ bool EBLAPPD::LoadLAPPDData()
   LAPPDOffset = 0;
   m_data->CStore.Get("LAPPDOffset", LAPPDOffset);
 
-  LAPPDBeamgate_ns = LAPPDBeamgate_ns + LAPPDBGCorrection + LAPPDOffset;
-  LAPPDTimestamp_ns = LAPPDTimestamp_ns + LAPPDTSCorrection + LAPPDOffset;
+  LAPPDBeamgate_ns = LAPPDBeamgate_ns + LAPPDBGCorrection*3.125 + LAPPDOffset;
+  LAPPDTimestamp_ns = LAPPDTimestamp_ns + LAPPDTSCorrection*3.125 + LAPPDOffset;
 
   LAPPDBG_PPSBefore = 0;
   LAPPDBG_PPSAfter = 0;

--- a/UserTools/LAPPDLoadStore/LAPPDLoadStore.cpp
+++ b/UserTools/LAPPDLoadStore/LAPPDLoadStore.cpp
@@ -143,7 +143,7 @@ bool LAPPDLoadStore::Initialise(std::string configfile, DataModel &data)
     LAPPDEventIndex_ID = {0, 0, 0, 0, 0}; // initialize for five LAPPDs
     if (loadOffsets)
         LoadOffsetsAndCorrections();
-    if (LAPPDStoreReadInVerbosity > 11)
+    if (LAPPDStoreReadInVerbosity > 5)
         debugStoreReadIn.open("debugStoreReadIn.txt");
 
     std::string ACCIDConfigFile;
@@ -347,7 +347,7 @@ bool LAPPDLoadStore::Execute()
         m_data->Stores["ANNIEEvent"]->Set("ReadedBoards", ReadedBoards);
 
         m_data->CStore.Set("NewLAPPDDataAvailable", true);
-        if (LAPPDStoreReadInVerbosity > 11)
+        if (LAPPDStoreReadInVerbosity > 5)
             debugStoreReadIn << " Set NewLAPPDDataAvailable to true" << endl;
 
         NonEmptyEvents += 1;
@@ -1336,8 +1336,16 @@ void LAPPDLoadStore::SaveTimeStamps()
     m_data->Stores["ANNIEEvent"]->Set("LAPPDBeamgate_Raw", beamgate_63_0);
     m_data->Stores["ANNIEEvent"]->Set("LAPPDTimestamp_Raw", timestamp_63_0);
 
-    if (LAPPDStoreReadInVerbosity > 11)
-        debugStoreReadIn << eventNo << " LAPPDStoreReadIn, Saving timestamps, beamgate_timestamp: " << beamgate_63_0 << ", lappd_timestamp: " << timestamp_63_0 << endl;
+    if (LAPPDStoreReadInVerbosity > 5) {
+        debugStoreReadIn
+            << "Event number: " << eventNo
+            << ", LAPPD ID: " << LAPPD_ID
+            << ", PSEC index: " << LAPPDEventIndex_ID[LAPPD_ID]
+            << ", PPS index: " << PPSnumber
+            << ", Timestamp: " << timestamp_63_0
+            << ", Beamgate: " << beamgate_63_0
+            << std::endl;
+    }
 
     if (loadOffsets && runInfoLoaded)
     {
@@ -1346,6 +1354,7 @@ void LAPPDLoadStore::SaveTimeStamps()
         // search it in the maps, then load
         SaveOffsets();
     }
+
     m_data->CStore.Set("LAPPD_new_event", true);
 }
 
@@ -1356,7 +1365,8 @@ void LAPPDLoadStore::SaveOffsets()
     {
         LAPPDEventIndex_ID.resize(LoadingOffsetID+1);
     }
-    int GetOffsetIndex_byID = LAPPDEventIndex_ID[LoadingOffsetID];
+    int GetOffsetIndex_byID = LAPPDEventIndex_ID[LoadingOffsetID] - 1;
+
     if(LAPPDStoreReadInVerbosity>0)
         cout << "LAPPDStoreReadIn, SavingOffsets, LoadingOffset for LAPPD_ID: " << LoadingOffsetID << ", OffsetIndex of this event: " << GetOffsetIndex_byID << endl;
 
@@ -1560,8 +1570,22 @@ void LAPPDLoadStore::SaveOffsets()
 
     // cout << "LAPPDStoreReadIn, Saving offsets and corrections, key: " << key << ", LAPPDOffset: " << LAPPDOffset << ", LAPPDOffset_minus_ps: " << LAPPDOffset_minus_ps << ", LAPPDBGCorrection: " << LAPPDBGCorrection << ", LAPPDTSCorrection: " << LAPPDTSCorrection << ", BG_PPSBefore: " << BG_PPSBefore << ", BG_PPSAfter: " << BG_PPSAfter << ", BG_PPSDiff: " << BG_PPSDiff << ", BG_PPSMissing: " << BG_PPSMissing << ", TS_PPSBefore: " << TS_PPSBefore << ", TS_PPSAfter: " << TS_PPSAfter << ", TS_PPSDiff: " << TS_PPSDiff << ", TS_PPSMissing: " << TS_PPSMissing << endl;
 
-    if (LAPPDStoreReadInVerbosity > 11)
-        debugStoreReadIn << eventNo << "+LAPPDStoreReadIn, Saving offsets and corrections, key: " << key << ", LAPPDOffset: " << LAPPDOffset << ", LAPPDOffset_minus_ps: " << LAPPDOffset_minus_ps << ", LAPPDBGCorrection: " << LAPPDBGCorrection << ", LAPPDTSCorrection: " << LAPPDTSCorrection << endl;
+    if (LAPPDStoreReadInVerbosity > 5) {
+        debugStoreReadIn
+            << "Event number: " << eventNo
+            << ", LAPPDStoreReadIn, Saving offsets, key: " << key
+            << ", LAPPD_ID: " << LAPPD_ID
+            << ", idx: " << GetOffsetIndex_byID
+            << ", TS_PPSBefore: " << TS_PPSBefore
+            << ", BG_PPSBefore: " << BG_PPSBefore
+            << ", TS_PPSAfter: " << TS_PPSAfter
+            << ", BG_PPSAfter: " << BG_PPSAfter
+            << ", LAPPDOffset: " << LAPPDOffset
+	    << ", LAPPDOffset_minus_ps: " << LAPPDOffset_minus_ps
+	    << ", LAPPDTSCorrection: " << LAPPDTSCorrection
+	    << ", LAPPDBGCorrection: " << LAPPDBGCorrection
+            << std::endl;
+    }
 }
 
 void LAPPDLoadStore::LoadOffsetsAndCorrections()


### PR DESCRIPTION
## Describe your changes

- Updated verbose commands in `LAPPDLoadStore.cpp`.
- Fixed LAPPD offset loading to use the correct index in `LAPPDLoadStore.cpp`.
- Fixed a unit mismatch in the timing correction used for event matching in `EBLAPPD.cpp`.

## Checklist before submitting your PR
- [ ] This PR implements a single change (one new/modified Tool, or a set of changes to implement one new/modified feature)
- [x] This PR alters the minimum number of files to affect this change
- [ ] If this PR includes a new Tool, a README and minimal demonstration ToolChain is provided
- [ ] If a new Tool/ToolChain requires model or configuration files, their paths are not hard-coded, and means of generating those files is described in the readme, with examples provided on /pnfs/annie/persistent
- [ ] For every `new` usage, there is a reason the data must be on the heap
- [ ] For every `new` there is a `delete`, unless I explicitly know why (e.g. ROOT or a BoostStore takes ownership)

## Additional Material
Attach any validation or demonstration files here. You may also link to relavant docdb articles.
